### PR TITLE
fix(tests): remove unused OTHER_TEACHER_ID in bulk-share test

### DIFF
--- a/src/routes/api/google/coursework/bulk-share/__tests__/google-coursework-bulk-share.test.ts
+++ b/src/routes/api/google/coursework/bulk-share/__tests__/google-coursework-bulk-share.test.ts
@@ -30,7 +30,6 @@ describe('POST /api/google/coursework/bulk-share', () => {
 	let mockRequest: Request;
 
 	const TEACHER_ID = '550e8400-e29b-41d4-a716-446655440001';
-	const OTHER_TEACHER_ID = '550e8400-e29b-41d4-a716-446655440002';
 	const COURSE_ID = '550e8400-e29b-41d4-a716-446655440010';
 	const COURSEWORK_ID_1 = '550e8400-e29b-41d4-a716-446655440100';
 	const COURSEWORK_ID_2 = '550e8400-e29b-41d4-a716-446655440101';


### PR DESCRIPTION
## 🤖 Proposition automatique de correctif CI (triage nocturne)

> PR générée automatiquement par le triage CI nocturne. À relire avant merge.

### Run en échec
- **Code Quality** sur `main` (HEAD `4fbb6dae`, v0.10.4) : https://github.com/Zahara-Nour/ubumaths/actions/runs/27514246922
  - Run du job en échec : https://github.com/Zahara-Nour/ubumaths/actions/runs/27514246927
- Même cause sur le commit précédent `9571295f` : https://github.com/Zahara-Nour/ubumaths/actions/runs/27504074602

### Cause racine
Le job **Lint** échoue (exit code 1) sur **une seule erreur** ESLint (les 171 autres entrées sont des `warning` non bloquants) :

```
src/routes/api/google/coursework/bulk-share/__tests__/google-coursework-bulk-share.test.ts
  33:8  error  'OTHER_TEACHER_ID' is assigned a value but never used.
               Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
```

La constante `OTHER_TEACHER_ID` est déclarée mais jamais référencée dans le fichier de test (vérifié : une seule occurrence, ligne 33). Les autres jobs (Type Check, Server Tests, Client Tests) sont au vert ; c'est donc l'unique blocage de la CI sur `main`.

### Changement
Suppression de la ligne déclarant la constante inutilisée. Aucun autre changement.

### Vérification
- `npx eslint <fichier>` → exit 0, aucune erreur.
- `pnpm test:server <fichier>` → 2 tests passés.
- Hook pre-commit (lint-staged : eslint + prettier + vitest related) → tout au vert.

### Note
La 3ᵉ erreur CI des dernières 24 h (run [27497614632](https://github.com/Zahara-Nour/ubumaths/actions/runs/27497614632), commit `3865180b`) était une erreur de formatage Prettier **déjà résolue** par le commit suivant `3387114a` ("style: prettier sur les fichiers de la migration") — aucune action requise.

---
https://claude.ai/code/session_01CKcpQv8tkaU1NJGLonQnes

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKcpQv8tkaU1NJGLonQnes)_