### PR TITLE
chore(deps): bumps de sécurité hebdomadaires (axios, fast-uri, brace-expansion)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2196,6 +2196,10 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2261,8 +2265,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2303,14 +2307,14 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-from@1.1.2:
@@ -2857,8 +2861,8 @@ packages:
   fast-png@6.4.0:
     resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3102,6 +3106,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5350,7 +5358,7 @@ snapshots:
 
   '@getbrevo/brevo@3.0.4':
     dependencies:
-      axios: 1.15.0
+      axios: 1.18.0
       bluebird: 3.7.2
       rewire: 7.0.0
     transitivePeerDependencies:
@@ -6505,6 +6513,12 @@ snapshots:
 
   add-stream@1.0.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.14.0:
@@ -6517,7 +6531,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6559,13 +6573,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.0:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -6610,16 +6626,16 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7283,7 +7299,7 @@ snapshots:
       iobuffer: 5.4.0
       pako: 2.1.0
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7526,6 +7542,13 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -7927,15 +7950,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.15
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.1
 
   minimist-options@4.1.0:
     dependencies:


### PR DESCRIPTION
## Audit sécurité hebdomadaire — 2026-06-15

Correctifs **sûrs uniquement** : bumps transitifs restant dans les ranges semver existants (`^`). **Aucune modification de `package.json`** — seul `pnpm-lock.yaml` change.

### Bilan vulnérabilités (`pnpm audit`)

| Sévérité | Avant | Après |
| --- | --- | --- |
| critical | 0 | 0 |
| high | 15 | 2 |
| moderate | 11 | 1 |
| low | 3 | 2 |
| **Total** | **29** | **5** |

### Advisories résolues (24)

| Paquet | Bump | Sévérité | Chaîne | Notes |
| --- | --- | --- | --- | --- |
| `axios` | 1.15.0 → 1.18.0 | 7× high, 9× moderate, 1× low | runtime, transitif sous `@getbrevo/brevo` (`^1.6.8`) | Prototype pollution (credential injection, MITM, header injection), NO_PROXY/SSRF bypass, ReDoS, fuite Proxy-Authorization, DoS. Dans le range → pas d'override nécessaire. |
| `fast-uri` | 3.1.0 → 3.1.2 | 2× high | dev, sous `@commitlint/...>ajv` | Path traversal + host confusion via percent-encoding. |
| `brace-expansion` | 5.0.5 → 5.0.6 | 1× moderate | dev, sous `typescript-eslint>minimatch` (`^5.0.5`) | ReDoS : contournement de la protection `max`. |

`pnpm dedupe` a aussi rapproché `brace-expansion` 1.x/2.x (patch, sans impact).

### Vérification

`pnpm check:incremental` (garde-fou de types, exécuté 1×) : **aucune erreur introduite par ces bumps**. Les seules erreurs rapportées sont des `$env/static/*` « has no exported member » (PUBLIC_SUPABASE_URL, etc.), pré-existantes et dues à l'absence des variables d'env Supabase dans le conteneur d'audit (seul `.env.example` est présent). Elles sont sans lien avec axios/fast-uri/brace-expansion. La CI de la PR validera le reste (lint, types avec env, tests).

### À traiter manuellement (bumps risqués — NON appliqués)

5 vulnérabilités restantes, toutes hors du périmètre « sûr » :

| Paquet | Sévérité | Patché à | Pourquoi non appliqué |
| --- | --- | --- | --- |
| `esbuild` | 2× high | ≥ 0.28.1 | Parents : `tsx` (`~0.27.0`) et `@sveltejs/adapter-vercel` 5.x (`^0.25.4`). 0.28.1 hors range des deux → nécessite un **override pnpm** ou le passage à `adapter-vercel` 6.x. Build tooling uniquement (RCE module Deno / lecture fichier dev server Windows). |
| `@sveltejs/adapter-vercel` | 1× moderate | ≥ 6.3.2 | Bump **majeur 5 → 6** (`^5.10.3` actuel). Cache poisoning. À planifier/tester séparément. |
| `cookie` | 1× low | ≥ 0.7.0 | Sous `@sveltejs/kit` qui épingle `cookie@^0.6.0`. Nécessite un bump de SvelteKit (ou un override). Faible sévérité. |

Recommandation : traiter `esbuild` + `adapter-vercel` ensemble (le bump majeur d'adapter-vercel 6.x embarque un esbuild patché et corrige aussi le cache poisoning), idéalement avec passage de la suite de tests E2E.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QgdwV15UdEyqZ4Erkhj1k)_