### PR TITLE
style: corrige le formatage Prettier qui casse la CI (Code Quality / Lint)

### DIFF
--- a/docs/wip/supabase-eu-migration-plan.md
+++ b/docs/wip/supabase-eu-migration-plan.md
@@ -505,6 +505,7 @@ suivantes quasi gratuites :
 > fausse, basée sur l'hypothèse `question-images`.)
 >
 > **Design retenu pour la future tâche TDD :**
+>
 > 1. Stocker des chemins relatifs **incluant le bucket** (`exercise-images/x.png`) + un helper
 >    unique `storageUrl(path)` (adapter `src/lib/utils/storage.ts`) ; `ImageDisplay` →
 >    `src.includes('://') ? src : storageUrl(src)`.

--- a/src/routes/(public)/legal/mentions-legales/+page.svelte
+++ b/src/routes/(public)/legal/mentions-legales/+page.svelte
@@ -51,7 +51,8 @@
 					970 Toa Payoh North #07-04, Singapore 318992<br />
 					<a href="https://supabase.com" target="_blank" rel="noopener noreferrer">supabase.com</a
 					><br />
-					Localisation des serveurs : <strong>Union Europeenne (France &ndash; Paris, eu-west-3)</strong>
+					Localisation des serveurs :
+					<strong>Union Europeenne (France &ndash; Paris, eu-west-3)</strong>
 				</p>
 			</div>
 		</section>


### PR DESCRIPTION
## 🤖 Proposition automatique de correctif CI (triage nocturne)

Cette PR est générée automatiquement par la routine de triage CI. Merci de relire avant de merger.

### Run en échec
- Workflow **Code Quality** : https://github.com/Zahara-Nour/ubumaths/actions/runs/27523526165
- Commit : `5e71c9f` (release 0.10.5), branche `main`
- Job en échec : **Lint**

### Cause racine
Le job `Lint` exécute `pnpm prettier --check .` sur tout le dépôt. Deux fichiers, introduits avec la release 0.10.5, ne respectaient pas le style Prettier :

```
[warn] docs/wip/supabase-eu-migration-plan.md
[warn] src/routes/(public)/legal/mentions-legales/+page.svelte
[warn] Code style issues found in 2 files. Run Prettier with --write to fix.
```

Le reste du pipeline (Type Check, Server Tests, Client Tests) passait ; seul le formatage bloquait la CI.

### Changement
`pnpm prettier --write` sur les deux fichiers concernés uniquement. Le diff est purement cosmétique :
- `docs/wip/...md` : ajout d'une ligne vide avant une liste numérotée (règle Markdown Prettier).
- `mentions-legales/+page.svelte` : un retour à la ligne sur un libellé trop long.

Aucune modification de logique, de contenu ou de comportement.

### Vérification
- Reproduit localement : `pnpm prettier --check` sur les deux fichiers → échec identique à la CI.
- Après correction : `pnpm prettier --check` sur les deux fichiers → ✅ « All matched files use Prettier code style! ».

---
_Generated by [Claude Code](https://claude.ai/code/session_014RzPNPCLjtSzEw6i9Z4nzF)_