### PR TITLE
fix(ci): prettier + test unblock-achievements (suite PR #12)

### DIFF
--- a/src/lib/server/achievements/__tests__/unblock-student-achievements-rls.test.ts
+++ b/src/lib/server/achievements/__tests__/unblock-student-achievements-rls.test.ts
@@ -20,22 +20,40 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
-const MIGRATIONS_DIR = join(process.cwd(), 'supabase', 'migrations');
+// Historical migrations were squashed into a baseline and moved to
+// supabase/migrations_archive/, so search both locations.
+const MIGRATIONS_DIRS = [
+	join(process.cwd(), 'supabase', 'migrations'),
+	join(process.cwd(), 'supabase', 'migrations_archive')
+];
+
+function resolveMigration(): { dir: string; file: string } | null {
+	for (const dir of MIGRATIONS_DIRS) {
+		let files: string[];
+		try {
+			files = readdirSync(dir);
+		} catch {
+			continue;
+		}
+		const match = files.find((f) => /unblock_student_achievements_inserts\.sql$/.test(f));
+		if (match) return { dir, file: match };
+	}
+	return null;
+}
 
 function findMigrationFile(): string | null {
-	const files = readdirSync(MIGRATIONS_DIR);
-	const match = files.find((f) => /unblock_student_achievements_inserts\.sql$/.test(f));
-	return match ?? null;
+	return resolveMigration()?.file ?? null;
 }
 
 function getMigrationContent(): string {
-	const file = findMigrationFile();
-	if (!file) {
+	const m = resolveMigration();
+	if (!m) {
 		throw new Error(
-			'Migration file unblock_student_achievements_inserts.sql not found in ' + MIGRATIONS_DIR
+			'Migration file unblock_student_achievements_inserts.sql not found in ' +
+				MIGRATIONS_DIRS.join(' or ')
 		);
 	}
-	return readFileSync(join(MIGRATIONS_DIR, file), 'utf-8');
+	return readFileSync(join(m.dir, m.file), 'utf-8');
 }
 
 describe('Migration: unblock_student_achievements_inserts', () => {

--- a/tests/helpers/database/test-data-factory.ts
+++ b/tests/helpers/database/test-data-factory.ts
@@ -277,11 +277,7 @@ export class GameCombatBuilder {
 		// was provided, use a seeded reference monster (supabase/seed.sql) instead of
 		// a fabricated id.
 		if (!this.data.monster_id) {
-			const { data: monster } = await client
-				.from('game_monsters')
-				.select('id')
-				.limit(1)
-				.single();
+			const { data: monster } = await client.from('game_monsters').select('id').limit(1).single();
 			if (!monster) {
 				throw new Error(
 					'GameCombatBuilder: no game_monsters row available (is supabase/seed.sql loaded?)'


### PR DESCRIPTION
Corrige les 2 échecs CI du PR #12 (mergé) :

- **Lint (Prettier)** : `tests/helpers/database/test-data-factory.ts` reformaté.
- **Server Tests** : `unblock-student-achievements-rls.test.ts` cherchait la migration dans `supabase/migrations/` ; le baseline l'a déplacée dans `supabase/migrations_archive/` → cherche désormais les 2 dossiers.

Vérifié local : projet `server` 814 fichiers / **0 échec** ; eslint + prettier OK sur tous les fichiers.