### PR TITLE
chore: lint pre-commit with oxlint instead of eslint (no OOM)

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,14 +1,28 @@
 /** @type {import('lint-staged').Config} */
 export default {
-	// Lint JS/TS/Svelte files (all at once, not per file)
-	// Type-checking is done in CI (too slow for pre-commit)
-	'*.{js,ts,svelte}': (filenames) => [
-		`eslint --cache --fix ${filenames.join(' ')}`,
-		`prettier --write ${filenames.join(' ')}`,
-		// Gate léger : ne lance que les tests liés aux fichiers stagés
-		`vitest related --run --passWithNoTests ${filenames.join(' ')}`
+	// Pre-commit is intentionally LIGHT — it must never OOM on this 8 GB machine
+	// (the old eslint --fix + `vitest related` steps did, which forced --no-verify).
+	//   - oxlint (Rust, ~0 RAM) gives fast local lint feedback. By default errors
+	//     block the commit, warnings don't (oxlint's exit code) — see .oxlintrc.json.
+	//   - prettier formats.
+	// Heavier gates live in CI: full eslint (eslint-plugin-svelte + the custom
+	// require-zod-validation rule, neither of which oxlint can run) and the test
+	// suites. Type-checking stays out of pre-commit (too slow) — see
+	// scripts/check-incremental.sh.
+
+	// JS/TS: lint + autofix, then format.
+	'*.{js,ts}': (filenames) => [
+		`oxlint --fix ${filenames.join(' ')}`,
+		`prettier --write ${filenames.join(' ')}`
 	],
 
-	// Format other files (all at once)
+	// Svelte: oxlint reports the <script> block only (NO --fix — avoid rewriting
+	// across the .svelte source mapping). Template/a11y rules are eslint's job in CI.
+	'*.svelte': (filenames) => [
+		`oxlint ${filenames.join(' ')}`,
+		`prettier --write ${filenames.join(' ')}`
+	],
+
+	// Other files: format only.
 	'*.{json,md,css,html}': (filenames) => `prettier --write ${filenames.join(' ')}`
 };

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"rules": {
+		"no-unused-vars": [
+			"warn",
+			{
+				"argsIgnorePattern": "^_",
+				"varsIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern": "^_"
+			}
+		]
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ Machine à faible RAM. **NE JAMAIS lancer sur tout le projet** (ça crashe) :
 
 - À la place : **`pnpm check:incremental`** (TS + Svelte, ~30 s, memory-safe, **0 erreur exigée**).
 - **eslint OOM en local → CI-only.** Ne pas le lancer en local (on accepte le round-trip CI).
-- Le **hook pre-commit OOM** aussi → `git commit --no-verify` + compenser : `prettier --write` sur les fichiers modifiés (+ `svelte-autofixer` sur les `.svelte`), puis `pnpm check:incremental` avant de pousser.
-- ⚠️ Un hook qui crashe **stashe** le travail non commité (→ perdu) → commit tôt ; après un crash, vérifier `git stash list`.
+- Le **hook pre-commit est léger** : `.lintstagedrc.js` lance `oxlint` (Rust, ~0 RAM) + `prettier` sur les fichiers staged (~2 s, **pas d'OOM**) → **`--no-verify` n'est plus nécessaire**. oxlint bloque sur _erreurs_ seulement (warnings non bloquants). eslint complet (`.svelte` + règle Zod) et les tests restent **en CI** ; le typecheck reste hors hook → `pnpm check:incremental` avant de pousser.
+- ⚠️ Si un hook crashe, il peut **stasher** le travail non commité (→ perdu) : commit tôt, et après un crash vérifie `git stash list`. (L'ancien hook OOMait via `eslint --fix` type-aware + `vitest related`, d'où le `--no-verify` historique.)
 
 ---
 

--- a/docs/claude/git-workflow.md
+++ b/docs/claude/git-workflow.md
@@ -33,11 +33,9 @@
 
 ## 4. Checks locaux (contrainte mémoire / OOM)
 
-- Le **hook pre-commit OOM** sur cette machine → `git commit --no-verify`, **MAIS compenser** :
-  - `pnpm exec prettier --write <fichiers modifiés>` (sinon le job **Lint** CI casse sur `prettier --check`).
-  - Fichiers `.svelte` → MCP `svelte-autofixer`.
+- Le **hook pre-commit est léger** (`.lintstagedrc.js` → `oxlint` + `prettier` sur les fichiers staged, ~2 s, **pas d'OOM**) → **`--no-verify` n'est plus nécessaire**. oxlint bloque sur _erreurs_ seulement (warnings non bloquants) ; prettier garde le job **Lint** CI (`prettier --check`) vert.
 - **Avant de pousser** : `pnpm check:incremental` (memory-safe, **0 erreur exigée**).
-- **eslint = CI-only** (il OOM en local). On accepte le round-trip CI ; `npx eslint <fichiers>` seulement si la machine tient.
+- **eslint = CI-only** (il OOM en local) — le hook utilise `oxlint` (Rust) à la place pour le feedback local. On accepte le round-trip CI ; `npx eslint <fichiers>` seulement si la machine tient.
 - **INTERDIT** (OOM) : `pnpm check` / `pnpm build` / `pnpm lint` / `svelte-check` sur tout le projet.
 
 ## 5. Base de données / migrations (chemin à haut risque)
@@ -83,7 +81,7 @@ Même flux, expédié : `fix/<slug>` depuis `main` → fix **+ test de non-régr
 ## 10. Interdits (leçons gravées — sessions 2026-06-16/17)
 
 - ❌ Smoke-test d'une fonction `SECURITY DEFINER` avec `auth.uid()` NULL.
-- ❌ Laisser du travail non commité : un hook pre-commit qui crashe le **stashe** (→ perdu). Commit tôt ; après un crash de hook, **vérifier `git stash list`**.
+- ❌ Laisser du travail non commité : un hook qui crashe peut le **stasher** (→ perdu). Commit tôt ; après un crash de hook, **vérifier `git stash list`**. (Le pre-commit est désormais léger — oxlint + prettier — donc ce risque a fortement baissé.)
 - ❌ Merger en CI rouge.
 - ❌ Pousser une migration que le code déployé ne supporte pas (ordre additive/destructive).
 - ❌ `pnpm db:migrate` depuis une branche non mergée.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
 		"lint-staged": "^16.4.0",
 		"lucide-svelte": "^0.545.0",
 		"openapi3-ts": "^4.5.0",
+		"oxlint": "^1.70.0",
 		"pg": "^8.20.0",
 		"playwright": "^1.59.1",
 		"prettier": "3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       openapi3-ts:
         specifier: ^4.5.0
         version: 4.5.0
+      oxlint:
+        specifier: ^1.70.0
+        version: 1.70.0
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -1366,6 +1369,120 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    resolution: {integrity: sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    resolution: {integrity: sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    resolution: {integrity: sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    resolution: {integrity: sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    resolution: {integrity: sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    resolution: {integrity: sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    resolution: {integrity: sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    resolution: {integrity: sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    resolution: {integrity: sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    resolution: {integrity: sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    resolution: {integrity: sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -3626,6 +3743,19 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  oxlint@1.70.0:
+    resolution: {integrity: sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
@@ -5650,6 +5780,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    optional: true
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -7969,6 +8156,28 @@ snapshots:
       word-wrap: 1.2.5
 
   orderedmap@2.1.1: {}
+
+  oxlint@1.70.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.70.0
+      '@oxlint/binding-android-arm64': 1.70.0
+      '@oxlint/binding-darwin-arm64': 1.70.0
+      '@oxlint/binding-darwin-x64': 1.70.0
+      '@oxlint/binding-freebsd-x64': 1.70.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.70.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.70.0
+      '@oxlint/binding-linux-arm64-gnu': 1.70.0
+      '@oxlint/binding-linux-arm64-musl': 1.70.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-musl': 1.70.0
+      '@oxlint/binding-linux-s390x-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-musl': 1.70.0
+      '@oxlint/binding-openharmony-arm64': 1.70.0
+      '@oxlint/binding-win32-arm64-msvc': 1.70.0
+      '@oxlint/binding-win32-ia32-msvc': 1.70.0
+      '@oxlint/binding-win32-x64-msvc': 1.70.0
 
   p-limit@1.3.0:
     dependencies:


### PR DESCRIPTION
## Pourquoi

L'ancien pre-commit (`.lintstagedrc.js`) lançait `eslint --fix` (type-aware) **et** `vitest related` — les deux **OOM** sur cette machine 8 Go, ce qui imposait `git commit --no-verify` (et le risque de perdre le travail *stashé* par un hook qui crashe).

## Changement

- **oxlint** (Rust, ~0 RAM) remplace eslint dans le hook → lint local rapide. **Bloque sur _erreurs_ seulement**, les warnings passent (exit code par défaut d'oxlint).
- **`vitest related` retiré** du hook (tests en CI + `pnpm test:changed` en local).
- `prettier` conservé.
- `.svelte` : oxlint en **report-only** (pas de `--fix`, pour ne pas réécrire à travers le mapping script↔fichier).
- `.oxlintrc.json` : `no-unused-vars` ignore le préfixe `^_` (tue le bruit des `_e` volontaires).

## Ce qui NE change PAS

- **eslint reste la vraie gate en CI** (job *Lint*) : `eslint-plugin-svelte` (templates/a11y) + la règle custom `require-zod-validation`, **qu'oxlint ne peut pas exécuter**.
- Le typecheck reste hors hook (`pnpm check:incremental`).

## Baseline oxlint (catégorie correctness)

**106 warnings, 0 error** sur `src/` — non bloquant ; en pre-commit, lint-staged ne voit que les fichiers stagés.

## Vérification (E2E)

Commit réel **sans `--no-verify`** → hook (oxlint + prettier) en **2,5 s, zéro OOM** ✅. Plus besoin de `--no-verify`.

## Docs

`CLAUDE.md` + `git-workflow.md` mis à jour (le hook est léger ; `--no-verify` n'est plus nécessaire).

## Portée

Outillage de dev local + CI lint inchangé. N'affecte pas le runtime.