### PR TITLE
refactor: migrate icons lucide-svelte -> @lucide/svelte (drop deprecated dep)

### DIFF
--- a/docs/wip/lucide-migration-progress.md
+++ b/docs/wip/lucide-migration-progress.md
@@ -1,0 +1,70 @@
+# Migration `lucide-svelte` → `@lucide/svelte` — progress
+
+> Chantier issu de l'analyse de bundle (visualizer, PR #21). Crash-recovery doc.
+
+## Objectif
+
+Migrer les imports d'icônes du paquet **déprécié** `lucide-svelte@0.545.0` (528 kB gz, **1ʳᵉ dépendance par le poids**, 482 fichiers) vers **`@lucide/svelte@1.16.0`** (maintenu, Svelte 5 natif, déjà tiré transitivement par bits-ui/shadcn). But : **lib d'icônes unique + fin de la dépréciation**. (Ne réduit PAS les 528 kB — mêmes icônes ; gain = maintenance/dédoublonnage.)
+
+## Périmètre mesuré
+
+- **482 fichiers**, **190 icônes distinctes**, 3 styles d'import :
+  1. Named : `import { X, Y } from 'lucide-svelte'` (majorité).
+  2. Sous-chemin : `import Play from 'lucide-svelte/icons/play'` (PlayerControls + qq.).
+  3. Type : `import type { Icon as LucideIcon } from 'lucide-svelte'` (ToolButton.svelte).
+
+## Phase 0 — Spec & table de renommage — ✅ FAIT
+
+**Découverte clé : la table de renommage est VIDE.** `@lucide/svelte` réexporte tous les anciens noms :
+
+```js
+// node_modules/@lucide/svelte/dist/lucide-svelte.js  (exports['.'])
+export * from './icons/index.js'; // noms canoniques
+export * from './aliases/index.js'; // aliases + prefixed + suffixed = TOUS les anciens noms
+export { default as Icon } from './Icon.svelte';
+```
+
+- **190/190 icônes couvertes** sous l'ancien nom (188 directes/alias + `FileIcon`/`ImageIcon` via `suffixed.js`). 0 à mapper.
+- Sous-chemins utilisés (`play`, `pause`, `rotate-ccw`, `skip-back`, `skip-forward`) : présents dans `@lucide/svelte/icons`.
+- Type `Icon` : exporté → l'import type devrait passer ; **à confirmer en Phase 2** (sinon basculer sur `LucideIcon`, exporté aussi).
+- ⚠️ On s'appuie sur les **alias dépréciés** (noms) : sort du _paquet_ déprécié, pas des _noms_. Nettoyage canonique = chantier séparé optionnel.
+
+**Filet de sécurité** : imports nommés typés → tout export inexistant = erreur TS → `check:incremental`/CI rouge. Pas de casse silencieuse.
+
+## Phase 1 — Codemod — ✅ FAIT (branche `chore/lucide-migration`)
+
+- **482 fichiers** migrés `'lucide-svelte'` → `'@lucide/svelte'` (named + sous-chemins + type import) via codemod perl.
+- `lucide-svelte` retiré de `package.json` (`pnpm remove`).
+- **2 différences d'API surfacées par le filet TS** (= la valeur du `check:incremental`) :
+  1. **Type icône** : `icon: ComponentType` (Svelte 4) incompatible avec `Component<LucideProps>` (Svelte 5) → corrigé en `icon: LucideIcon` (importé de `@lucide/svelte`, = `Component<LucideProps>`) dans `dashboard-nav.ts`, `Header.svelte`, `Sidebar.svelte`, `navigation/MobileNavDrawer.svelte`.
+  2. **Icône de marque retirée** : `Youtube` n'existe plus dans Lucide (trademark) → remplacé par **`Video`** dans `materials/+page.svelte` (type `YOUTUBE_VIDEO`). ⚠️ choix visuel à confirmer (alternatives : `Film`, `MonitorPlay`).
+- `pnpm check:incremental` = **0 erreur** (1697 fichiers, 46 warnings préexistants).
+- NB `Chrome` (20 occurrences) = chaînes user-agent, **pas** des icônes lucide (confirmé).
+
+### Détails initiaux du codemod (référence)
+
+Script `tsx` déterministe sur `src/` :
+
+- `from 'lucide-svelte'` → `from '@lucide/svelte'` (named).
+- `from 'lucide-svelte/icons/<kebab>'` → `from '@lucide/svelte/icons/<kebab>'`.
+- Type import : `'lucide-svelte'` → `'@lucide/svelte'` (garder `Icon as LucideIcon`, ajuster si Phase 2 le réclame).
+- Retirer `lucide-svelte` de `package.json` (garder `@lucide/svelte`).
+
+## Phase 2 — Vérif — ⏳
+
+`pnpm check:incremental` = 0 erreur · CI verte (Type Check + Build) · smoke visuel (dashboard-nav, whiteboard toolbar, PlayerControls) · re-run `bundle-analyze` → `lucide-svelte` disparu.
+
+## Phase 3 — `code-reviewer` + PR — ⏳
+
+1 PR atomique. Pas de `security-auditor` (aucun auth/RLS/API).
+
+## Definition of Done
+
+check:incremental 0 erreur · CI verte · bundle sans `lucide-svelte` · icônes OK pages clés · dep retirée.
+
+## Statut
+
+- [x] Phase 0 (table vide, périmètre confirmé) — 2026-06-17
+- [ ] Phase 1 codemod
+- [ ] Phase 2 vérif
+- [ ] Phase 3 review + PR

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
 		"globals": "^17.5.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.4.0",
-		"lucide-svelte": "^0.545.0",
 		"openapi3-ts": "^4.5.0",
 		"oxlint": "^1.70.0",
 		"pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,9 +340,6 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
-      lucide-svelte:
-        specifier: ^0.545.0
-        version: 0.545.0(svelte@5.56.3(@typescript-eslint/types@8.58.2))
       openapi3-ts:
         specifier: ^4.5.0
         version: 4.5.0
@@ -3610,12 +3607,6 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
-
-  lucide-svelte@0.545.0:
-    resolution: {integrity: sha512-lVza6hIAf1abADTU1ThyNp+M3bQZtzTGQ9EQZ2xo3n9ftkd4QcWbDB2ekP2MqRLTJpeLXX5gaFEgFZtbWCnyqg==}
-    deprecated: Package deprecated. Please use @lucide/svelte instead.
-    peerDependencies:
-      svelte: ^3 || ^4 || ^5.0.0-next.42
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -8109,10 +8100,6 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  lucide-svelte@0.545.0(svelte@5.56.3(@typescript-eslint/types@8.58.2)):
-    dependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.58.2)
 
   lz-string@1.5.0: {}
 

--- a/src/lib/components/AddFriend.svelte
+++ b/src/lib/components/AddFriend.svelte
@@ -6,7 +6,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Search, UserPlus, Check, Clock, UserX, Users, Loader2 } from 'lucide-svelte';
+	import { Search, UserPlus, Check, Clock, UserX, Users, Loader2 } from '@lucide/svelte';
 
 	let searchQuery = $state('');
 	let searchResults = $state<

--- a/src/lib/components/AnswerEditor.svelte
+++ b/src/lib/components/AnswerEditor.svelte
@@ -26,7 +26,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
 
 	interface Props {
 		questionType: QuestionType;

--- a/src/lib/components/BonusHistoryModal.svelte
+++ b/src/lib/components/BonusHistoryModal.svelte
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X, Star, Plus, ArrowRight, Trash2 } from 'lucide-svelte';
+	import { X, Star, Plus, ArrowRight, Trash2 } from '@lucide/svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';

--- a/src/lib/components/CartFloatingButton.svelte
+++ b/src/lib/components/CartFloatingButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ShoppingCart } from 'lucide-svelte';
+	import { ShoppingCart } from '@lucide/svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import { questionCart } from '$lib/stores/questionCart.svelte';
 	import { goto } from '$app/navigation';

--- a/src/lib/components/CartQuestionCard.svelte
+++ b/src/lib/components/CartQuestionCard.svelte
@@ -3,7 +3,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { convertLegacyLatexToMarkdown } from '$lib/utils/latex-syntax-adapter';
-	import { Plus, Minus } from 'lucide-svelte';
+	import { Plus, Minus } from '@lucide/svelte';
 	import type { CartItem, QuestionCategory } from '$lib/stores/questionCart.svelte';
 	import type { QuestionInstance } from '$lib/questions/types';
 

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -36,7 +36,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { Plus } from 'lucide-svelte';
+	import { Plus } from '@lucide/svelte';
 
 	interface Props {
 		label: string;

--- a/src/lib/components/ChatBot.svelte
+++ b/src/lib/components/ChatBot.svelte
@@ -58,7 +58,7 @@
 	import * as Avatar from '$lib/components/ui/avatar';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { personalities, type PersonalityKey } from '$lib/config/personalities';
-	import { Trash2, Send, User, Paperclip, X, Link as LinkIcon } from 'lucide-svelte';
+	import { Trash2, Send, User, Paperclip, X, Link as LinkIcon } from '@lucide/svelte';
 	import pereUbuImage from '$lib/assets/images/avatar-pereubu.png';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { convertLegacyLatexToMarkdown } from '$lib/utils/latex-syntax-adapter';

--- a/src/lib/components/ClassStatsCard.svelte
+++ b/src/lib/components/ClassStatsCard.svelte
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { CalendarClock, Users } from 'lucide-svelte';
+	import { CalendarClock, Users } from '@lucide/svelte';
 
 	interface Props {
 		studentCount: number;

--- a/src/lib/components/ConsentBanner.svelte
+++ b/src/lib/components/ConsentBanner.svelte
@@ -16,7 +16,7 @@
 -->
 <script lang="ts">
 	import * as Alert from '$lib/components/ui/alert';
-	import { Clock, ShieldAlert } from 'lucide-svelte';
+	import { Clock, ShieldAlert } from '@lucide/svelte';
 	import type { ConsentStatus } from '$lib/utils/consent';
 
 	interface Props {

--- a/src/lib/components/DisplayOptionsEditor.svelte
+++ b/src/lib/components/DisplayOptionsEditor.svelte
@@ -10,7 +10,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import MyCheckbox from './MyCheckbox.svelte';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/FriendRequests.svelte
+++ b/src/lib/components/FriendRequests.svelte
@@ -3,7 +3,7 @@
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Check, X, Clock, UserPlus } from 'lucide-svelte';
+	import { Check, X, Clock, UserPlus } from '@lucide/svelte';
 
 	// Friendships are a single relation type now ('friend'); legacy values map to "Ami".
 	function getFriendshipTypeLabel(): string {

--- a/src/lib/components/FriendsList.svelte
+++ b/src/lib/components/FriendsList.svelte
@@ -5,7 +5,7 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { MoreVertical, Search, User } from 'lucide-svelte';
+	import { MoreVertical, Search, User } from '@lucide/svelte';
 
 	let searchQuery = $state('');
 

--- a/src/lib/components/GidouilleHistoryModal.svelte
+++ b/src/lib/components/GidouilleHistoryModal.svelte
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X, Plus, ArrowRight, Trash2 } from 'lucide-svelte';
+	import { X, Plus, ArrowRight, Trash2 } from '@lucide/svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';

--- a/src/lib/components/GradeBadgeSelector.svelte
+++ b/src/lib/components/GradeBadgeSelector.svelte
@@ -21,7 +21,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { X, Plus } from 'lucide-svelte';
+	import { X, Plus } from '@lucide/svelte';
 	import {
 		GRADES,
 		PRIMARY_GRADES,

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -42,7 +42,7 @@
 	import { fontSize } from '$lib/stores/fontSize.svelte';
 	import type { User } from '@supabase/supabase-js';
 	import type { Profile } from '$lib/types/database-helpers';
-	import type { ComponentType } from 'svelte';
+	import type { LucideIcon } from '@lucide/svelte';
 	import {
 		Menu,
 		LogIn,
@@ -60,7 +60,7 @@
 		Calculator,
 		PenTool,
 		Laugh
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import gidouille from '$lib/assets/images/gidouille.png';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
@@ -95,7 +95,7 @@
 	});
 
 	// Navigation item type
-	type NavItem = { label: string; href: string; icon: ComponentType; roles?: string[] };
+	type NavItem = { label: string; href: string; icon: LucideIcon; roles?: string[] };
 
 	// Props received from parent layout (+layout.svelte)
 	// These are automatically reactive in Svelte 5

--- a/src/lib/components/JsonViewer.svelte
+++ b/src/lib/components/JsonViewer.svelte
@@ -17,7 +17,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { Copy, Check } from 'lucide-svelte';
+	import { Copy, Check } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	interface Props {

--- a/src/lib/components/QuestionPreview.svelte
+++ b/src/lib/components/QuestionPreview.svelte
@@ -23,7 +23,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Label } from '$lib/components/ui/label';
-	import { AlertCircle, RefreshCw, Check, X } from 'lucide-svelte';
+	import { AlertCircle, RefreshCw, Check, X } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import FlashCard from '$lib/components/questions/FlashCard.svelte';
 	import { MarkdownRenderer } from '$lib/components/markdown';

--- a/src/lib/components/QuestionPreviewCard.svelte
+++ b/src/lib/components/QuestionPreviewCard.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Plus, Check } from 'lucide-svelte';
+	import { Plus, Check } from '@lucide/svelte';
 	import { questionCart } from '$lib/stores/questionCart.svelte';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { convertLegacyLatexToMarkdown } from '$lib/utils/latex-syntax-adapter';

--- a/src/lib/components/QuestionTemplateCard.svelte
+++ b/src/lib/components/QuestionTemplateCard.svelte
@@ -26,7 +26,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
-	import { Eye, Pencil, Copy, Trash2 } from 'lucide-svelte';
+	import { Eye, Pencil, Copy, Trash2 } from '@lucide/svelte';
 
 	interface Props {
 		template: QuestionTemplate;

--- a/src/lib/components/QuestionTemplateForm.svelte
+++ b/src/lib/components/QuestionTemplateForm.svelte
@@ -81,7 +81,7 @@
 		CircleQuestionMark,
 		Braces,
 		FlaskConical
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { questionCategoriesCache } from '$lib/stores/questionCategories.svelte';
 	import QuestionTemplateHelpDialogs from './QuestionTemplateHelpDialogs.svelte';
 	import DisplayOptionsEditor from './DisplayOptionsEditor.svelte';

--- a/src/lib/components/RewardsBlock.svelte
+++ b/src/lib/components/RewardsBlock.svelte
@@ -20,7 +20,7 @@
 -->
 
 <script lang="ts">
-	import { Star } from 'lucide-svelte';
+	import { Star } from '@lucide/svelte';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';
 	import type { StudentVipCards } from '$lib/types/vip-card';
 	import { getTotalUnusedCards } from '$lib/utils/vip-cards';

--- a/src/lib/components/ScheduleEntryModal.svelte
+++ b/src/lib/components/ScheduleEntryModal.svelte
@@ -59,7 +59,7 @@
 	import { formatPeriodDisplay, type SchoolPeriod } from '$lib/utils/timetable';
 
 	type ClassSchedule = Tables<'class_schedules'>;
-	import { Trash2 } from 'lucide-svelte';
+	import { Trash2 } from '@lucide/svelte';
 
 	export interface ScheduleFormData {
 		id?: string;

--- a/src/lib/components/SharedFieldsEditor.svelte
+++ b/src/lib/components/SharedFieldsEditor.svelte
@@ -28,7 +28,7 @@
 	import MySelect from './MySelect.svelte';
 	import MyCheckbox from './MyCheckbox.svelte';
 	import PrecisionEditor from './PrecisionEditor.svelte';
-	import { ChevronDown, CircleQuestionMark } from 'lucide-svelte';
+	import { ChevronDown, CircleQuestionMark } from '@lucide/svelte';
 	import { REQUIRED_FORM_OPTIONS } from '$lib/questions/form-options';
 
 	interface Props {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
-	import { Home, Gamepad2, PenTool, Terminal, Calculator, Laugh } from 'lucide-svelte';
-	import type { ComponentType } from 'svelte';
+	import { Home, Gamepad2, PenTool, Terminal, Calculator, Laugh } from '@lucide/svelte';
+	import type { LucideIcon } from '@lucide/svelte';
 	import type { Tables } from '$lib/types/database';
 
 	type NavSection = 'serious' | 'fun';
 	type NavItem = {
 		label: string;
 		href: string;
-		icon: ComponentType;
+		icon: LucideIcon;
 		roles?: string[];
 		section?: NavSection;
 	};

--- a/src/lib/components/StudentVipCardsModal.svelte
+++ b/src/lib/components/StudentVipCardsModal.svelte
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import VipCard from './VipCard.svelte';
 	import VipCardHoloModal from './VipCardHoloModal.svelte';
 	import {
@@ -49,7 +49,7 @@
 		getTotalUnusedCards
 	} from '$lib/utils/vip-cards';
 	import type { VipCard as VipCardType, StudentVipCards } from '$lib/types/vip-card';
-	import { Sparkles } from 'lucide-svelte';
+	import { Sparkles } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import { vipCardTemplates } from '$lib/stores/vipCardTemplates.svelte';
@@ -62,7 +62,7 @@
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';
 	import { syncVipCards } from '$lib/utils/cache-sync';
 	import StudentJournalModal from '$lib/components/rewards/StudentJournalModal.svelte';
-	import { ScrollText } from 'lucide-svelte';
+	import { ScrollText } from '@lucide/svelte';
 
 	interface Props {
 		studentId: string;

--- a/src/lib/components/TagBadgeSelector.svelte
+++ b/src/lib/components/TagBadgeSelector.svelte
@@ -27,7 +27,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { X, Plus, Loader2 } from 'lucide-svelte';
+	import { X, Plus, Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Types

--- a/src/lib/components/ValidationOptionsEditor.svelte
+++ b/src/lib/components/ValidationOptionsEditor.svelte
@@ -22,7 +22,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import MySelect from './MySelect.svelte';
 	import MyCheckbox from './MyCheckbox.svelte';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/VariableEditor.svelte
+++ b/src/lib/components/VariableEditor.svelte
@@ -30,7 +30,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Plus, Trash2, ArrowUp, ArrowDown } from 'lucide-svelte';
+	import { Plus, Trash2, ArrowUp, ArrowDown } from '@lucide/svelte';
 
 	interface Props {
 		variables?: QuestionVariable[];

--- a/src/lib/components/VipCard.svelte
+++ b/src/lib/components/VipCard.svelte
@@ -35,7 +35,7 @@
 	import type { VipCard } from '$lib/types/vip-card';
 	import { cn } from '$lib/utils';
 	import Badge from '$lib/components/ui/badge/badge.svelte';
-	import { Trash2, Sparkles, Clock, Zap, Coins } from 'lucide-svelte';
+	import { Trash2, Sparkles, Clock, Zap, Coins } from '@lucide/svelte';
 
 	interface Props {
 		card: VipCard;

--- a/src/lib/components/VipCardActivationButton.svelte
+++ b/src/lib/components/VipCardActivationButton.svelte
@@ -20,7 +20,7 @@
 	import { getActionDescription } from '$lib/utils/vip-cards';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2, Sparkles } from 'lucide-svelte';
+	import { Loader2, Sparkles } from '@lucide/svelte';
 	import { vipCardTemplates } from '$lib/stores/vipCardTemplates.svelte';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';
 	import { syncVipCards } from '$lib/utils/cache-sync';

--- a/src/lib/components/VipCardSelector.svelte
+++ b/src/lib/components/VipCardSelector.svelte
@@ -25,7 +25,7 @@
 	import VipCard from '$lib/components/VipCard.svelte';
 	import VipCardSelectorModal from '$lib/components/VipCardSelectorModal.svelte';
 	import { cn } from '$lib/utils';
-	import { CreditCard, X } from 'lucide-svelte';
+	import { CreditCard, X } from '@lucide/svelte';
 	import {
 		templateToVipCard,
 		getTemplateById,

--- a/src/lib/components/VipCardsModal.svelte
+++ b/src/lib/components/VipCardsModal.svelte
@@ -52,7 +52,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import VipCard from './VipCard.svelte';
 	import VipCardHoloModal from './VipCardHoloModal.svelte';
 	import {
@@ -62,7 +62,7 @@
 		sortCardsByPriority
 	} from '$lib/utils/vip-cards';
 	import type { VipCard as VipCardType } from '$lib/types/vip-card';
-	import { Sparkles } from 'lucide-svelte';
+	import { Sparkles } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';

--- a/src/lib/components/__tests__/Sidebar.svelte.test.ts
+++ b/src/lib/components/__tests__/Sidebar.svelte.test.ts
@@ -1,7 +1,7 @@
 import { page } from '@vitest/browser/context';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
-import { Home } from 'lucide-svelte';
+import { Home } from '@lucide/svelte';
 import Sidebar from '../Sidebar.svelte';
 import type { Tables } from '$lib/types/database';
 

--- a/src/lib/components/account/AccountDeletionDialog.svelte
+++ b/src/lib/components/account/AccountDeletionDialog.svelte
@@ -19,7 +19,7 @@
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { AlertTriangle, Loader2, Trash2, X } from 'lucide-svelte';
+	import { AlertTriangle, Loader2, Trash2, X } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/achievements/AchievementCard.svelte
+++ b/src/lib/components/achievements/AchievementCard.svelte
@@ -15,7 +15,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Progress } from '$lib/components/ui/progress';
-	import { Lock, Trophy, Star, Sparkles, Crown, Gem } from 'lucide-svelte';
+	import { Lock, Trophy, Star, Sparkles, Crown, Gem } from '@lucide/svelte';
 	import type { Achievement, AchievementRarity } from '$lib/types/achievements';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/achievements/AchievementLeaderboard.svelte
+++ b/src/lib/components/achievements/AchievementLeaderboard.svelte
@@ -13,7 +13,7 @@
 <script lang="ts">
 	import { Avatar, AvatarFallback, AvatarImage } from '$lib/components/ui/avatar';
 	import { Skeleton } from '$lib/components/ui/skeleton';
-	import { Trophy, Medal, Award } from 'lucide-svelte';
+	import { Trophy, Medal, Award } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	// Type for leaderboard entry

--- a/src/lib/components/achievements/AchievementList.svelte
+++ b/src/lib/components/achievements/AchievementList.svelte
@@ -13,7 +13,7 @@
 	import AchievementCard from './AchievementCard.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
-	import { Trophy, Target, Percent, Star } from 'lucide-svelte';
+	import { Trophy, Target, Percent, Star } from '@lucide/svelte';
 	import type { Achievement, AchievementRarity } from '$lib/types/achievements';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/achievements/AchievementToast.svelte
+++ b/src/lib/components/achievements/AchievementToast.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
 	import { fly, scale } from 'svelte/transition';
 	import { backOut } from 'svelte/easing';
-	import { X, Trophy, Star, Sparkles, Crown, Gem } from 'lucide-svelte';
+	import { X, Trophy, Star, Sparkles, Crown, Gem } from '@lucide/svelte';
 	import type { Achievement, AchievementRarity } from '$lib/types/achievements';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/admin/widgets/ErrorSummaryWidget.svelte
+++ b/src/lib/components/admin/widgets/ErrorSummaryWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AlertTriangle, TrendingUp } from 'lucide-svelte';
+	import { AlertTriangle, TrendingUp } from '@lucide/svelte';
 	import * as Card from '$lib/components/ui/card';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { cn } from '$lib/utils';

--- a/src/lib/components/admin/widgets/HealthStatusCard.svelte
+++ b/src/lib/components/admin/widgets/HealthStatusCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp } from '@lucide/svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/admin/widgets/MetricCard.svelte
+++ b/src/lib/components/admin/widgets/MetricCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowUp, ArrowDown, type Icon } from 'lucide-svelte';
+	import { ArrowUp, ArrowDown, type Icon } from '@lucide/svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/admin/widgets/README.md
+++ b/src/lib/components/admin/widgets/README.md
@@ -43,7 +43,7 @@ Display a single metric with value, label, trend indicator, and optional alert b
 ```svelte
 <script>
 	import MetricCard from '$lib/components/admin/widgets/MetricCard.svelte';
-	import { Users } from 'lucide-svelte';
+	import { Users } from '@lucide/svelte';
 </script>
 
 <MetricCard
@@ -202,7 +202,7 @@ Loading skeleton placeholder for widgets.
 		TrendChart,
 		WidgetSkeleton
 	} from '$lib/components/admin/widgets';
-	import { Users, Activity, Database } from 'lucide-svelte';
+	import { Users, Activity, Database } from '@lucide/svelte';
 
 	let loading = $state(false);
 </script>

--- a/src/lib/components/assessments/AssessmentCard.svelte
+++ b/src/lib/components/assessments/AssessmentCard.svelte
@@ -27,7 +27,7 @@
 		Clock,
 		AlertCircle,
 		Calendar
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { DbAssessment } from '$lib/types/assessment';
 	import type { AssignmentWithDetails } from '$lib/types/assessment';
 	import { getStatusColor, getStatusLabel, getAttemptsRemaining } from '$lib/types/assessment';

--- a/src/lib/components/blockly/BlocklyOutput.svelte
+++ b/src/lib/components/blockly/BlocklyOutput.svelte
@@ -5,7 +5,7 @@
   Shows stdout, stderr, and info messages with color coding.
 -->
 <script lang="ts">
-	import { Trash2, Terminal } from 'lucide-svelte';
+	import { Trash2, Terminal } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import type { OutputLine } from '$lib/shared/blockly';
 	import { cn } from '$lib/utils';

--- a/src/lib/components/blockly/BlocklyToolbar.svelte
+++ b/src/lib/components/blockly/BlocklyToolbar.svelte
@@ -5,7 +5,7 @@
   clearing output/workspace, and switching between JavaScript and Python.
 -->
 <script lang="ts">
-	import { Play, Trash2, RefreshCw, Loader2, Maximize2, Minimize2 } from 'lucide-svelte';
+	import { Play, Trash2, RefreshCw, Loader2, Maximize2, Minimize2 } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import type { ExecutionLanguage } from '$lib/shared/blockly';
 

--- a/src/lib/components/buddy/BuddyStatusPanel.svelte
+++ b/src/lib/components/buddy/BuddyStatusPanel.svelte
@@ -10,7 +10,7 @@
 	import { xpProgress, MAX_LEVEL } from '$lib/utils/buddy-xp';
 	import { Progress } from '$lib/components/ui/progress';
 	import { Button } from '$lib/components/ui/button';
-	import { Flame, Star, ArrowRightLeft, X } from 'lucide-svelte';
+	import { Flame, Star, ArrowRightLeft, X } from '@lucide/svelte';
 	import { fade } from 'svelte/transition';
 
 	interface Props {

--- a/src/lib/components/bug-reports/BugReportDialog.svelte
+++ b/src/lib/components/bug-reports/BugReportDialog.svelte
@@ -24,7 +24,7 @@
 		BUG_REPORT_CATEGORY_ICONS,
 		BUG_REPORT_SEVERITY_LABELS
 	} from '$lib/types/bug-reports';
-	import { Loader2, Upload, X } from 'lucide-svelte';
+	import { Loader2, Upload, X } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/bug-reports/BugReportFAB.svelte
+++ b/src/lib/components/bug-reports/BugReportFAB.svelte
@@ -6,7 +6,7 @@
 	 * Clicking it opens the bug report dialog.
 	 */
 	import { cn } from '$lib/utils';
-	import { Bug } from 'lucide-svelte';
+	import { Bug } from '@lucide/svelte';
 
 	interface Props {
 		onclick: () => void;

--- a/src/lib/components/bug-reports/BugReportList.svelte
+++ b/src/lib/components/bug-reports/BugReportList.svelte
@@ -15,7 +15,7 @@
 	import BugReportCard from './BugReportCard.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 
 	interface Props {
 		reports: BugReportWithAuthor[];

--- a/src/lib/components/bug-reports/BugReportsConfigCard.svelte
+++ b/src/lib/components/bug-reports/BugReportsConfigCard.svelte
@@ -8,7 +8,7 @@
 	import { onMount } from 'svelte';
 	import * as Card from '$lib/components/ui/card';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
-	import { Loader2, Settings2 } from 'lucide-svelte';
+	import { Loader2, Settings2 } from '@lucide/svelte';
 	import { bugReportsConfigStore } from '$lib/stores/bugReportsConfig.svelte';
 	import {
 		BUG_REPORTS_CONFIG_LABELS,

--- a/src/lib/components/bug-reports/ExportClaudeCodeButton.svelte
+++ b/src/lib/components/bug-reports/ExportClaudeCodeButton.svelte
@@ -8,7 +8,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Download, Copy, Loader2, FileText, Check } from 'lucide-svelte';
+	import { Download, Copy, Loader2, FileText, Check } from '@lucide/svelte';
 
 	interface Props {
 		reportId: string;

--- a/src/lib/components/bug-reports/FreezeReportPrompt.svelte
+++ b/src/lib/components/bug-reports/FreezeReportPrompt.svelte
@@ -9,7 +9,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { getFreezeDetectionContext } from '$lib/utils/freezeDetection';
-	import { Loader2, AlertTriangle } from 'lucide-svelte';
+	import { Loader2, AlertTriangle } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/calculator/CalculatorContainer.svelte
+++ b/src/lib/components/calculator/CalculatorContainer.svelte
@@ -2,7 +2,7 @@
 	import type { MathfieldElement } from 'mathlive';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { Button } from '$lib/components/ui/button';
-	import { Keyboard, Share2, Download, Trash2 } from 'lucide-svelte';
+	import { Keyboard, Share2, Download, Trash2 } from '@lucide/svelte';
 	import UnifiedInput from './UnifiedInput.svelte';
 	import ResultDisplay from './ResultDisplay.svelte';
 	import CalculatorKeyboard from './CalculatorKeyboard.svelte';

--- a/src/lib/components/calculator/ResultDisplay.svelte
+++ b/src/lib/components/calculator/ResultDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { Copy, ChevronDown, AlertCircle, Lightbulb, TrendingUp, Loader2 } from 'lucide-svelte';
+	import { Copy, ChevronDown, AlertCircle, Lightbulb, TrendingUp, Loader2 } from '@lucide/svelte';
 	import type { CalculationResult } from '$lib/stores/calculator.svelte';
 	import StepsDisplay from './StepsDisplay.svelte';
 	import {

--- a/src/lib/components/calculator/StepsDisplay.svelte
+++ b/src/lib/components/calculator/StepsDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { ChevronRight } from 'lucide-svelte';
+	import { ChevronRight } from '@lucide/svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import type { CalculationStep, SchoolLevel } from '$lib/mathAST/step-generator';
 	import StepsDisplay from './StepsDisplay.svelte';

--- a/src/lib/components/calculator/UnifiedInput.svelte
+++ b/src/lib/components/calculator/UnifiedInput.svelte
@@ -2,7 +2,7 @@
 	import type { MathfieldElement } from 'mathlive';
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { Play } from 'lucide-svelte';
+	import { Play } from '@lucide/svelte';
 
 	// Types
 	interface SubmitInput {

--- a/src/lib/components/cas/AstDrawer.svelte
+++ b/src/lib/components/cas/AstDrawer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from 'bits-ui';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
 	import { replStore } from '$lib/stores/repl.svelte';

--- a/src/lib/components/cas/AstTreeViewer.svelte
+++ b/src/lib/components/cas/AstTreeViewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronRight, ChevronDown } from 'lucide-svelte';
+	import { ChevronRight, ChevronDown } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import { replStore } from '$lib/stores/repl.svelte';
 	import type { MathNode } from '$lib/mathAST/types';

--- a/src/lib/components/cas/ExportModal.svelte
+++ b/src/lib/components/cas/ExportModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Copy, Download, Check } from 'lucide-svelte';
+	import { Copy, Download, Check } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	interface Props {

--- a/src/lib/components/cas/HelpPopover.svelte
+++ b/src/lib/components/cas/HelpPopover.svelte
@@ -2,7 +2,7 @@
 	import { replStore } from '$lib/stores/repl.svelte';
 	import * as Popover from '$lib/components/ui/popover';
 	import { Button } from '$lib/components/ui/button';
-	import { HelpCircle, Keyboard, Info } from 'lucide-svelte';
+	import { HelpCircle, Keyboard, Info } from '@lucide/svelte';
 	import { Separator } from '$lib/components/ui/separator';
 
 	// Get available commands from the store

--- a/src/lib/components/cas/HistoryEntry.svelte
+++ b/src/lib/components/cas/HistoryEntry.svelte
@@ -2,7 +2,7 @@
 	import { cn } from '$lib/utils';
 	import type { ReplHistoryEntry, TabStyle } from '$lib/mathAST/cli/web';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowRightLeft } from 'lucide-svelte';
+	import { ArrowRightLeft } from '@lucide/svelte';
 
 	interface Props {
 		entry: ReplHistoryEntry;

--- a/src/lib/components/cas/ReplContainer.svelte
+++ b/src/lib/components/cas/ReplContainer.svelte
@@ -6,7 +6,7 @@
 	import HelpPopover from './HelpPopover.svelte';
 	import ExportModal from './ExportModal.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Trash2 } from 'lucide-svelte';
+	import { Trash2 } from '@lucide/svelte';
 	import type { TabStyle } from '$lib/mathAST/cli/web';
 
 	// Map tab IDs to TabStyle

--- a/src/lib/components/cas/ReplInput.svelte
+++ b/src/lib/components/cas/ReplInput.svelte
@@ -2,7 +2,7 @@
 	import { replStore } from '$lib/stores/repl.svelte';
 	import MathField from '$lib/components/MathField.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Play, Search } from 'lucide-svelte';
+	import { Play, Search } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import { CompletionProvider, type Completion } from '$lib/mathAST/cli/completion';
 

--- a/src/lib/components/chat/ChatComposer.svelte
+++ b/src/lib/components/chat/ChatComposer.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
 	import RichTextEditor from '$lib/components/rich-text/RichTextEditor.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Paperclip, X } from 'lucide-svelte';
+	import { Paperclip, X } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Component Props

--- a/src/lib/components/chat/ChatConversationList.svelte
+++ b/src/lib/components/chat/ChatConversationList.svelte
@@ -25,7 +25,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import OnlineStatus from '$lib/components/OnlineStatus.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { Search, MessageSquarePlus, Users } from 'lucide-svelte';
+	import { Search, MessageSquarePlus, Users } from '@lucide/svelte';
 	import type { Conversation } from '$lib/stores/chat.svelte';
 	import { presenceManager } from '$lib/stores/presence.svelte';
 

--- a/src/lib/components/chat/ChatMessageList.svelte
+++ b/src/lib/components/chat/ChatMessageList.svelte
@@ -30,7 +30,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { MoreVertical, Flag, Download, Trash2 } from 'lucide-svelte';
+	import { MoreVertical, Flag, Download, Trash2 } from '@lucide/svelte';
 	import DeleteMessageDialog from '$lib/components/moderation/DeleteMessageDialog.svelte';
 	import type { Message } from '$lib/stores/chat.svelte';
 	import { tipTapToMarkdown } from '$lib/components/rich-text/markdown-export';

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -28,7 +28,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { ArrowLeft, MoreVertical, Users, UserPlus } from 'lucide-svelte';
+	import { ArrowLeft, MoreVertical, Users, UserPlus } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { uploadMultipleAttachments } from '$lib/utils/file-upload';
 	import type { SupabaseClient } from '@supabase/supabase-js';

--- a/src/lib/components/chat/NewChatDialog.svelte
+++ b/src/lib/components/chat/NewChatDialog.svelte
@@ -23,7 +23,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import OnlineStatus from '$lib/components/OnlineStatus.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { Search, MessageSquare } from 'lucide-svelte';
+	import { Search, MessageSquare } from '@lucide/svelte';
 	import type { SupabaseClient } from '@supabase/supabase-js';
 	import { presenceManager } from '$lib/stores/presence.svelte';
 

--- a/src/lib/components/chat/ReportMessageDialog.svelte
+++ b/src/lib/components/chat/ReportMessageDialog.svelte
@@ -23,7 +23,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Label } from '$lib/components/ui/label';
 	import * as RadioGroup from '$lib/components/ui/radio-group';
-	import { Flag, AlertTriangle } from 'lucide-svelte';
+	import { Flag, AlertTriangle } from '@lucide/svelte';
 
 	// Component Props
 	interface Props {

--- a/src/lib/components/cours/ChapterCard.svelte
+++ b/src/lib/components/cours/ChapterCard.svelte
@@ -44,7 +44,7 @@
 		Ruler,
 		Shapes,
 		Box
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/cours/ChapterProgressIndicator.svelte
+++ b/src/lib/components/cours/ChapterProgressIndicator.svelte
@@ -12,7 +12,7 @@
 	import type { ChapterProgress } from '$lib/types/chapters';
 	import { Progress } from '$lib/components/ui/progress';
 	import { cn } from '$lib/utils';
-	import { CheckCircle2, Circle, Target, HelpCircle } from 'lucide-svelte';
+	import { CheckCircle2, Circle, Target, HelpCircle } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/cours/ChapterQuiz.svelte
+++ b/src/lib/components/cours/ChapterQuiz.svelte
@@ -18,7 +18,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
 	import { cn } from '$lib/utils';
-	import { ChevronRight, ChevronLeft } from 'lucide-svelte';
+	import { ChevronRight, ChevronLeft } from '@lucide/svelte';
 
 	import QuizQuestion from './QuizQuestion.svelte';
 	import QuizSummary from './QuizSummary.svelte';

--- a/src/lib/components/cours/ChecklistSection.svelte
+++ b/src/lib/components/cours/ChecklistSection.svelte
@@ -14,7 +14,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
 	import { cn } from '$lib/utils';
-	import { CheckCircle2, Circle, Target } from 'lucide-svelte';
+	import { CheckCircle2, Circle, Target } from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 
 	// Item with progress included

--- a/src/lib/components/cours/DocumentCard.svelte
+++ b/src/lib/components/cours/DocumentCard.svelte
@@ -24,7 +24,7 @@
 		Download,
 		Eye,
 		Cloud
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/cours/QuizQuestion.svelte
+++ b/src/lib/components/cours/QuizQuestion.svelte
@@ -12,7 +12,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { cn } from '$lib/utils';
-	import { Check, X } from 'lucide-svelte';
+	import { Check, X } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/cours/QuizSummary.svelte
+++ b/src/lib/components/cours/QuizSummary.svelte
@@ -12,7 +12,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { cn } from '$lib/utils';
-	import { Trophy, RotateCcw, X, Star } from 'lucide-svelte';
+	import { Trophy, RotateCcw, X, Star } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/cours/teacher/ChapterEditor.svelte
+++ b/src/lib/components/cours/teacher/ChapterEditor.svelte
@@ -41,7 +41,7 @@
 		Box,
 		Save,
 		X
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Types for create/update inputs
 	interface CreateChapterInput {

--- a/src/lib/components/cours/teacher/ChecklistEditor.svelte
+++ b/src/lib/components/cours/teacher/ChecklistEditor.svelte
@@ -26,7 +26,7 @@
 		ChevronUp,
 		ChevronDown,
 		Target
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props - callbacks are now optional (using form actions instead)
 	interface Props {

--- a/src/lib/components/cours/teacher/DocumentUpload.svelte
+++ b/src/lib/components/cours/teacher/DocumentUpload.svelte
@@ -18,7 +18,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
-	import { Upload, Link, FileText, Image, X, Loader2 } from 'lucide-svelte';
+	import { Upload, Link, FileText, Image, X, Loader2 } from '@lucide/svelte';
 
 	interface Props {
 		chapterId: string;

--- a/src/lib/components/cours/teacher/StudentProgressTable.svelte
+++ b/src/lib/components/cours/teacher/StudentProgressTable.svelte
@@ -14,7 +14,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Progress } from '$lib/components/ui/progress';
 	import { cn } from '$lib/utils';
-	import { Check, X, Users } from 'lucide-svelte';
+	import { Check, X, Users } from '@lucide/svelte';
 
 	// Props
 	interface Student {

--- a/src/lib/components/documents/DocumentCard.svelte
+++ b/src/lib/components/documents/DocumentCard.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
-	import { FileText, Trash2, ToggleLeft, ToggleRight, Edit } from 'lucide-svelte';
+	import { FileText, Trash2, ToggleLeft, ToggleRight, Edit } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { GradeCode } from '$lib/types/grades';
 

--- a/src/lib/components/documents/DocumentManager.svelte
+++ b/src/lib/components/documents/DocumentManager.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import { Search, RefreshCw, FileText, Upload } from 'lucide-svelte';
+	import { Search, RefreshCw, FileText, Upload } from '@lucide/svelte';
 	import DocumentUploader from './DocumentUploader.svelte';
 	import DocumentCard from './DocumentCard.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';

--- a/src/lib/components/documents/DocumentUploader.svelte
+++ b/src/lib/components/documents/DocumentUploader.svelte
@@ -3,7 +3,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
-	import { Upload, FileText, X, Loader2 } from 'lucide-svelte';
+	import { Upload, FileText, X, Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { GRADE_OPTIONS, type GradeCode } from '$lib/types/grades';
 

--- a/src/lib/components/exercises/ExerciseForm.svelte
+++ b/src/lib/components/exercises/ExerciseForm.svelte
@@ -27,7 +27,7 @@
 	} from '$lib/exercises/types';
 	import { EXERCISE_CATEGORIES } from '$lib/exercises/types';
 	import type { Variable } from '$lib/ubumark';
-	import { Save, Loader2 } from 'lucide-svelte';
+	import { Save, Loader2 } from '@lucide/svelte';
 
 	type ExerciseInsert = Database['public']['Tables']['exercises']['Insert'];
 

--- a/src/lib/components/exercises/ExerciseParameterizationEditor.svelte
+++ b/src/lib/components/exercises/ExerciseParameterizationEditor.svelte
@@ -25,7 +25,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import VariableEditor from '$lib/components/VariableEditor.svelte';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown } from '@lucide/svelte';
 	import type { Variable } from '$lib/ubumark';
 	import type { DistributionMode } from '$lib/exercises/types';
 

--- a/src/lib/components/exercises/GenericFunctionInput.svelte
+++ b/src/lib/components/exercises/GenericFunctionInput.svelte
@@ -21,7 +21,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 
 	interface Props {
 		/** Array of function identifiers */

--- a/src/lib/components/exercises/ImageAlignmentSelector.svelte
+++ b/src/lib/components/exercises/ImageAlignmentSelector.svelte
@@ -14,7 +14,7 @@
 -->
 <script lang="ts">
 	import { Label } from '$lib/components/ui/label';
-	import { AlignLeft, AlignCenter, AlignRight } from 'lucide-svelte';
+	import { AlignLeft, AlignCenter, AlignRight } from '@lucide/svelte';
 	import type { ImageAlignment } from '$lib/ubumark';
 
 	// Types

--- a/src/lib/components/exercises/ImageAttributePanel.svelte
+++ b/src/lib/components/exercises/ImageAttributePanel.svelte
@@ -22,7 +22,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Separator } from '$lib/components/ui/separator';
-	import { Copy, Check, Image as ImageIcon, Settings } from 'lucide-svelte';
+	import { Copy, Check, Image as ImageIcon, Settings } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { ImageSizeClass, ImageAlignment } from '$lib/ubumark';
 	import { autoDetectSizeClass } from '$lib/exercises/services/image-dimensions';

--- a/src/lib/components/exercises/ImageUploader.svelte
+++ b/src/lib/components/exercises/ImageUploader.svelte
@@ -17,7 +17,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Progress } from '$lib/components/ui/progress';
-	import { Upload, X, Image, Loader2, AlertCircle, CheckCircle } from 'lucide-svelte';
+	import { Upload, X, Image, Loader2, AlertCircle, CheckCircle } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Types

--- a/src/lib/components/game/minesweeper/AchievementsWidget.svelte
+++ b/src/lib/components/game/minesweeper/AchievementsWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Trophy } from 'lucide-svelte';
+	import { Trophy } from '@lucide/svelte';
 	import AchievementBadge from './AchievementBadge.svelte';
 
 	interface Achievement {

--- a/src/lib/components/game/minesweeper/DefeatModal.svelte
+++ b/src/lib/components/game/minesweeper/DefeatModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCcw } from 'lucide-svelte';
+	import { RotateCcw } from '@lucide/svelte';
 
 	interface Props {
 		onPlayAgain: () => void;

--- a/src/lib/components/game/minesweeper/TournamentDefeatModal.svelte
+++ b/src/lib/components/game/minesweeper/TournamentDefeatModal.svelte
@@ -28,7 +28,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCcw, ArrowLeft } from 'lucide-svelte';
+	import { RotateCcw, ArrowLeft } from '@lucide/svelte';
 	import type { Difficulty } from '$lib/types/minesweeper';
 	import { DIFFICULTY_LABELS } from '$lib/types/minesweeper';
 	import { formatDuration } from '$lib/utils/format';

--- a/src/lib/components/game/minesweeper/TournamentVictoryModal.svelte
+++ b/src/lib/components/game/minesweeper/TournamentVictoryModal.svelte
@@ -29,7 +29,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCcw, ArrowLeft, Trophy } from 'lucide-svelte';
+	import { RotateCcw, ArrowLeft, Trophy } from '@lucide/svelte';
 	import type { Difficulty } from '$lib/types/minesweeper';
 	import { DIFFICULTY_LABELS } from '$lib/types/minesweeper';
 	import { formatDuration } from '$lib/utils/format';

--- a/src/lib/components/game/minesweeper/UndoConfirmModal.svelte
+++ b/src/lib/components/game/minesweeper/UndoConfirmModal.svelte
@@ -20,7 +20,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Undo2, X, Clock } from 'lucide-svelte';
+	import { Undo2, X, Clock } from '@lucide/svelte';
 	import { onMount, onDestroy } from 'svelte';
 
 	interface Props {

--- a/src/lib/components/game/minesweeper/VictoryModal.svelte
+++ b/src/lib/components/game/minesweeper/VictoryModal.svelte
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCcw, Trophy } from 'lucide-svelte';
+	import { RotateCcw, Trophy } from '@lucide/svelte';
 	import type { Difficulty, RewardBreakdown } from '$lib/types/minesweeper';
 	import { DIFFICULTY_LABELS } from '$lib/types/minesweeper';
 	import { formatDuration } from '$lib/utils/format';

--- a/src/lib/components/google/ManageSharedCourseworkDialog.svelte
+++ b/src/lib/components/google/ManageSharedCourseworkDialog.svelte
@@ -26,7 +26,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Trash2 } from 'lucide-svelte';
+	import { Loader2, Trash2 } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/google/ManageSharedMaterialDialog.svelte
+++ b/src/lib/components/google/ManageSharedMaterialDialog.svelte
@@ -26,7 +26,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Trash2 } from 'lucide-svelte';
+	import { Loader2, Trash2 } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/google/ShareCourseworkBulkDialog.svelte
+++ b/src/lib/components/google/ShareCourseworkBulkDialog.svelte
@@ -33,7 +33,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, CheckCircle2, Users } from 'lucide-svelte';
+	import { Loader2, CheckCircle2, Users } from '@lucide/svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 
 	// ============================================================================

--- a/src/lib/components/google/ShareCourseworkDialog.svelte
+++ b/src/lib/components/google/ShareCourseworkDialog.svelte
@@ -27,7 +27,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/google/ShareMaterialDialog.svelte
+++ b/src/lib/components/google/ShareMaterialDialog.svelte
@@ -27,7 +27,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, BookOpen } from 'lucide-svelte';
+	import { Loader2, BookOpen } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/google/ShareMultipleCourseworkDialog.svelte
+++ b/src/lib/components/google/ShareMultipleCourseworkDialog.svelte
@@ -29,7 +29,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Search } from 'lucide-svelte';
+	import { Loader2, Search } from '@lucide/svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 
 	// ============================================================================

--- a/src/lib/components/google/ShareMultipleMaterialsDialog.svelte
+++ b/src/lib/components/google/ShareMultipleMaterialsDialog.svelte
@@ -29,7 +29,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, BookOpen } from 'lucide-svelte';
+	import { Loader2, BookOpen } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/google/UnshareTopicMaterialsDialog.svelte
+++ b/src/lib/components/google/UnshareTopicMaterialsDialog.svelte
@@ -26,7 +26,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, AlertTriangle } from 'lucide-svelte';
+	import { Loader2, AlertTriangle } from '@lucide/svelte';
 
 	// ============================================================================
 	// Types

--- a/src/lib/components/grapheur/ExportButton.svelte
+++ b/src/lib/components/grapheur/ExportButton.svelte
@@ -10,7 +10,7 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
-	import { Download, FileCode, Image } from 'lucide-svelte';
+	import { Download, FileCode, Image } from '@lucide/svelte';
 	import { exportSvg, exportPng } from '$lib/grapheur/export';
 	import { toaster } from '$lib/stores/toaster.svelte';
 

--- a/src/lib/components/grapheur/FunctionInput.svelte
+++ b/src/lib/components/grapheur/FunctionInput.svelte
@@ -27,7 +27,7 @@ Features:
 	import ColorPicker from './ColorPicker.svelte';
 	import LineWidthPicker from './LineWidthPicker.svelte';
 	import LineStylePicker from './LineStylePicker.svelte';
-	import { Eye, EyeOff, Trash2 } from 'lucide-svelte';
+	import { Eye, EyeOff, Trash2 } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 
 	let { func }: { func: ExplicitFunction } = $props();

--- a/src/lib/components/grapheur/FunctionPanel.svelte
+++ b/src/lib/components/grapheur/FunctionPanel.svelte
@@ -21,7 +21,7 @@ Features:
 	import { grapheurStore } from '$lib/stores/grapheur.svelte';
 	import FunctionInput from './FunctionInput.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Plus } from 'lucide-svelte';
+	import { Plus } from '@lucide/svelte';
 
 	/**
 	 * Add a new empty function

--- a/src/lib/components/grapheur/ViewportControls.svelte
+++ b/src/lib/components/grapheur/ViewportControls.svelte
@@ -14,7 +14,7 @@
 
 	import { grapheurStore } from '$lib/stores/grapheur.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ZoomIn, ZoomOut, Maximize2, Grid3x3 } from 'lucide-svelte';
+	import { ZoomIn, ZoomOut, Maximize2, Grid3x3 } from '@lucide/svelte';
 	import ExportButton from './ExportButton.svelte';
 
 	// Props

--- a/src/lib/components/journal/HomeworkCard.svelte
+++ b/src/lib/components/journal/HomeworkCard.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { ClipboardList, Calendar, Clock, AlertCircle } from 'lucide-svelte';
+	import { ClipboardList, Calendar, Clock, AlertCircle } from '@lucide/svelte';
 	import type { UpcomingHomework } from '$lib/types/journal';
 	import { GRADES, type GradeCode } from '$lib/types/grades';
 	import { cn } from '$lib/utils';

--- a/src/lib/components/journal/JournalDatePicker.svelte
+++ b/src/lib/components/journal/JournalDatePicker.svelte
@@ -19,7 +19,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { ChevronLeft, ChevronRight, Calendar } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Calendar } from '@lucide/svelte';
 
 	interface Props {
 		/** Start of the week (Monday) */

--- a/src/lib/components/journal/JournalEntryCard.svelte
+++ b/src/lib/components/journal/JournalEntryCard.svelte
@@ -21,7 +21,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { FileText, BookCheck, Globe, Calendar, ClipboardList } from 'lucide-svelte';
+	import { FileText, BookCheck, Globe, Calendar, ClipboardList } from '@lucide/svelte';
 	import type { ClassJournalEntry, JournalEntryWithClass } from '$lib/types/journal';
 	import { GRADES, type GradeCode } from '$lib/types/grades';
 	import { cn } from '$lib/utils';

--- a/src/lib/components/journal/JournalWeekGrid.svelte
+++ b/src/lib/components/journal/JournalWeekGrid.svelte
@@ -22,7 +22,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { FileText, BookCheck, Globe, Plus, Calendar } from 'lucide-svelte';
+	import { FileText, BookCheck, Globe, Plus, Calendar } from '@lucide/svelte';
 	import type { JournalWeekDay } from '$lib/types/journal';
 	import { cn } from '$lib/utils';
 

--- a/src/lib/components/markdown/MarkdownEditor.svelte
+++ b/src/lib/components/markdown/MarkdownEditor.svelte
@@ -43,7 +43,7 @@
 		LayoutGrid,
 		Upload,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import MarkdownRenderer from './MarkdownRenderer.svelte';
 	import type { ImageUploadConfig } from './types';
 	import type { Variable } from '$lib/ubumark';

--- a/src/lib/components/markdown/nodes/HintReference.svelte
+++ b/src/lib/components/markdown/nodes/HintReference.svelte
@@ -25,7 +25,7 @@
 	import * as Popover from '$lib/components/ui/popover';
 	import MarkdownRenderer from '../MarkdownRenderer.svelte';
 	import { cn } from '$lib/utils';
-	import { Lightbulb, AlertCircle, ExternalLink, FileText, Video } from 'lucide-svelte';
+	import { Lightbulb, AlertCircle, ExternalLink, FileText, Video } from '@lucide/svelte';
 
 	interface Props {
 		/** Hint ID to look up in hints array */

--- a/src/lib/components/markdown/nodes/InternalLink.svelte
+++ b/src/lib/components/markdown/nodes/InternalLink.svelte
@@ -23,7 +23,7 @@
 <script lang="ts">
 	import type { InternalLinkReferenceType } from '$lib/ubumark';
 	import { cn } from '$lib/utils';
-	import { BookOpen, FileText, PencilRuler, ClipboardCheck } from 'lucide-svelte';
+	import { BookOpen, FileText, PencilRuler, ClipboardCheck } from '@lucide/svelte';
 
 	interface Props {
 		/** Type of the internal resource */

--- a/src/lib/components/marketplace/CreateListingModal.svelte
+++ b/src/lib/components/marketplace/CreateListingModal.svelte
@@ -12,7 +12,7 @@
 	import TradeCardSelector from './trade/TradeCardSelector.svelte';
 	import VipCard from '$lib/components/VipCard.svelte';
 	import { RARITY_COLORS, RARITY_LABELS } from '$lib/constants/vip-card-ui';
-	import { Info, Check } from 'lucide-svelte';
+	import { Info, Check } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	// Props

--- a/src/lib/components/marketplace/CreateProposalModal.svelte
+++ b/src/lib/components/marketplace/CreateProposalModal.svelte
@@ -10,7 +10,7 @@
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import TradeCardSelector from './trade/TradeCardSelector.svelte';
 	import VipCard from '$lib/components/VipCard.svelte';
-	import { Info, ArrowRight } from 'lucide-svelte';
+	import { Info, ArrowRight } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { VipCard as VipCardType } from '$lib/types/vip-card';

--- a/src/lib/components/marketplace/MarketplaceListingCard.svelte
+++ b/src/lib/components/marketplace/MarketplaceListingCard.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { Clock, ArrowRight } from 'lucide-svelte';
+	import { Clock, ArrowRight } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';

--- a/src/lib/components/marketplace/MarketplaceListings.svelte
+++ b/src/lib/components/marketplace/MarketplaceListings.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import SkeletonList from '$lib/components/skeleton/SkeletonList.svelte';
-	import { RefreshCw, ShoppingBag } from 'lucide-svelte';
+	import { RefreshCw, ShoppingBag } from '@lucide/svelte';
 	import MarketplaceListingCard from './MarketplaceListingCard.svelte';
 	import ListingDetailsModal from './ListingDetailsModal.svelte';
 	import type { MarketplaceListing } from '$lib/types/marketplace';

--- a/src/lib/components/marketplace/MarketplaceSettings.svelte
+++ b/src/lib/components/marketplace/MarketplaceSettings.svelte
@@ -12,7 +12,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Settings, ShoppingBag, AlertCircle, Info, Check, X } from 'lucide-svelte';
+	import { Settings, ShoppingBag, AlertCircle, Info, Check, X } from '@lucide/svelte';
 	import { z } from 'zod';
 
 	interface MarketplaceConfig {

--- a/src/lib/components/marketplace/MyListings.svelte
+++ b/src/lib/components/marketplace/MyListings.svelte
@@ -15,7 +15,7 @@
 		Trash2,
 		CheckCircle,
 		AlertCircle
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import ProposalResponseModal from './ProposalResponseModal.svelte';

--- a/src/lib/components/marketplace/MyProposals.svelte
+++ b/src/lib/components/marketplace/MyProposals.svelte
@@ -3,7 +3,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Clock, CheckCircle, XCircle, Loader2 } from 'lucide-svelte';
+	import { Clock, CheckCircle, XCircle, Loader2 } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/lib/components/marketplace/MyTrades.svelte
+++ b/src/lib/components/marketplace/MyTrades.svelte
@@ -16,7 +16,7 @@
 		RefreshCw,
 		AlertCircle,
 		Plus
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import TradeNegotiationModal from './TradeNegotiationModal.svelte';

--- a/src/lib/components/marketplace/ProposalResponseModal.svelte
+++ b/src/lib/components/marketplace/ProposalResponseModal.svelte
@@ -6,7 +6,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import VipCard from '$lib/components/VipCard.svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
-	import { ArrowDown } from 'lucide-svelte';
+	import { ArrowDown } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/marketplace/StartFriendTradeModal.svelte
+++ b/src/lib/components/marketplace/StartFriendTradeModal.svelte
@@ -19,7 +19,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
 	import OnlineStatus from '$lib/components/OnlineStatus.svelte';
-	import { Search, ArrowLeftRight, UserPlus, Loader2 } from 'lucide-svelte';
+	import { Search, ArrowLeftRight, UserPlus, Loader2 } from '@lucide/svelte';
 	import type { SupabaseClient } from '@supabase/supabase-js';
 	import { presenceManager } from '$lib/stores/presence.svelte';
 	import { marketplaceStore } from '$lib/stores/marketplace.svelte';

--- a/src/lib/components/marketplace/StudentActivityFeed.svelte
+++ b/src/lib/components/marketplace/StudentActivityFeed.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Clock, CheckCircle, XCircle, Plus, Loader2, MessageSquare } from 'lucide-svelte';
+	import { Clock, CheckCircle, XCircle, Plus, Loader2, MessageSquare } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import { goto } from '$app/navigation';

--- a/src/lib/components/marketplace/TradeNegotiationModal.svelte
+++ b/src/lib/components/marketplace/TradeNegotiationModal.svelte
@@ -8,7 +8,7 @@
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import { Separator } from '$lib/components/ui/separator';
 	import VipCardSelector from './VipCardSelector.svelte';
-	import { ArrowLeftRight, CheckCircle, XCircle } from 'lucide-svelte';
+	import { ArrowLeftRight, CheckCircle, XCircle } from '@lucide/svelte';
 	import { page } from '$app/stores';
 	import { toaster } from '$lib/stores/toaster.svelte';
 

--- a/src/lib/components/marketplace/VipCardSelector.svelte
+++ b/src/lib/components/marketplace/VipCardSelector.svelte
@@ -3,7 +3,7 @@
 	import type { Database } from '$lib/types/database';
 	import type { VipCard as VipCardType } from '$lib/types/vip-card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Lock, Check } from 'lucide-svelte';
+	import { Lock, Check } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import VipCard from '$lib/components/VipCard.svelte';
 	import { RARITY_COLORS, RARITY_LABELS } from '$lib/constants/vip-card-ui';

--- a/src/lib/components/marketplace/teacher/ActivityFeed.svelte
+++ b/src/lib/components/marketplace/teacher/ActivityFeed.svelte
@@ -13,7 +13,7 @@
 		Clock,
 		TrendingUp,
 		RefreshCw
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	interface ActivityDetails {
 		title?: string;

--- a/src/lib/components/marketplace/teacher/ListingsMonitor.svelte
+++ b/src/lib/components/marketplace/teacher/ListingsMonitor.svelte
@@ -5,7 +5,7 @@
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Package, Coins, User, TrendingUp, TrendingDown } from 'lucide-svelte';
+	import { Package, Coins, User, TrendingUp, TrendingDown } from '@lucide/svelte';
 
 	interface Listing {
 		id: string;

--- a/src/lib/components/marketplace/teacher/MarketplaceAnalytics.svelte
+++ b/src/lib/components/marketplace/teacher/MarketplaceAnalytics.svelte
@@ -10,7 +10,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Progress } from '$lib/components/ui/progress';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { TrendingUp, BarChart3, Award, Coins } from 'lucide-svelte';
+	import { TrendingUp, BarChart3, Award, Coins } from '@lucide/svelte';
 
 	interface Analytics {
 		engagement: {

--- a/src/lib/components/marketplace/teacher/MarketplaceStats.svelte
+++ b/src/lib/components/marketplace/teacher/MarketplaceStats.svelte
@@ -2,7 +2,7 @@
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Progress } from '$lib/components/ui/progress';
-	import { TrendingUp, Package, Coins, CheckCircle, XCircle, Clock, Trophy } from 'lucide-svelte';
+	import { TrendingUp, Package, Coins, CheckCircle, XCircle, Clock, Trophy } from '@lucide/svelte';
 
 	interface Stats {
 		period: string;

--- a/src/lib/components/marketplace/teacher/TradeHistoryTable.svelte
+++ b/src/lib/components/marketplace/teacher/TradeHistoryTable.svelte
@@ -13,7 +13,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ChevronLeft, ChevronRight, Package, Coins, Calendar } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Package, Coins, Calendar } from '@lucide/svelte';
 
 	interface Trade {
 		id: string;

--- a/src/lib/components/marketplace/trade/IdleWarningModal.svelte
+++ b/src/lib/components/marketplace/trade/IdleWarningModal.svelte
@@ -6,7 +6,7 @@
 -->
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { Clock, LogOut } from 'lucide-svelte';
+	import { Clock, LogOut } from '@lucide/svelte';
 
 	interface Props {
 		onContinue: () => void;

--- a/src/lib/components/marketplace/trade/TradeChatDrawer.svelte
+++ b/src/lib/components/marketplace/trade/TradeChatDrawer.svelte
@@ -20,7 +20,7 @@
 <script lang="ts">
 	import * as Sheet from '$lib/components/ui/sheet';
 	import { Button } from '$lib/components/ui/button';
-	import { MessageCircle, Send } from 'lucide-svelte';
+	import { MessageCircle, Send } from '@lucide/svelte';
 	import type { TradeChatMessage } from '$lib/stores/tradeRealtime.svelte';
 
 	interface Props {

--- a/src/lib/components/marketplace/trade/TradeConfirmationModal.svelte
+++ b/src/lib/components/marketplace/trade/TradeConfirmationModal.svelte
@@ -28,7 +28,7 @@
 		getTemplateById,
 		templateToVipCard
 	} from '$lib/stores/vipCardTemplates.svelte';
-	import { Check, X, Clock, ArrowRightLeft, Loader2 } from 'lucide-svelte';
+	import { Check, X, Clock, ArrowRightLeft, Loader2 } from '@lucide/svelte';
 	import type { VipCardInstance, VipCard as VipCardType } from '$lib/types/vip-card';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';
 

--- a/src/lib/components/marketplace/trade/TradeOfferPanel.svelte
+++ b/src/lib/components/marketplace/trade/TradeOfferPanel.svelte
@@ -24,7 +24,7 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
-	import { Check } from 'lucide-svelte';
+	import { Check } from '@lucide/svelte';
 	import TradeCardSelector from './TradeCardSelector.svelte';
 	import type { VipCardInstance } from '$lib/types/vip-card';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';

--- a/src/lib/components/migration/MigrationQuestionEditForm.svelte
+++ b/src/lib/components/migration/MigrationQuestionEditForm.svelte
@@ -44,7 +44,7 @@
 		Edit3,
 		AlertCircle,
 		CheckCircle2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	// ============================================================================

--- a/src/lib/components/migration/MigrationTree.svelte
+++ b/src/lib/components/migration/MigrationTree.svelte
@@ -18,7 +18,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { cn } from '$lib/utils';
 	import CategoryProgress from './CategoryProgress.svelte';
-	import { ChevronRight, Folder, FolderOpen, BookOpen, FileText, Layers } from 'lucide-svelte';
+	import { ChevronRight, Folder, FolderOpen, BookOpen, FileText, Layers } from '@lucide/svelte';
 
 	// Import types from shared type definitions
 	import type { TreeNode } from '$lib/types/migration';

--- a/src/lib/components/migration/QuestionCard.svelte
+++ b/src/lib/components/migration/QuestionCard.svelte
@@ -17,7 +17,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import { cn } from '$lib/utils';
-	import { AlertCircle, AlertTriangle, CheckCircle2, ChevronRight, XCircle } from 'lucide-svelte';
+	import { AlertCircle, AlertTriangle, CheckCircle2, ChevronRight, XCircle } from '@lucide/svelte';
 
 	type ReviewStatus = 'pending' | 'approved' | 'rejected';
 

--- a/src/lib/components/migration/QuestionCompareView.svelte
+++ b/src/lib/components/migration/QuestionCompareView.svelte
@@ -28,7 +28,7 @@
 		Code2,
 		Copy,
 		Check
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import FlashCard from '$lib/components/questions/FlashCard.svelte';
 	import { generateInstance } from '$lib/questions/generator/instance-generator';

--- a/src/lib/components/migration/ReviewActions.svelte
+++ b/src/lib/components/migration/ReviewActions.svelte
@@ -17,7 +17,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
-	import { CheckCircle2, XCircle } from 'lucide-svelte';
+	import { CheckCircle2, XCircle } from '@lucide/svelte';
 
 	interface Props {
 		onApprove?: () => void;

--- a/src/lib/components/migration/TestSpecBatchRunner.svelte
+++ b/src/lib/components/migration/TestSpecBatchRunner.svelte
@@ -16,7 +16,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Check, X, Play, ChevronDown } from 'lucide-svelte';
+	import { Check, X, Play, ChevronDown } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/minesweeper/multiplayer/MultiplayerLobby.svelte
+++ b/src/lib/components/minesweeper/multiplayer/MultiplayerLobby.svelte
@@ -6,7 +6,7 @@
 	import { multiplayerStore } from '$lib/stores/multiplayer.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { cn } from '$lib/utils';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 
 	// Types
 	type Difficulty = 'beginner' | 'intermediate' | 'expert';

--- a/src/lib/components/modals/ExampleModal.svelte
+++ b/src/lib/components/modals/ExampleModal.svelte
@@ -29,7 +29,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 
 	interface Props {
 		title: string;

--- a/src/lib/components/moderation/ActiveRestrictionsTable.svelte
+++ b/src/lib/components/moderation/ActiveRestrictionsTable.svelte
@@ -22,7 +22,7 @@
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { Trash2 } from 'lucide-svelte';
+	import { Trash2 } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import { toaster } from '$lib/stores/toaster.svelte';

--- a/src/lib/components/moderation/DeleteMessageDialog.svelte
+++ b/src/lib/components/moderation/DeleteMessageDialog.svelte
@@ -22,7 +22,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Component Props

--- a/src/lib/components/moderation/MessageReportsTable.svelte
+++ b/src/lib/components/moderation/MessageReportsTable.svelte
@@ -21,7 +21,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { ChevronLeft, ChevronRight, Eye } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Eye } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import ReviewReportDialog, {

--- a/src/lib/components/moderation/ModerationLogsTable.svelte
+++ b/src/lib/components/moderation/ModerationLogsTable.svelte
@@ -19,7 +19,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/lib/components/moderation/RestrictUserDialog.svelte
+++ b/src/lib/components/moderation/RestrictUserDialog.svelte
@@ -34,7 +34,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { Ban, Clock, AlertTriangle, Loader2, UserX } from 'lucide-svelte';
+	import { Ban, Clock, AlertTriangle, Loader2, UserX } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Student type for selection mode

--- a/src/lib/components/moderation/RestrictedUserBanner.svelte
+++ b/src/lib/components/moderation/RestrictedUserBanner.svelte
@@ -14,7 +14,7 @@
 -->
 <script lang="ts">
 	import * as Alert from '$lib/components/ui/alert';
-	import { Ban, Clock, AlertTriangle } from 'lucide-svelte';
+	import { Ban, Clock, AlertTriangle } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/lib/components/moderation/ReviewReportDialog.svelte
+++ b/src/lib/components/moderation/ReviewReportDialog.svelte
@@ -27,7 +27,7 @@
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import RestrictUserDialog from './RestrictUserDialog.svelte';
-	import { CheckCircle, XCircle, AlertTriangle, Loader2, Trash2, UserX } from 'lucide-svelte';
+	import { CheckCircle, XCircle, AlertTriangle, Loader2, Trash2, UserX } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { formatDistanceToNow, format } from 'date-fns';
 	import { fr } from 'date-fns/locale';

--- a/src/lib/components/navigation/MobileNavDrawer.svelte
+++ b/src/lib/components/navigation/MobileNavDrawer.svelte
@@ -4,8 +4,8 @@
 	import * as Sheet from '$lib/components/ui/sheet';
 	import { theme } from '$lib/stores/theme.svelte';
 	import { fontSize } from '$lib/stores/fontSize.svelte';
-	import { Sun, Moon, Minus, Plus } from 'lucide-svelte';
-	import type { ComponentType } from 'svelte';
+	import { Sun, Moon, Minus, Plus } from '@lucide/svelte';
+	import type { LucideIcon } from '@lucide/svelte';
 
 	/**
 	 * Navigation item type for MobileNavDrawer
@@ -13,7 +13,7 @@
 	export type NavItem = {
 		label: string;
 		href: string;
-		icon: ComponentType;
+		icon: LucideIcon;
 		roles?: string[];
 		badge?: number;
 		/** Footer items render after a separator at the bottom of the drawer. */

--- a/src/lib/components/notebook/CellGutter.svelte
+++ b/src/lib/components/notebook/CellGutter.svelte
@@ -8,7 +8,7 @@
 
 	import type { CellExecutionState, CellType } from '$lib/types/notebook';
 	import { Button } from '$lib/components/ui/button';
-	import { Play, Square } from 'lucide-svelte';
+	import { Play, Square } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/notebook/CellOutputs.svelte
+++ b/src/lib/components/notebook/CellOutputs.svelte
@@ -10,7 +10,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import type { CellOutput } from '$lib/types/notebook';
 	import { Button } from '$lib/components/ui/button';
-	import { ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { foldOutput } from '$lib/utils/output-fold';
 	import 'mathlive';
 

--- a/src/lib/components/notebook/CheckpointCell.svelte
+++ b/src/lib/components/notebook/CheckpointCell.svelte
@@ -16,7 +16,14 @@
 	import type { CheckpointCell } from '$lib/types/notebook';
 	import type { NotebookStore } from '$lib/stores/notebookStore.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2, CheckCircle2, XCircle, CircleDashed, Sparkles, Lightbulb } from 'lucide-svelte';
+	import {
+		Loader2,
+		CheckCircle2,
+		XCircle,
+		CircleDashed,
+		Sparkles,
+		Lightbulb
+	} from '@lucide/svelte';
 
 	/**
 	 * Number of failed Vérifier clicks before the teacher's hint is

--- a/src/lib/components/notebook/CheckpointEditor.svelte
+++ b/src/lib/components/notebook/CheckpointEditor.svelte
@@ -23,7 +23,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Button } from '$lib/components/ui/button';
-	import { Plus, Trash2, AlertCircle } from 'lucide-svelte';
+	import { Plus, Trash2, AlertCircle } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/notebook/KeyboardShortcutsHelp.svelte
+++ b/src/lib/components/notebook/KeyboardShortcutsHelp.svelte
@@ -10,7 +10,7 @@
 	 */
 
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { HelpCircle } from 'lucide-svelte';
+	import { HelpCircle } from '@lucide/svelte';
 
 	// Props
 	let { isReadonly = false }: { isReadonly?: boolean } = $props();

--- a/src/lib/components/notebook/NotebookCell.svelte
+++ b/src/lib/components/notebook/NotebookCell.svelte
@@ -18,7 +18,7 @@
 	import CheckpointCell from './CheckpointCell.svelte';
 	import CheckpointEditor from './CheckpointEditor.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Trash2, GripVertical } from 'lucide-svelte';
+	import { Trash2, GripVertical } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/notebook/NotebookOutline.svelte
+++ b/src/lib/components/notebook/NotebookOutline.svelte
@@ -14,7 +14,7 @@
 	import type { NotebookCell } from '$lib/types/notebook';
 	import { extractOutline } from '$lib/utils/notebook-outline';
 	import { Button } from '$lib/components/ui/button';
-	import { ListTree, X } from 'lucide-svelte';
+	import { ListTree, X } from '@lucide/svelte';
 
 	let {
 		cells,

--- a/src/lib/components/notebook/NotebookPdfDialog.svelte
+++ b/src/lib/components/notebook/NotebookPdfDialog.svelte
@@ -19,7 +19,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
-	import { FileDown, Loader2 } from 'lucide-svelte';
+	import { FileDown, Loader2 } from '@lucide/svelte';
 	import type { NotebookExportOptions } from '$lib/typst/generators/notebook-generator';
 
 	interface Props {

--- a/src/lib/components/notebook/NotebookStatusBar.svelte
+++ b/src/lib/components/notebook/NotebookStatusBar.svelte
@@ -13,7 +13,7 @@
 	 */
 
 	import type { NotebookStore } from '$lib/stores/notebookStore.svelte';
-	import { Circle, CheckCircle2, AlertCircle, Loader2 } from 'lucide-svelte';
+	import { Circle, CheckCircle2, AlertCircle, Loader2 } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/notebook/NotebookToolbar.svelte
+++ b/src/lib/components/notebook/NotebookToolbar.svelte
@@ -29,7 +29,7 @@
 		FileDown,
 		Presentation,
 		BookmarkPlus
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 	import KeyboardShortcutsHelp from './KeyboardShortcutsHelp.svelte';
 	import NotebookPdfDialog from './NotebookPdfDialog.svelte';

--- a/src/lib/components/notebook/NotebookView.svelte
+++ b/src/lib/components/notebook/NotebookView.svelte
@@ -21,7 +21,7 @@
 	import NotebookCell from './NotebookCell.svelte';
 	import NotebookOutline from './NotebookOutline.svelte';
 	import { Alert } from '$lib/components/ui/alert';
-	import { Eye } from 'lucide-svelte';
+	import { Eye } from '@lucide/svelte';
 
 	const FLIP_MS = 200;
 

--- a/src/lib/components/notebook/ShareNotebookDialog.svelte
+++ b/src/lib/components/notebook/ShareNotebookDialog.svelte
@@ -24,7 +24,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Share2, Users, Lock, Unlock } from 'lucide-svelte';
+	import { Share2, Users, Lock, Unlock } from '@lucide/svelte';
 	import type { ClassWithData } from '$lib/server/students';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
 	import { SvelteSet } from 'svelte/reactivity';

--- a/src/lib/components/notebook/presentation/NotebookCodeSlide.svelte
+++ b/src/lib/components/notebook/presentation/NotebookCodeSlide.svelte
@@ -18,7 +18,7 @@
 	import PythonEditor from '$lib/components/python/PythonEditor.svelte';
 	import CellOutputs from '$lib/components/notebook/CellOutputs.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Play, Loader2, Square } from 'lucide-svelte';
+	import { Play, Loader2, Square } from '@lucide/svelte';
 
 	interface Props {
 		cell: NotebookCell;

--- a/src/lib/components/notebook/templates/SaveAsTemplateDialog.svelte
+++ b/src/lib/components/notebook/templates/SaveAsTemplateDialog.svelte
@@ -16,7 +16,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Sparkles, Loader2 } from 'lucide-svelte';
+	import { Sparkles, Loader2 } from '@lucide/svelte';
 
 	interface Props {
 		open: boolean;

--- a/src/lib/components/notebook/templates/TemplateCard.svelte
+++ b/src/lib/components/notebook/templates/TemplateCard.svelte
@@ -17,7 +17,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Copy, Loader2, Globe } from 'lucide-svelte';
+	import { Copy, Loader2, Globe } from '@lucide/svelte';
 
 	interface Author {
 		firstname: string | null;

--- a/src/lib/components/notebook/templates/TemplateGallery.svelte
+++ b/src/lib/components/notebook/templates/TemplateGallery.svelte
@@ -12,7 +12,7 @@
 -->
 <script lang="ts">
 	import TemplateCard from './TemplateCard.svelte';
-	import { Sparkles } from 'lucide-svelte';
+	import { Sparkles } from '@lucide/svelte';
 
 	interface Author {
 		firstname: string | null;

--- a/src/lib/components/notifications/NotificationBanner.svelte
+++ b/src/lib/components/notifications/NotificationBanner.svelte
@@ -8,7 +8,7 @@
 		type NotificationWithDetails
 	} from '$lib/types/notification';
 	import { Button } from '$lib/components/ui/button';
-	import { X, ChevronLeft, ChevronRight } from 'lucide-svelte';
+	import { X, ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 
 	// Show max 5 notifications in carousel

--- a/src/lib/components/notifications/NotificationDropdown.svelte
+++ b/src/lib/components/notifications/NotificationDropdown.svelte
@@ -9,7 +9,7 @@
 	} from '$lib/types/notification';
 	import { Button } from '$lib/components/ui/button';
 	import * as Popover from '$lib/components/ui/popover';
-	import { Bell } from 'lucide-svelte';
+	import { Bell } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 
 	// Get top 5 notifications for dropdown

--- a/src/lib/components/python/PythonFileManager.svelte
+++ b/src/lib/components/python/PythonFileManager.svelte
@@ -21,7 +21,7 @@
 		Clock,
 		BookOpen,
 		Library
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { pythonStore, type PythonFile } from '$lib/stores/pythonPlayground.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import LibraryBrowser from './library/LibraryBrowser.svelte';

--- a/src/lib/components/python/PythonMigrationPrompt.svelte
+++ b/src/lib/components/python/PythonMigrationPrompt.svelte
@@ -8,7 +8,7 @@
 
 	// Imports
 	import { Button } from '$lib/components/ui/button';
-	import { Cloud, X } from 'lucide-svelte';
+	import { Cloud, X } from '@lucide/svelte';
 	import { pythonStore } from '$lib/stores/pythonPlayground.svelte';
 	import { browser } from '$app/environment';
 

--- a/src/lib/components/python/PythonOutput.svelte
+++ b/src/lib/components/python/PythonOutput.svelte
@@ -12,7 +12,7 @@
 
 	// Imports
 	import { Button } from '$lib/components/ui/button';
-	import { Download } from 'lucide-svelte';
+	import { Download } from '@lucide/svelte';
 	import { browser } from '$app/environment';
 	import 'mathlive';
 

--- a/src/lib/components/python/PythonSaveDialog.svelte
+++ b/src/lib/components/python/PythonSaveDialog.svelte
@@ -13,7 +13,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Label } from '$lib/components/ui/label';
 	import { Switch } from '$lib/components/ui/switch';
-	import { Loader2, Save } from 'lucide-svelte';
+	import { Loader2, Save } from '@lucide/svelte';
 	import { pythonStore } from '$lib/stores/pythonPlayground.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 

--- a/src/lib/components/python/PythonSettings.svelte
+++ b/src/lib/components/python/PythonSettings.svelte
@@ -14,7 +14,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Switch } from '$lib/components/ui/switch';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { Settings, Minus, Plus, Palette, Type, GraduationCap } from 'lucide-svelte';
+	import { Settings, Minus, Plus, Palette, Type, GraduationCap } from '@lucide/svelte';
 	import {
 		pythonStore,
 		EDITOR_THEMES,

--- a/src/lib/components/python/PythonToolbar.svelte
+++ b/src/lib/components/python/PythonToolbar.svelte
@@ -20,7 +20,7 @@
 		FilePlus,
 		FileCode,
 		Settings
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Props

--- a/src/lib/components/python/exercises/ASTRequirementsPanel.svelte
+++ b/src/lib/components/python/exercises/ASTRequirementsPanel.svelte
@@ -17,7 +17,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
 
 	type Props = {
 		requirements: ASTRequirement[];

--- a/src/lib/components/python/exercises/ExerciseForm.svelte
+++ b/src/lib/components/python/exercises/ExerciseForm.svelte
@@ -45,7 +45,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import TagBadgeSelector from '$lib/components/TagBadgeSelector.svelte';
 	import { PlaygroundExecutor, type ExerciseValidationResult as Result } from '$lib/shared/python';
-	import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-svelte';
+	import { CheckCircle2, AlertTriangle, Loader2 } from '@lucide/svelte';
 
 	type Props = {
 		initialForm: FormState;

--- a/src/lib/components/python/exercises/ExerciseStrategyEditor.svelte
+++ b/src/lib/components/python/exercises/ExerciseStrategyEditor.svelte
@@ -13,7 +13,7 @@
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
 	import ASTRequirementsPanel from './ASTRequirementsPanel.svelte';
 
 	type Props = {

--- a/src/lib/components/python/exercises/ExerciseValidationResult.svelte
+++ b/src/lib/components/python/exercises/ExerciseValidationResult.svelte
@@ -15,7 +15,7 @@
 	 */
 
 	import type { ExerciseValidationResult } from '$lib/shared/python';
-	import { CheckCircle2, XCircle, AlertTriangle, Loader2, Lock } from 'lucide-svelte';
+	import { CheckCircle2, XCircle, AlertTriangle, Loader2, Lock } from '@lucide/svelte';
 
 	type Props = {
 		/** Validation result, or null when no validation has run yet */

--- a/src/lib/components/python/library/LibraryBrowser.svelte
+++ b/src/lib/components/python/library/LibraryBrowser.svelte
@@ -2,7 +2,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { BookOpen, Search, X, Tag } from 'lucide-svelte';
+	import { BookOpen, Search, X, Tag } from '@lucide/svelte';
 	import { PYTHON_EXAMPLES } from '$lib/data/python-examples';
 	import { filterExamples, getAllTagsFromExamples } from '$lib/data/python-examples/utils';
 	import type { ExampleTag, PythonExample } from '$lib/data/python-examples/types';

--- a/src/lib/components/question-inputs/MultipleChoiceInput.svelte
+++ b/src/lib/components/question-inputs/MultipleChoiceInput.svelte
@@ -17,7 +17,7 @@
 <script lang="ts">
 	import type { ResolvedMarkdown } from '$lib/ubumark';
 	import { MarkdownRenderer } from '$lib/components/markdown';
-	import { Check, X } from 'lucide-svelte';
+	import { Check, X } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	interface Choice {

--- a/src/lib/components/question-inputs/OrderingInput.svelte
+++ b/src/lib/components/question-inputs/OrderingInput.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { convertLegacyLatexToMarkdown } from '$lib/utils/latex-syntax-adapter';
-	import { GripVertical, Check, X } from 'lucide-svelte';
+	import { GripVertical, Check, X } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	interface OrderingItem {

--- a/src/lib/components/questions/CorrectionCard.svelte
+++ b/src/lib/components/questions/CorrectionCard.svelte
@@ -27,7 +27,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCw, Check, X, ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { RotateCw, Check, X, ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import GeneratedStepsCorrection from './GeneratedStepsCorrection.svelte';
 

--- a/src/lib/components/questions/FlashCard.svelte
+++ b/src/lib/components/questions/FlashCard.svelte
@@ -22,7 +22,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { RotateCw, Check, X, AlertCircle } from 'lucide-svelte';
+	import { RotateCw, Check, X, AlertCircle } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import FlipCard from '$lib/components/FlipCard.svelte';
 	import { createLogger } from '$lib/utils/logger';

--- a/src/lib/components/questions/QuestionPreviewBaseCard.svelte
+++ b/src/lib/components/questions/QuestionPreviewBaseCard.svelte
@@ -47,7 +47,7 @@
 		List,
 		Info,
 		FileText
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	// ============================================================================

--- a/src/lib/components/questions/TestSpecEditor.svelte
+++ b/src/lib/components/questions/TestSpecEditor.svelte
@@ -31,7 +31,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MathField from '$lib/components/MathField.svelte';
-	import { Plus, Trash2, Play, Check, X, Copy, Loader2 } from 'lucide-svelte';
+	import { Plus, Trash2, Play, Check, X, Copy, Loader2 } from '@lucide/svelte';
 
 	interface Props {
 		testSpecs: TestSpec[];

--- a/src/lib/components/rewards/RemoveWarningsModal.svelte
+++ b/src/lib/components/rewards/RemoveWarningsModal.svelte
@@ -26,7 +26,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { cn } from '$lib/utils';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import { WARNING_TYPE_LABELS } from '$lib/types/warnings';
 
 	interface Props {

--- a/src/lib/components/rewards/RewardEventCard.svelte
+++ b/src/lib/components/rewards/RewardEventCard.svelte
@@ -11,7 +11,7 @@
 	import { cn } from '$lib/utils';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
-	import { Star, Trophy, Package } from 'lucide-svelte';
+	import { Star, Trophy, Package } from '@lucide/svelte';
 	import { format } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';

--- a/src/lib/components/rewards/RewardJournalFilters.svelte
+++ b/src/lib/components/rewards/RewardJournalFilters.svelte
@@ -11,7 +11,7 @@
 	import type { RewardType } from '$lib/types/reward-journal';
 	import { cn } from '$lib/utils';
 	import { Button } from '$lib/components/ui/button';
-	import { Coins, Star, Crown, Trophy, Package, AlertTriangle, X } from 'lucide-svelte';
+	import { Coins, Star, Crown, Trophy, Package, AlertTriangle, X } from '@lucide/svelte';
 
 	// Props
 	let {

--- a/src/lib/components/rewards/StudentJournalModal.svelte
+++ b/src/lib/components/rewards/StudentJournalModal.svelte
@@ -20,7 +20,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Card from '$lib/components/ui/card';
-	import { X, RefreshCw, ChevronDown, Inbox } from 'lucide-svelte';
+	import { X, RefreshCw, ChevronDown, Inbox } from '@lucide/svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import type { RewardType } from '$lib/types/reward-journal';
 	import type { Snippet } from 'svelte';

--- a/src/lib/components/rewards/VipCardChooseModal.svelte
+++ b/src/lib/components/rewards/VipCardChooseModal.svelte
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import VipCard from '$lib/components/VipCard.svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';

--- a/src/lib/components/rewards/VipCardExchangeModal.svelte
+++ b/src/lib/components/rewards/VipCardExchangeModal.svelte
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import VipCard from '$lib/components/VipCard.svelte';
 	import { modalStack } from '$lib/stores/modalStack.svelte';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';

--- a/src/lib/components/rich-text/ImageGalleryModal.svelte
+++ b/src/lib/components/rich-text/ImageGalleryModal.svelte
@@ -18,7 +18,7 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Upload, ImageIcon, Loader2 } from 'lucide-svelte';
+	import { Upload, ImageIcon, Loader2 } from '@lucide/svelte';
 	import type { GalleryImageInfo } from './types';
 
 	interface Props {

--- a/src/lib/components/rich-text/RichTextEditor.svelte
+++ b/src/lib/components/rich-text/RichTextEditor.svelte
@@ -68,7 +68,7 @@
 		TrendingUp,
 		Table2,
 		Grid3x3
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import ImageAttributePanel from '$lib/components/exercises/ImageAttributePanel.svelte';
 	import ImageGalleryModal from './ImageGalleryModal.svelte';

--- a/src/lib/components/riddles/AnswerConfigEditor.svelte
+++ b/src/lib/components/riddles/AnswerConfigEditor.svelte
@@ -16,7 +16,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Switch } from '$lib/components/ui/switch';
-	import { Plus, X, CheckCircle2 } from 'lucide-svelte';
+	import { Plus, X, CheckCircle2 } from '@lucide/svelte';
 
 	interface Props {
 		config: AnswerConfig | null;

--- a/src/lib/components/riddles/RiddleCard.svelte
+++ b/src/lib/components/riddles/RiddleCard.svelte
@@ -41,7 +41,7 @@
 	import RiddleManualInput from '$lib/components/riddles/inputs/RiddleManualInput.svelte';
 	import { cn } from '$lib/utils';
 	import { MarkdownRenderer } from '$lib/components/markdown';
-	import { Send, CheckCircle2, XCircle, Clock } from 'lucide-svelte';
+	import { Send, CheckCircle2, XCircle, Clock } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/riddles/RiddleForm.svelte
+++ b/src/lib/components/riddles/RiddleForm.svelte
@@ -33,7 +33,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import RichTextEditor from '$lib/components/rich-text/RichTextEditor.svelte';
 	import AnswerConfigEditor from '$lib/components/riddles/AnswerConfigEditor.svelte';
-	import { Lightbulb, Image as ImageIcon, Save, X } from 'lucide-svelte';
+	import { Lightbulb, Image as ImageIcon, Save, X } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/riddles/RiddleNav.svelte
+++ b/src/lib/components/riddles/RiddleNav.svelte
@@ -16,7 +16,7 @@
 		BarChart3,
 		Calendar,
 		Plus
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { page } from '$app/stores';
 
 	interface Props {

--- a/src/lib/components/riddles/RiddleOfTheDayCard.svelte
+++ b/src/lib/components/riddles/RiddleOfTheDayCard.svelte
@@ -10,7 +10,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
-	import { Sparkles, Trophy, Calendar, ArrowRight, History } from 'lucide-svelte';
+	import { Sparkles, Trophy, Calendar, ArrowRight, History } from '@lucide/svelte';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { format } from 'date-fns';
 	import { fr } from 'date-fns/locale';

--- a/src/lib/components/riddles/inputs/RiddleManualInput.svelte
+++ b/src/lib/components/riddles/inputs/RiddleManualInput.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Label } from '$lib/components/ui/label';
-	import { Info } from 'lucide-svelte';
+	import { Info } from '@lucide/svelte';
 
 	interface Props {
 		value: string;

--- a/src/lib/components/riddles/inputs/RiddleMathInput.svelte
+++ b/src/lib/components/riddles/inputs/RiddleMathInput.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { Info } from 'lucide-svelte';
+	import { Info } from '@lucide/svelte';
 
 	interface Props {
 		value: string;

--- a/src/lib/components/spreadsheet/SpreadsheetImportExport.svelte
+++ b/src/lib/components/spreadsheet/SpreadsheetImportExport.svelte
@@ -26,7 +26,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
-	import { Download, Upload, FileSpreadsheet } from 'lucide-svelte';
+	import { Download, Upload, FileSpreadsheet } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';

--- a/src/lib/components/spreadsheet/SpreadsheetToolbar.svelte
+++ b/src/lib/components/spreadsheet/SpreadsheetToolbar.svelte
@@ -32,7 +32,7 @@
 		Hash,
 		Trash2,
 		Eraser
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { TextAlignment, NumberFormat } from '$lib/spreadsheet/types';
 
 	// =============================================================================

--- a/src/lib/components/srs/CapacityFsrsBadge.svelte
+++ b/src/lib/components/srs/CapacityFsrsBadge.svelte
@@ -8,7 +8,7 @@
 	Cf. docs/ref/srs/architecture.md §5.1.
 -->
 <script lang="ts">
-	import { AlertCircle, RefreshCw, Clock, CheckCircle, Circle } from 'lucide-svelte';
+	import { AlertCircle, RefreshCw, Clock, CheckCircle, Circle } from '@lucide/svelte';
 	import type { CapacityBadge } from '$lib/server/srs/capacity-badge';
 
 	interface Props {

--- a/src/lib/components/srs/CustomCardEditor.svelte
+++ b/src/lib/components/srs/CustomCardEditor.svelte
@@ -22,7 +22,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
-	import { Eye, Save, X } from 'lucide-svelte';
+	import { Eye, Save, X } from '@lucide/svelte';
 	import type { TemplateMarkdown } from '$lib/ubumark';
 	import { templateMarkdown } from '$lib/ubumark';
 

--- a/src/lib/components/srs/CustomFlashCard.svelte
+++ b/src/lib/components/srs/CustomFlashCard.svelte
@@ -20,7 +20,7 @@
 <script lang="ts">
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import * as Card from '$lib/components/ui/card';
-	import { RotateCw } from 'lucide-svelte';
+	import { RotateCw } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import type { TemplateMarkdown } from '$lib/ubumark';
 

--- a/src/lib/components/srs/DeckCard.svelte
+++ b/src/lib/components/srs/DeckCard.svelte
@@ -20,7 +20,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { BookOpen, Clock, Sparkles, Lock } from 'lucide-svelte';
+	import { BookOpen, Clock, Sparkles, Lock } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import type { Deck } from '$lib/srs/types';
 

--- a/src/lib/components/srs/ReviewSession.svelte
+++ b/src/lib/components/srs/ReviewSession.svelte
@@ -25,7 +25,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
-	import { CheckCircle2, Trophy, ArrowLeft } from 'lucide-svelte';
+	import { CheckCircle2, Trophy, ArrowLeft } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { ReviewCard } from '$lib/srs/types';
 

--- a/src/lib/components/srs/TemplateSelector.svelte
+++ b/src/lib/components/srs/TemplateSelector.svelte
@@ -22,7 +22,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Badge } from '$lib/components/ui/badge';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Search, Check, X } from 'lucide-svelte';
+	import { Search, Check, X } from '@lucide/svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
 	interface Props {

--- a/src/lib/components/student-inbox/InboxWidget.svelte
+++ b/src/lib/components/student-inbox/InboxWidget.svelte
@@ -12,7 +12,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { ListTodo, Inbox } from 'lucide-svelte';
+	import { ListTodo, Inbox } from '@lucide/svelte';
 	import WorkItemCard from './WorkItemCard.svelte';
 	import { resolve } from '$app/paths';
 	import type { StudentWorkInbox } from '$lib/types/student-inbox';

--- a/src/lib/components/student-inbox/WorkInboxSection.svelte
+++ b/src/lib/components/student-inbox/WorkInboxSection.svelte
@@ -18,7 +18,7 @@
 <script lang="ts">
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import WorkItemCard from './WorkItemCard.svelte';
-	import { ChevronDown, AlertTriangle } from 'lucide-svelte';
+	import { ChevronDown, AlertTriangle } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import type { WorkItem } from '$lib/types/student-inbox';
 

--- a/src/lib/components/student-inbox/WorkItemCard.svelte
+++ b/src/lib/components/student-inbox/WorkItemCard.svelte
@@ -30,7 +30,7 @@
 		GraduationCap,
 		Clock,
 		NotebookPen
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { resolve } from '$app/paths';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';

--- a/src/lib/components/student/worksheets/ExerciseDisplay.svelte
+++ b/src/lib/components/student/worksheets/ExerciseDisplay.svelte
@@ -13,7 +13,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { CheckCircle, ChevronDown, ChevronUp, Info } from 'lucide-svelte';
+	import { CheckCircle, ChevronDown, ChevronUp, Info } from '@lucide/svelte';
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import type { StudentExerciseView } from '$lib/types/worksheets';
 

--- a/src/lib/components/student/worksheets/ExerciseListItem.svelte
+++ b/src/lib/components/student/worksheets/ExerciseListItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
-	import { CheckCircle, AlertCircle, BookOpen, Star } from 'lucide-svelte';
+	import { CheckCircle, AlertCircle, BookOpen, Star } from '@lucide/svelte';
 	import type { StudentExerciseView } from '$lib/types/worksheets';
 	import type { MasteryStatus } from '$lib/types/exercise-mastery';
 

--- a/src/lib/components/student/worksheets/ExerciseModal.svelte
+++ b/src/lib/components/student/worksheets/ExerciseModal.svelte
@@ -14,7 +14,7 @@
 		AlertCircle,
 		X,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import ReportErrorButton from '$lib/components/worksheets/ReportErrorButton.svelte';
 	import TutorChat from '$lib/components/tutor/TutorChat.svelte';

--- a/src/lib/components/student/worksheets/TutorDrawer.svelte
+++ b/src/lib/components/student/worksheets/TutorDrawer.svelte
@@ -13,7 +13,7 @@
 -->
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 
 	interface Props {

--- a/src/lib/components/student/worksheets/TutorFAB.svelte
+++ b/src/lib/components/student/worksheets/TutorFAB.svelte
@@ -11,7 +11,7 @@
 	@component
 -->
 <script lang="ts">
-	import { HelpCircle } from 'lucide-svelte';
+	import { HelpCircle } from '@lucide/svelte';
 
 	interface Props {
 		onclick: () => void;

--- a/src/lib/components/student/worksheets/WorksheetCard.svelte
+++ b/src/lib/components/student/worksheets/WorksheetCard.svelte
@@ -23,7 +23,7 @@
 		PenLine,
 		FileQuestion,
 		ArrowRight
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { StudentWorksheetListItem, WorksheetType } from '$lib/types/worksheets';
 
 	interface Props {

--- a/src/lib/components/student/worksheets/WorksheetHeader.svelte
+++ b/src/lib/components/student/worksheets/WorksheetHeader.svelte
@@ -26,7 +26,7 @@
 		Info,
 		Download,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { generateAndDownloadPdf } from '$lib/typst/pdf-generator';
 	import { generateStudentWorksheetTypst } from '$lib/worksheets/student-worksheet-typst';
 	import { toaster } from '$lib/stores/toaster.svelte';

--- a/src/lib/components/teacher/BonusReasonModal.svelte
+++ b/src/lib/components/teacher/BonusReasonModal.svelte
@@ -28,7 +28,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { X, Star } from 'lucide-svelte';
+	import { X, Star } from '@lucide/svelte';
 
 	interface Props {
 		studentName: string;

--- a/src/lib/components/teacher/StudentQuickActionsTable.svelte
+++ b/src/lib/components/teacher/StudentQuickActionsTable.svelte
@@ -90,7 +90,7 @@
 	import { openVipCardsModal } from '$lib/utils/vip-card-modals';
 	import { openBonusReasonModal } from '$lib/utils/bonus-modals';
 	import { onDestroy } from 'svelte';
-	import { Star, Loader2, ScrollText } from 'lucide-svelte';
+	import { Star, Loader2, ScrollText } from '@lucide/svelte';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';
 	import type { StudentVipCards } from '$lib/types/vip-card';
 	import { getTotalUnusedCards } from '$lib/utils/vip-cards';

--- a/src/lib/components/teacher/VipCardUseDialog.svelte
+++ b/src/lib/components/teacher/VipCardUseDialog.svelte
@@ -7,7 +7,7 @@
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import Wheel from '$lib/components/Wheel.svelte';
-	import { Target, ArrowLeft } from 'lucide-svelte';
+	import { Target, ArrowLeft } from '@lucide/svelte';
 
 	let {
 		open = $bindable(false),

--- a/src/lib/components/teacher/analytics/ClassActivityHeatmap.svelte
+++ b/src/lib/components/teacher/analytics/ClassActivityHeatmap.svelte
@@ -5,7 +5,7 @@
 	sans review depuis > 5 jours (paramétré).
 -->
 <script lang="ts">
-	import { AlertTriangle } from 'lucide-svelte';
+	import { AlertTriangle } from '@lucide/svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';

--- a/src/lib/components/teacher/analytics/ClassCapacityGrid.svelte
+++ b/src/lib/components/teacher/analytics/ClassCapacityGrid.svelte
@@ -6,7 +6,7 @@
 	Mode projection (anonymisation) reçu via prop pour cohérence page.
 -->
 <script lang="ts">
-	import { ArrowUpDown, AlertCircle, RefreshCw, Clock, CheckCircle, Circle } from 'lucide-svelte';
+	import { ArrowUpDown, AlertCircle, RefreshCw, Clock, CheckCircle, Circle } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { Badge } from '$lib/components/ui/badge';

--- a/src/lib/components/teacher/analytics/TopCapacitiesToRemediate.svelte
+++ b/src/lib/components/teacher/analytics/TopCapacitiesToRemediate.svelte
@@ -5,7 +5,7 @@
 	Modal "élèves concernés" au clic.
 -->
 <script lang="ts">
-	import { Users } from 'lucide-svelte';
+	import { Users } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Skeleton } from '$lib/components/ui/skeleton';

--- a/src/lib/components/teacher/analytics/TopObservablesToConsolidate.svelte
+++ b/src/lib/components/teacher/analytics/TopObservablesToConsolidate.svelte
@@ -2,7 +2,7 @@
 	Widget G — Top observables famille B où le % minus est le plus élevé.
 -->
 <script lang="ts">
-	import { Users } from 'lucide-svelte';
+	import { Users } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Skeleton } from '$lib/components/ui/skeleton';

--- a/src/lib/components/teacher/anti-fraud/AntiFraudFlagsList.svelte
+++ b/src/lib/components/teacher/anti-fraud/AntiFraudFlagsList.svelte
@@ -8,7 +8,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { CircleAlert, AlertTriangle, ShieldCheck, Eye } from 'lucide-svelte';
+	import { CircleAlert, AlertTriangle, ShieldCheck, Eye } from '@lucide/svelte';
 	import FlagDetailsDialog from './FlagDetailsDialog.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { SvelteSet } from 'svelte/reactivity';

--- a/src/lib/components/templates/ChapterTemplateIndicator.svelte
+++ b/src/lib/components/templates/ChapterTemplateIndicator.svelte
@@ -14,7 +14,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { cn } from '$lib/utils';
-	import { Package, ArrowUpCircle, Unlink, AlertCircle } from 'lucide-svelte';
+	import { Package, ArrowUpCircle, Unlink, AlertCircle } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/FiltersHelp.svelte
+++ b/src/lib/components/templates/FiltersHelp.svelte
@@ -3,7 +3,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { HelpCircle, Zap } from 'lucide-svelte';
+	import { HelpCircle, Zap } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/TagsInput.svelte
+++ b/src/lib/components/templates/TagsInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
-	import { X } from 'lucide-svelte';
+	import { X } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/TemplateCard.svelte
+++ b/src/lib/components/templates/TemplateCard.svelte
@@ -42,7 +42,7 @@
 		ClipboardList,
 		HelpCircle,
 		Dumbbell
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { ChapterIcon } from '$lib/types/chapters';
 
 	// Props

--- a/src/lib/components/templates/TemplateEditor.svelte
+++ b/src/lib/components/templates/TemplateEditor.svelte
@@ -55,7 +55,7 @@
 		ClipboardList,
 		Dumbbell,
 		AlertCircle
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/TemplateGallery.svelte
+++ b/src/lib/components/templates/TemplateGallery.svelte
@@ -15,7 +15,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { cn } from '$lib/utils';
-	import { Search, Package, Users } from 'lucide-svelte';
+	import { Search, Package, Users } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/TemplateInstantiationDialog.svelte
+++ b/src/lib/components/templates/TemplateInstantiationDialog.svelte
@@ -25,7 +25,7 @@
 		ClipboardList,
 		Dumbbell,
 		AlertCircle
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props
 	interface ClassOption {

--- a/src/lib/components/templates/TemplateMigrationDialog.svelte
+++ b/src/lib/components/templates/TemplateMigrationDialog.svelte
@@ -21,7 +21,7 @@
 		HelpCircle,
 		ClipboardList,
 		Dumbbell
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/TemplateVersionHistory.svelte
+++ b/src/lib/components/templates/TemplateVersionHistory.svelte
@@ -14,7 +14,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { Clock, ChevronDown, ChevronUp, GitCommit } from 'lucide-svelte';
+	import { Clock, ChevronDown, ChevronUp, GitCommit } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/templates/VariableAutocomplete.svelte
+++ b/src/lib/components/templates/VariableAutocomplete.svelte
@@ -6,7 +6,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Hash, Zap } from 'lucide-svelte';
+	import { Hash, Zap } from '@lucide/svelte';
 
 	// Props
 	interface Props {

--- a/src/lib/components/test/TestCourse.svelte
+++ b/src/lib/components/test/TestCourse.svelte
@@ -25,7 +25,7 @@
 	import TestResults from './TestResults.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowLeft, CheckCircle2, ArrowUp } from 'lucide-svelte';
+	import { ArrowLeft, CheckCircle2, ArrowUp } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	interface Props {

--- a/src/lib/components/test/TestDisplay.svelte
+++ b/src/lib/components/test/TestDisplay.svelte
@@ -28,7 +28,7 @@
 	import TestTimer from './TestTimer.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Pause, Play, ArrowLeft, Eye, BookOpen, Plus, Minus } from 'lucide-svelte';
+	import { Pause, Play, ArrowLeft, Eye, BookOpen, Plus, Minus } from '@lucide/svelte';
 	import { slideFromRight, slideToLeft } from '$lib/transitions/slide-transition';
 
 	interface Props {

--- a/src/lib/components/test/TestInteractive.svelte
+++ b/src/lib/components/test/TestInteractive.svelte
@@ -26,7 +26,7 @@
 	import TestTimer from './TestTimer.svelte';
 	import { Progress } from '$lib/components/ui/progress';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { slideFromRight, slideToLeft } from '$lib/transitions/slide-transition';
 

--- a/src/lib/components/test/TestModeDialog.svelte
+++ b/src/lib/components/test/TestModeDialog.svelte
@@ -19,7 +19,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { Eye, BrainCircuit, Timer, Rocket } from 'lucide-svelte';
+	import { Eye, BrainCircuit, Timer, Rocket } from '@lucide/svelte';
 	import type { TestMode } from '$lib/types/test';
 
 	// Props

--- a/src/lib/components/test/TestResults.svelte
+++ b/src/lib/components/test/TestResults.svelte
@@ -21,7 +21,7 @@
 	import CorrectionCard from '$lib/components/questions/CorrectionCard.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft, RotateCw, Clock, TrendingUp } from 'lucide-svelte';
+	import { ArrowLeft, RotateCw, Clock, TrendingUp } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	interface Props {

--- a/src/lib/components/tutor/TutorChat.svelte
+++ b/src/lib/components/tutor/TutorChat.svelte
@@ -37,7 +37,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Avatar from '$lib/components/ui/avatar';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { User, Trash2, Loader2 } from 'lucide-svelte';
+	import { User, Trash2, Loader2 } from '@lucide/svelte';
 	import pereUbuImage from '$lib/assets/images/avatar-pereubu.png';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { convertLegacyLatexToMarkdown } from '$lib/utils/latex-syntax-adapter';

--- a/src/lib/components/tutor/TutorHelpButton.svelte
+++ b/src/lib/components/tutor/TutorHelpButton.svelte
@@ -33,7 +33,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { HelpCircle } from 'lucide-svelte';
+	import { HelpCircle } from '@lucide/svelte';
 	import TutorChat from './TutorChat.svelte';
 
 	interface ExerciseContext {

--- a/src/lib/components/tutor/TutorWidget.svelte
+++ b/src/lib/components/tutor/TutorWidget.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { X, Minimize2, Maximize2 } from 'lucide-svelte';
+	import { X, Minimize2, Maximize2 } from '@lucide/svelte';
 	import TutorChat from './TutorChat.svelte';
 	import pereUbuImage from '$lib/assets/images/avatar-pereubu.png';
 

--- a/src/lib/components/tutor/USAGE_EXAMPLES.md
+++ b/src/lib/components/tutor/USAGE_EXAMPLES.md
@@ -239,7 +239,7 @@ Custom styled tutor access:
 ```svelte
 <script lang="ts">
 	import { TutorWidget } from '$lib/components/tutor';
-	import { HelpCircle } from 'lucide-svelte';
+	import { HelpCircle } from '@lucide/svelte';
 
 	let { exerciseContext } = $props();
 </script>

--- a/src/lib/components/vip-cards/VipCardPreview.svelte
+++ b/src/lib/components/vip-cards/VipCardPreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Switch } from '$lib/components/ui/switch';
-	import { Check, ImageIcon, Pencil, Trash2 } from 'lucide-svelte';
+	import { Check, ImageIcon, Pencil, Trash2 } from '@lucide/svelte';
 	import type { VipCardTemplate } from '$lib/stores/vipCardTemplates.svelte';
 	import type { VipCardAction } from '$lib/types/vip-card';
 	import { categoryIcon } from './utils';

--- a/src/lib/components/vip-cards/VipCardPurchaseModal.svelte
+++ b/src/lib/components/vip-cards/VipCardPurchaseModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { ShoppingCart, AlertCircle, Check } from 'lucide-svelte';
+	import { ShoppingCart, AlertCircle, Check } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { VipCard } from '$lib/types/vip-card';

--- a/src/lib/components/vip-cards/VipCardSellModal.svelte
+++ b/src/lib/components/vip-cards/VipCardSellModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { AlertCircle, Check, Sparkles } from 'lucide-svelte';
+	import { AlertCircle, Check, Sparkles } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { VipCard } from '$lib/types/vip-card';

--- a/src/lib/components/vip-cards/VipCardShopSection.svelte
+++ b/src/lib/components/vip-cards/VipCardShopSection.svelte
@@ -5,7 +5,7 @@
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { consent } from '$lib/stores/consent.svelte';
 	import Badge from '$lib/components/ui/badge/badge.svelte';
-	import { Search, ShoppingCart, Sparkles, Gem } from 'lucide-svelte';
+	import { Search, ShoppingCart, Sparkles, Gem } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import VipCardPurchaseModal from './VipCardPurchaseModal.svelte';

--- a/src/lib/components/worksheets/AssignmentStudentsPanel.svelte
+++ b/src/lib/components/worksheets/AssignmentStudentsPanel.svelte
@@ -27,7 +27,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import StudentSelector from '$lib/components/worksheets/StudentSelector.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Users, UserMinus, RefreshCw } from 'lucide-svelte';
+	import { Loader2, Users, UserMinus, RefreshCw } from '@lucide/svelte';
 
 	// ============================================================================
 	// TYPES

--- a/src/lib/components/worksheets/CorrectionManager.svelte
+++ b/src/lib/components/worksheets/CorrectionManager.svelte
@@ -8,7 +8,7 @@
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Eye, Loader2, EyeOff, Settings2, FileText, AlertTriangle } from 'lucide-svelte';
+	import { Eye, Loader2, EyeOff, Settings2, FileText, AlertTriangle } from '@lucide/svelte';
 	import type { WorksheetAssignmentRow, CorrectionReleaseMode } from '$lib/types/worksheets';
 
 	// Typst library type

--- a/src/lib/components/worksheets/ExerciseConfigModal.svelte
+++ b/src/lib/components/worksheets/ExerciseConfigModal.svelte
@@ -30,7 +30,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Save, Star } from 'lucide-svelte';
+	import { Loader2, Save, Star } from '@lucide/svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import type {
 		WorksheetExerciseWithExercise,

--- a/src/lib/components/worksheets/ExerciseList.svelte
+++ b/src/lib/components/worksheets/ExerciseList.svelte
@@ -31,7 +31,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { GripVertical, Trash2, Loader2, Settings2, Star } from 'lucide-svelte';
+	import { GripVertical, Trash2, Loader2, Settings2, Star } from '@lucide/svelte';
 	import type {
 		WorksheetExerciseWithExercise,
 		WorksheetSectionRow,

--- a/src/lib/components/worksheets/ExercisePreview.svelte
+++ b/src/lib/components/worksheets/ExercisePreview.svelte
@@ -23,7 +23,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { Separator } from '$lib/components/ui/separator';
-	import { Variable, Eye, EyeOff, GraduationCap, Tag } from 'lucide-svelte';
+	import { Variable, Eye, EyeOff, GraduationCap, Tag } from '@lucide/svelte';
 	import { formatGradeShort } from '$lib/utils/grades';
 	import type { GradeCode } from '$lib/types/grades';
 	import ExerciseDisplay from '$lib/components/exercises/ExerciseDisplay.svelte';

--- a/src/lib/components/worksheets/ExerciseSelector.svelte
+++ b/src/lib/components/worksheets/ExerciseSelector.svelte
@@ -53,7 +53,7 @@
 		ChevronLeft,
 		ChevronRight,
 		X
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { formatGradeShort } from '$lib/utils/grades';
 	import type { GradeCode } from '$lib/types/grades';
 	import type { Exercise } from '$lib/exercises/types';

--- a/src/lib/components/worksheets/MetadataCards.svelte
+++ b/src/lib/components/worksheets/MetadataCards.svelte
@@ -26,7 +26,7 @@
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import GradeBadgeSelector from '$lib/components/GradeBadgeSelector.svelte';
 	import TagBadgeSelector from '$lib/components/TagBadgeSelector.svelte';
-	import { Loader2, Check, X, Settings } from 'lucide-svelte';
+	import { Loader2, Check, X, Settings } from '@lucide/svelte';
 	import {
 		WORKSHEET_TYPE_LABELS,
 		WORKSHEET_TYPE_OPTIONS,

--- a/src/lib/components/worksheets/MultiClassStudentSelector.svelte
+++ b/src/lib/components/worksheets/MultiClassStudentSelector.svelte
@@ -37,7 +37,7 @@
 		UserPlus,
 		CheckSquare,
 		Square
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { untrack } from 'svelte';
 
 	// ============================================================================

--- a/src/lib/components/worksheets/PdfPreview.svelte
+++ b/src/lib/components/worksheets/PdfPreview.svelte
@@ -24,7 +24,7 @@
 		Code,
 		Copy,
 		FileCode
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { generateWorksheetTypst } from '$lib/worksheets/typst-generator';
 	import {
 		clearTrackedExternalImages,

--- a/src/lib/components/worksheets/ReportDetailsPopover.svelte
+++ b/src/lib/components/worksheets/ReportDetailsPopover.svelte
@@ -2,7 +2,7 @@
 	import * as Popover from '$lib/components/ui/popover';
 	import { Button } from '$lib/components/ui/button';
 	import { Separator } from '$lib/components/ui/separator';
-	import { Info } from 'lucide-svelte';
+	import { Info } from '@lucide/svelte';
 	import ReportStatusBadge from './ReportStatusBadge.svelte';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';
 	import type { StudentErrorReportView } from '$lib/types/worksheets';

--- a/src/lib/components/worksheets/ReportErrorButton.svelte
+++ b/src/lib/components/worksheets/ReportErrorButton.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Popover from '$lib/components/ui/popover';
 	import { Separator } from '$lib/components/ui/separator';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { AlertTriangle } from '@lucide/svelte';
 	import ReportStatusBadge from './ReportStatusBadge.svelte';
 	import ReportErrorDialog from './ReportErrorDialog.svelte';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';

--- a/src/lib/components/worksheets/SectionManager.svelte
+++ b/src/lib/components/worksheets/SectionManager.svelte
@@ -29,7 +29,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Plus, Pencil, Trash2, GripVertical, Loader2, Save, X } from 'lucide-svelte';
+	import { Plus, Pencil, Trash2, GripVertical, Loader2, Save, X } from '@lucide/svelte';
 	import type { WorksheetSectionRow } from '$lib/types/worksheets';
 
 	// Types

--- a/src/lib/components/worksheets/StudentSelector.svelte
+++ b/src/lib/components/worksheets/StudentSelector.svelte
@@ -28,7 +28,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Users, UserPlus, Search } from 'lucide-svelte';
+	import { Loader2, Users, UserPlus, Search } from '@lucide/svelte';
 	import { Input } from '$lib/components/ui/input';
 
 	// ============================================================================

--- a/src/lib/components/worksheets/TemplateSelector.svelte
+++ b/src/lib/components/worksheets/TemplateSelector.svelte
@@ -19,7 +19,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Card from '$lib/components/ui/card';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { FileText, Eye, Globe, Lock, Sparkles, X } from 'lucide-svelte';
+	import { FileText, Eye, Globe, Lock, Sparkles, X } from '@lucide/svelte';
 	import type { WorksheetTemplateRow } from '$lib/types/worksheets';
 	import {
 		DEFAULT_TEMPLATES,

--- a/src/lib/components/worksheets/TypstEditor.svelte
+++ b/src/lib/components/worksheets/TypstEditor.svelte
@@ -28,7 +28,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Label } from '$lib/components/ui/label';
 	import { Separator } from '$lib/components/ui/separator';
-	import { Code2, Eye, Plus, AlertCircle, FileText, RefreshCw, Loader2 } from 'lucide-svelte';
+	import { Code2, Eye, Plus, AlertCircle, FileText, RefreshCw, Loader2 } from '@lucide/svelte';
 	import type { TemplatePlaceholder } from '$lib/types/worksheets';
 	import {
 		COMMON_PLACEHOLDERS,

--- a/src/lib/components/worksheets/VariantPreview.svelte
+++ b/src/lib/components/worksheets/VariantPreview.svelte
@@ -12,7 +12,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { sanitizeHtml } from '$lib/utils/sanitize';
-	import { Eye, RefreshCw, Users, Copy } from 'lucide-svelte';
+	import { Eye, RefreshCw, Users, Copy } from '@lucide/svelte';
 	import type { InstanceData } from '$lib/types/worksheets';
 
 	interface Props {

--- a/src/lib/components/worksheets/WorksheetAssignmentForm.svelte
+++ b/src/lib/components/worksheets/WorksheetAssignmentForm.svelte
@@ -34,7 +34,7 @@
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import MultiClassStudentSelector from '$lib/components/worksheets/MultiClassStudentSelector.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, Users, Calendar, Monitor, Info } from 'lucide-svelte';
+	import { Loader2, Users, Calendar, Monitor, Info } from '@lucide/svelte';
 	import type {
 		WorksheetAssignmentInsert,
 		WorksheetAssignmentWithRelations

--- a/src/lib/components/worksheets/student/CancelReportDialog.svelte
+++ b/src/lib/components/worksheets/student/CancelReportDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Loader2, AlertTriangle } from 'lucide-svelte';
+	import { Loader2, AlertTriangle } from '@lucide/svelte';
 	import type { StudentErrorReportWithDisplay } from '$lib/types/worksheets';
 
 	// Props

--- a/src/lib/components/worksheets/student/StudentReportCard.svelte
+++ b/src/lib/components/worksheets/student/StudentReportCard.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Calendar, MessageSquare, Hash, FileText, XCircle, CheckCircle2 } from 'lucide-svelte';
+	import { Calendar, MessageSquare, Hash, FileText, XCircle, CheckCircle2 } from '@lucide/svelte';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';
 	import type { StudentErrorReportWithDisplay } from '$lib/types/worksheets';
 

--- a/src/lib/components/worksheets/student/StudentReportsPanel.svelte
+++ b/src/lib/components/worksheets/student/StudentReportsPanel.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import { AlertCircle, Loader2 } from 'lucide-svelte';
+	import { AlertCircle, Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import StudentReportCard from './StudentReportCard.svelte';
 	import CancelReportDialog from './CancelReportDialog.svelte';

--- a/src/lib/components/worksheets/teacher/ErrorReportCard.svelte
+++ b/src/lib/components/worksheets/teacher/ErrorReportCard.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { User, Hash, Calendar, MessageSquare, CheckCircle2, XCircle } from 'lucide-svelte';
+	import { User, Hash, Calendar, MessageSquare, CheckCircle2, XCircle } from '@lucide/svelte';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';
 	import type { TeacherErrorReportView } from '$lib/types/worksheets';
 

--- a/src/lib/components/worksheets/teacher/ErrorReportsPanel.svelte
+++ b/src/lib/components/worksheets/teacher/ErrorReportsPanel.svelte
@@ -3,7 +3,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { AlertCircle, Loader2 } from 'lucide-svelte';
+	import { AlertCircle, Loader2 } from '@lucide/svelte';
 	import ErrorReportCard from './ErrorReportCard.svelte';
 	import type { TeacherErrorReportView, ErrorReportStatus } from '$lib/types/worksheets';
 

--- a/src/lib/components/worksheets/teacher/ReviewReportDialog.svelte
+++ b/src/lib/components/worksheets/teacher/ReviewReportDialog.svelte
@@ -4,7 +4,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Loader2, CheckCircle2, XCircle, User, Hash } from 'lucide-svelte';
+	import { Loader2, CheckCircle2, XCircle, User, Hash } from '@lucide/svelte';
 	import type { TeacherErrorReportView } from '$lib/types/worksheets';
 
 	// Props

--- a/src/lib/config/dashboard-nav.ts
+++ b/src/lib/config/dashboard-nav.ts
@@ -33,13 +33,13 @@ import {
 	Brain,
 	User as UserIcon,
 	LogOut
-} from 'lucide-svelte';
-import type { ComponentType } from 'svelte';
+} from '@lucide/svelte';
+import type { LucideIcon } from '@lucide/svelte';
 
 export type DashboardNavLink = {
 	href: string;
 	label: string;
-	icon: ComponentType;
+	icon: LucideIcon;
 	badge?: number;
 	/** Marks footer items (Mon profil, Déconnexion) rendered after a separator. */
 	footer?: boolean;

--- a/src/lib/constructions-v2/components/PlayerControls.svelte
+++ b/src/lib/constructions-v2/components/PlayerControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { RotateCcw, SkipBack, Play, Pause, SkipForward, StepForward } from 'lucide-svelte';
+	import { RotateCcw, SkipBack, Play, Pause, SkipForward, StepForward } from '@lucide/svelte';
 	import type { TimelineState } from '../core/timeline.svelte';
 
 	interface Props {

--- a/src/lib/constructions-v2/components/SpeedControl.svelte
+++ b/src/lib/constructions-v2/components/SpeedControl.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { Minus, Plus } from 'lucide-svelte';
+	import { Minus, Plus } from '@lucide/svelte';
 	import { formatPlaybackRate } from '../core/timeline.svelte';
 	import type { TimelineState } from '../core/timeline.svelte';
 

--- a/src/lib/constructions/components/ConstructionPlayer.svelte
+++ b/src/lib/constructions/components/ConstructionPlayer.svelte
@@ -13,7 +13,7 @@
 	import ParameterControls from './ParameterControls.svelte';
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { RefreshCw } from 'lucide-svelte';
+	import { RefreshCw } from '@lucide/svelte';
 	import { onDestroy } from 'svelte';
 	import 'mathlive'; // Required for math rendering in instructions
 

--- a/src/lib/constructions/components/PlayerControls.svelte
+++ b/src/lib/constructions/components/PlayerControls.svelte
@@ -9,11 +9,11 @@
 	import type { Timeline } from '../core/timeline.svelte';
 	import type { ConstructionEngine } from '../core/engine.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import Play from 'lucide-svelte/icons/play';
-	import Pause from 'lucide-svelte/icons/pause';
-	import RotateCcw from 'lucide-svelte/icons/rotate-ccw';
-	import SkipBack from 'lucide-svelte/icons/skip-back';
-	import SkipForward from 'lucide-svelte/icons/skip-forward';
+	import Play from '@lucide/svelte/icons/play';
+	import Pause from '@lucide/svelte/icons/pause';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+	import SkipBack from '@lucide/svelte/icons/skip-back';
+	import SkipForward from '@lucide/svelte/icons/skip-forward';
 
 	// Types
 	interface Props {

--- a/src/lib/extensions/ImageNodeView.svelte
+++ b/src/lib/extensions/ImageNodeView.svelte
@@ -25,7 +25,7 @@
 		getPos: () => number | undefined;
 		selected: boolean;
 	}
-	import { Pencil, Trash2, Check, X } from 'lucide-svelte';
+	import { Pencil, Trash2, Check, X } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import ImageAttributePanel from '$lib/components/exercises/ImageAttributePanel.svelte';

--- a/src/lib/extensions/NumberLineNodeView.svelte
+++ b/src/lib/extensions/NumberLineNodeView.svelte
@@ -23,7 +23,7 @@
 		getPos: () => number | undefined;
 		selected: boolean;
 	}
-	import { Pencil, Trash2, Check, X, AlertCircle } from 'lucide-svelte';
+	import { Pencil, Trash2, Check, X, AlertCircle } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import NumberLine from '$lib/components/markdown/nodes/NumberLine.svelte';

--- a/src/lib/extensions/VariationTableNodeView.svelte
+++ b/src/lib/extensions/VariationTableNodeView.svelte
@@ -24,7 +24,7 @@
 		getPos: () => number | undefined;
 		selected: boolean;
 	}
-	import { Pencil, Trash2, Check, X, AlertCircle } from 'lucide-svelte';
+	import { Pencil, Trash2, Check, X, AlertCircle } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import VariationTable from '$lib/components/markdown/nodes/VariationTable.svelte';

--- a/src/lib/slides/components/SlideAnnotationToolbar.svelte
+++ b/src/lib/slides/components/SlideAnnotationToolbar.svelte
@@ -22,7 +22,7 @@
 		Redo2,
 		Pencil,
 		PencilOff
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type {
 		SlideAnnotationToolType,
 		AnnotationStyle

--- a/src/lib/utils/worksheet-constants.ts
+++ b/src/lib/utils/worksheet-constants.ts
@@ -3,7 +3,7 @@
  */
 
 import type { WorksheetType, WorksheetStatus } from '$lib/types/worksheets';
-import { FileText, ClipboardCheck, BookOpen, HelpCircle, Home } from 'lucide-svelte';
+import { FileText, ClipboardCheck, BookOpen, HelpCircle, Home } from '@lucide/svelte';
 
 // =============================================================================
 // TYPE AND STATUS OPTIONS (for form selects)

--- a/src/lib/whiteboard/components/AnnotationToolbar.svelte
+++ b/src/lib/whiteboard/components/AnnotationToolbar.svelte
@@ -31,7 +31,7 @@
 		Redo2,
 		Paintbrush,
 		GripVertical
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { FillMode, StrokeStyle } from '../types/document';
 	import type { AnnotationToolType, StampType } from '../types/document';
 	import { STAMP_CATEGORIES, STAMP_CATEGORY_LABELS } from '../types/document';

--- a/src/lib/whiteboard/components/AutosaveRecoveryDialog.svelte
+++ b/src/lib/whiteboard/components/AutosaveRecoveryDialog.svelte
@@ -13,7 +13,7 @@
 	import DialogFooter from '$lib/components/ui/dialog/dialog-footer.svelte';
 	import DialogTitle from '$lib/components/ui/dialog/dialog-title.svelte';
 	import DialogDescription from '$lib/components/ui/dialog/dialog-description.svelte';
-	import { History, FileText, Loader2 } from 'lucide-svelte';
+	import { History, FileText, Loader2 } from '@lucide/svelte';
 
 	// ==========================================================================
 	// Props

--- a/src/lib/whiteboard/components/ContextMenu.svelte
+++ b/src/lib/whiteboard/components/ContextMenu.svelte
@@ -25,7 +25,7 @@
 		AlignEndHorizontal,
 		AlignHorizontalSpaceAround,
 		AlignVerticalSpaceAround
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// ==========================================================================
 	// State

--- a/src/lib/whiteboard/components/CreateFolderDialog.svelte
+++ b/src/lib/whiteboard/components/CreateFolderDialog.svelte
@@ -9,7 +9,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { FolderPlus, Loader2 } from 'lucide-svelte';
+	import { FolderPlus, Loader2 } from '@lucide/svelte';
 
 	// ==========================================================================
 	// Props

--- a/src/lib/whiteboard/components/DraggablePanel.svelte
+++ b/src/lib/whiteboard/components/DraggablePanel.svelte
@@ -9,7 +9,7 @@
 	 * - Close button
 	 */
 
-	import { GripVertical, X } from 'lucide-svelte';
+	import { GripVertical, X } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import type { Snippet } from 'svelte';
 

--- a/src/lib/whiteboard/components/DriveFilePicker.svelte
+++ b/src/lib/whiteboard/components/DriveFilePicker.svelte
@@ -10,7 +10,7 @@
 
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2, FileText, AlertCircle } from 'lucide-svelte';
+	import { Loader2, FileText, AlertCircle } from '@lucide/svelte';
 	import { driveSyncService, type DriveFile } from '../services/drive-sync';
 	import { toaster } from '$lib/stores/toaster.svelte';
 

--- a/src/lib/whiteboard/components/ExportDialog.svelte
+++ b/src/lib/whiteboard/components/ExportDialog.svelte
@@ -23,7 +23,7 @@
 		type PngResolution,
 		type ExportOptions
 	} from '../core/pdf-export';
-	import { Download, FileImage, FileCode, FileText, Loader2 } from 'lucide-svelte';
+	import { Download, FileImage, FileCode, FileText, Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// ==========================================================================

--- a/src/lib/whiteboard/components/ExportToClassroomDialog.svelte
+++ b/src/lib/whiteboard/components/ExportToClassroomDialog.svelte
@@ -30,7 +30,7 @@
 		Calendar,
 		Sparkles,
 		FilePlus
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { exportToPdf } from '../core/pdf-export';
 

--- a/src/lib/whiteboard/components/FileDrawer.svelte
+++ b/src/lib/whiteboard/components/FileDrawer.svelte
@@ -40,7 +40,7 @@
 		Image,
 		Upload,
 		Trash2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { importImageFile } from '../utils/image-loader';
 	import { importPdfFile, type PdfImportMode } from '../utils/pdf-loader';
 	import ExportDialog from './ExportDialog.svelte';

--- a/src/lib/whiteboard/components/FloatingToolbar.svelte
+++ b/src/lib/whiteboard/components/FloatingToolbar.svelte
@@ -43,7 +43,7 @@
 		Redo2,
 		GripVertical,
 		Palette
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import {
 		INSTRUMENT_LABELS,
 		SLOPPINESS_PRESETS,

--- a/src/lib/whiteboard/components/PageThumbnails.svelte
+++ b/src/lib/whiteboard/components/PageThumbnails.svelte
@@ -18,7 +18,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Sheet from '$lib/components/ui/sheet';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
-	import { Plus, X, GripVertical, FileText, LayoutTemplate } from 'lucide-svelte';
+	import { Plus, X, GripVertical, FileText, LayoutTemplate } from '@lucide/svelte';
 	import TemplatePickerModal from './TemplatePickerModal.svelte';
 	import type { TemplatePageData } from '../types/templates';
 

--- a/src/lib/whiteboard/components/SaveAsDialog.svelte
+++ b/src/lib/whiteboard/components/SaveAsDialog.svelte
@@ -12,7 +12,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 
 	// ==========================================================================
 	// Props

--- a/src/lib/whiteboard/components/TemplatePickerModal.svelte
+++ b/src/lib/whiteboard/components/TemplatePickerModal.svelte
@@ -26,7 +26,7 @@
 		Axis3d,
 		Star,
 		Plus
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { templateService, type CreateFromModalInput } from '../services/template-service';
 	import {
 		TEMPLATE_CATEGORIES,

--- a/src/lib/whiteboard/components/Whiteboard.svelte
+++ b/src/lib/whiteboard/components/Whiteboard.svelte
@@ -29,7 +29,7 @@
 		FolderOpen,
 		PanelRight,
 		PenTool
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageFormatKey } from '../types/document';
 	import type { TemplatePageData } from '../types/templates';
 	import { driveSyncService } from '../services/drive-sync';

--- a/src/lib/whiteboard/components/WhiteboardToolbar.svelte
+++ b/src/lib/whiteboard/components/WhiteboardToolbar.svelte
@@ -41,7 +41,7 @@
 		Grid3x3,
 		Palette,
 		Crosshair
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import {
 		INSTRUMENT_LABELS,
 		STROKE_STYLE_LABELS,

--- a/src/lib/whiteboard/components/toolbar/StyleSection.svelte
+++ b/src/lib/whiteboard/components/toolbar/StyleSection.svelte
@@ -5,7 +5,7 @@
 	 * Groups related style controls with a title and optional collapse behavior.
 	 */
 
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 
 	interface Props {

--- a/src/lib/whiteboard/components/toolbar/ToolButton.svelte
+++ b/src/lib/whiteboard/components/toolbar/ToolButton.svelte
@@ -9,7 +9,7 @@
 	import { Button } from '$lib/components/ui/button';
 	// lucide-svelte v0.545 exports Svelte 4 class-based components (SvelteComponentTyped),
 	// not Svelte 5 Component<Props> interface. Use typeof to accept the class constructor.
-	import type { Icon as LucideIcon } from 'lucide-svelte';
+	import type { Icon as LucideIcon } from '@lucide/svelte';
 
 	interface Props {
 		/** Lucide icon component */

--- a/src/routes/(protected)/constructions/+page.svelte
+++ b/src/routes/(protected)/constructions/+page.svelte
@@ -24,7 +24,7 @@
 		Compass,
 		User,
 		FileUp
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/constructions/[id]/+page.svelte
+++ b/src/routes/(protected)/constructions/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto } from '$app/navigation';
-	import { ArrowLeft, Edit, Trash2, Globe, Lock, User, Calendar } from 'lucide-svelte';
+	import { ArrowLeft, Edit, Trash2, Globe, Lock, User, Calendar } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/constructions/[id]/edit/+page.svelte
+++ b/src/routes/(protected)/constructions/[id]/edit/+page.svelte
@@ -7,7 +7,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto } from '$app/navigation';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/constructions/conversion/+page.svelte
+++ b/src/routes/(protected)/constructions/conversion/+page.svelte
@@ -35,7 +35,7 @@
 		Loader2,
 		X,
 		Code2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	// Types for XML/JSON comparison
 	interface XmlJsonPair {

--- a/src/routes/(protected)/constructions/new/+page.svelte
+++ b/src/routes/(protected)/constructions/new/+page.svelte
@@ -6,7 +6,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto } from '$app/navigation';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	let EditorComponent = $state<Component | null>(null);
 

--- a/src/routes/(protected)/dashboard/+layout.svelte
+++ b/src/routes/(protected)/dashboard/+layout.svelte
@@ -36,7 +36,7 @@
 	import type { LayoutData } from './$types';
 	import { page } from '$app/state';
 	import { navigating } from '$app/stores';
-	import { Sun, Moon, Minus, Plus, Maximize, Minimize, Menu } from 'lucide-svelte';
+	import { Sun, Moon, Minus, Plus, Maximize, Minimize, Menu } from '@lucide/svelte';
 	import { getNavLinks, getZoneTitle } from '$lib/config/dashboard-nav';
 	import { submitLogoutForm } from '$lib/utils/auth';
 	import { resolve } from '$app/paths';

--- a/src/routes/(protected)/dashboard/AdminDashboard.svelte
+++ b/src/routes/(protected)/dashboard/AdminDashboard.svelte
@@ -70,7 +70,7 @@
 		AlertTriangle,
 		RefreshCw,
 		Clock
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	import type { PageData } from './$types';

--- a/src/routes/(protected)/dashboard/StudentDashboard.svelte
+++ b/src/routes/(protected)/dashboard/StudentDashboard.svelte
@@ -46,11 +46,11 @@
 		Circle,
 		LifeBuoy,
 		ChevronRight
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	// import AchievementsWidget from '$lib/components/game/minesweeper/AchievementsWidget.svelte';
 	// import { Button } from '$lib/components/ui/button';
 	// import { formatDeadline, isDeadlinePassed, isDeadlineSoon } from '$lib/utils/dates';
-	// import { BookOpen, FileText, Calendar, CheckCircle } from 'lucide-svelte';
+	// import { BookOpen, FileText, Calendar, CheckCircle } from '@lucide/svelte';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';
 	import { findCurrentPeriod } from '$lib/utils/academic-period';
 

--- a/src/routes/(protected)/dashboard/TeacherDashboard.svelte
+++ b/src/routes/(protected)/dashboard/TeacherDashboard.svelte
@@ -72,7 +72,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Calendar, Clock, Target, BookOpen, Users } from 'lucide-svelte';
+	import { Calendar, Clock, Target, BookOpen, Users } from '@lucide/svelte';
 	import Wheel from '$lib/components/Wheel.svelte';
 	import StudentQuickActionsTable from '$lib/components/teacher/StudentQuickActionsTable.svelte';
 	import VipCardUseDialog from '$lib/components/teacher/VipCardUseDialog.svelte';

--- a/src/routes/(protected)/dashboard/admin/backup/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/backup/+page.svelte
@@ -18,7 +18,7 @@
 		AlertCircle,
 		CheckCircle2,
 		RefreshCw
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { BackupStats, RestoreResult } from '$lib/server/validation/backup';
 
 	let { data } = $props();

--- a/src/routes/(protected)/dashboard/admin/bug-reports/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/bug-reports/+page.svelte
@@ -57,7 +57,7 @@
 		Trash2,
 		X,
 		CheckSquare
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/dashboard/admin/classes/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/classes/+page.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Copy, Check, Loader2, Pencil, PowerOff, Power } from 'lucide-svelte';
+	import { Copy, Check, Loader2, Pencil, PowerOff, Power } from '@lucide/svelte';
 	import { Switch } from '$lib/components/ui/switch';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';

--- a/src/routes/(protected)/dashboard/admin/cron/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/cron/+page.svelte
@@ -20,7 +20,7 @@
 		Play,
 		Timer,
 		Activity
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { CronJobRun } from '$lib/server/validation/cron';
 
 	let { data } = $props();

--- a/src/routes/(protected)/dashboard/admin/debug/latex-preview/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/latex-preview/+page.svelte
@@ -3,7 +3,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { FileDown, Play, AlertCircle, Trash2, Settings2 } from 'lucide-svelte';
+	import { FileDown, Play, AlertCircle, Trash2, Settings2 } from '@lucide/svelte';
 
 	// LaTeX engine options
 	const engineOptions = [

--- a/src/routes/(protected)/dashboard/admin/debug/mathfield/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/mathfield/+page.svelte
@@ -6,7 +6,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Label } from '$lib/components/ui/label';
-	import { Keyboard, Type, Copy, Check, RotateCcw, Settings2, Code, Braces } from 'lucide-svelte';
+	import { Keyboard, Type, Copy, Check, RotateCcw, Settings2, Code, Braces } from '@lucide/svelte';
 
 	// State
 	let latexOutput = $state('');

--- a/src/routes/(protected)/dashboard/admin/debug/question-display/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/question-display/+page.svelte
@@ -18,7 +18,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Separator } from '$lib/components/ui/separator';
 	import { Input } from '$lib/components/ui/input';
-	import { RefreshCw, Copy, Check } from 'lucide-svelte';
+	import { RefreshCw, Copy, Check } from '@lucide/svelte';
 	import { browser } from '$app/environment';
 
 	// ============================================================================

--- a/src/routes/(protected)/dashboard/admin/debug/rich-text/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/rich-text/+page.svelte
@@ -18,7 +18,7 @@
 		Settings,
 		Beaker,
 		ArrowRightLeft
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { markdownToTipTap } from '$lib/components/rich-text/markdown-import';
 	import { tipTapToMarkdown } from '$lib/components/rich-text/markdown-export';
 	import type { MathTemplateLevel, RichTextMode } from '$lib/components/rich-text/types';

--- a/src/routes/(protected)/dashboard/admin/debug/rls/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/rls/+page.svelte
@@ -2,7 +2,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Separator } from '$lib/components/ui/separator';
-	import { CheckCircle2, XCircle, AlertCircle } from 'lucide-svelte';
+	import { CheckCircle2, XCircle, AlertCircle } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/dashboard/admin/debug/typst-preview/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/typst-preview/+page.svelte
@@ -4,7 +4,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
-	import { FileDown, Eye, AlertCircle } from 'lucide-svelte';
+	import { FileDown, Eye, AlertCircle } from '@lucide/svelte';
 
 	// Type for typst library
 	type TypstLibrary = {

--- a/src/routes/(protected)/dashboard/admin/debug/wheel/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/debug/wheel/+page.svelte
@@ -23,7 +23,7 @@
 	import Wheel from '$lib/components/Wheel.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Copy, Plus, Trash2, RotateCcw } from 'lucide-svelte';
+	import { Copy, Plus, Trash2, RotateCcw } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	// Student interface matching Wheel component requirements

--- a/src/routes/(protected)/dashboard/admin/friendships/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/friendships/+page.svelte
@@ -6,7 +6,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Trash2, Search, Users, AlertTriangle } from 'lucide-svelte';
+	import { Trash2, Search, Users, AlertTriangle } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/admin/message-templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/message-templates/+page.svelte
@@ -23,7 +23,7 @@
 		ChevronUp,
 		BarChart3,
 		Search
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { sanitizeHtml } from '$lib/utils/sanitize';
 	import type { MessageTemplate, TriggerType } from '$lib/types/messageTemplates';

--- a/src/routes/(protected)/dashboard/admin/message-templates/stats/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/message-templates/stats/+page.svelte
@@ -44,7 +44,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { Loader2, TrendingUp, Users, CheckCircle, BarChart3, ArrowLeft } from 'lucide-svelte';
+	import { Loader2, TrendingUp, Users, CheckCircle, BarChart3, ArrowLeft } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto } from '$app/navigation';
 

--- a/src/routes/(protected)/dashboard/admin/migration/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/migration/+page.svelte
@@ -27,7 +27,7 @@
 		XCircle,
 		Calendar,
 		RefreshCw
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/+page.svelte
@@ -36,11 +36,11 @@
 		XCircle,
 		X,
 		Edit3
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import ReviewActions from '$lib/components/migration/ReviewActions.svelte';
 	import TestSpecBatchRunner from '$lib/components/migration/TestSpecBatchRunner.svelte';
 	import { SvelteMap } from 'svelte/reactivity';
-	import { FlaskConical } from 'lucide-svelte';
+	import { FlaskConical } from '@lucide/svelte';
 	import type { QuestionTemplate } from '$lib/questions/types';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/[globalIndex]/edit/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/[globalIndex]/edit/+page.svelte
@@ -15,7 +15,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
-	import { ArrowLeft, Home, Loader2, RotateCcw } from 'lucide-svelte';
+	import { ArrowLeft, Home, Loader2, RotateCcw } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/admin/notifications/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/notifications/+page.svelte
@@ -8,7 +8,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Separator } from '$lib/components/ui/separator';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Plus, Trash2, Send } from 'lucide-svelte';
+	import { Plus, Trash2, Send } from '@lucide/svelte';
 	import {
 		NOTIFICATION_TYPE_LABELS,
 		NOTIFICATION_PRIORITY_LABELS,

--- a/src/routes/(protected)/dashboard/admin/questions/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/questions/+page.svelte
@@ -64,7 +64,7 @@
 		ArrowDown,
 		Loader2,
 		ChevronDown
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/admin/questions/[id]/edit/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/questions/[id]/edit/+page.svelte
@@ -28,7 +28,7 @@
 	import type { QuestionTemplate } from '$lib/questions/types';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowLeft, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Loader2 } from '@lucide/svelte';
 	import { questionCategoriesCache } from '$lib/stores/questionCategories.svelte';
 	import { questionTemplatesCache } from '$lib/stores/questionTemplates.svelte';
 	import { onMount } from 'svelte';

--- a/src/routes/(protected)/dashboard/admin/questions/[id]/preview/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/questions/[id]/preview/+page.svelte
@@ -27,7 +27,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Switch } from '$lib/components/ui/switch';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, RefreshCw, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, RefreshCw, Loader2 } from '@lucide/svelte';
 
 	// ===========================
 	// PROPS & DERIVED STATE

--- a/src/routes/(protected)/dashboard/admin/questions/create/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/questions/create/+page.svelte
@@ -25,7 +25,7 @@
 	import type { QuestionTemplate } from '$lib/questions/types';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowLeft, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Loader2 } from '@lucide/svelte';
 	import { questionCategoriesCache } from '$lib/stores/questionCategories.svelte';
 	import { questionTemplatesCache } from '$lib/stores/questionTemplates.svelte';
 	import { onMount } from 'svelte';

--- a/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.svelte
@@ -23,7 +23,7 @@
 		Calendar,
 		Copy,
 		Check
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import MySelect from '$lib/components/MySelect.svelte';
 

--- a/src/routes/(protected)/dashboard/admin/settings/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/settings/+page.svelte
@@ -19,7 +19,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import { Button } from '$lib/components/ui/button';
 	import { getVersion, getRawVersion } from '$lib/utils/version';
-	import { Settings, Info, ListOrdered, RotateCcw } from 'lucide-svelte';
+	import { Settings, Info, ListOrdered, RotateCcw } from '@lucide/svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { listNumberingStore } from '$lib/stores/listNumbering.svelte';
 	import { NUMBERING_SCHEMES, type SchemeId } from '$lib/types/list-numbering';

--- a/src/routes/(protected)/dashboard/admin/users/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/users/+page.svelte
@@ -22,7 +22,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import type { Database } from '$lib/types/database';
-	import { Upload, Save, RotateCcw, Loader2, Clock, Check, X } from 'lucide-svelte';
+	import { Upload, Save, RotateCcw, Loader2, Clock, Check, X } from '@lucide/svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { Switch } from '$lib/components/ui/switch';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';

--- a/src/routes/(protected)/dashboard/bug-reports/+page.svelte
+++ b/src/routes/(protected)/dashboard/bug-reports/+page.svelte
@@ -24,7 +24,7 @@
 		BugReportStatus
 	} from '$lib/types/bug-reports';
 	import BugReportStatusBadge from '$lib/components/bug-reports/BugReportStatusBadge.svelte';
-	import { Plus, Bug, Clock, CheckCircle, ArrowLeft } from 'lucide-svelte';
+	import { Plus, Bug, Clock, CheckCircle, ArrowLeft } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/dashboard/friends/+page.svelte
+++ b/src/routes/(protected)/dashboard/friends/+page.svelte
@@ -9,7 +9,7 @@
 	import * as Tabs from '$lib/components/ui/tabs';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Users, Bell, Plus } from 'lucide-svelte';
+	import { Users, Bell, Plus } from '@lucide/svelte';
 
 	let addFriendModalOpen = $state(false);
 

--- a/src/routes/(protected)/dashboard/notifications/+page.svelte
+++ b/src/routes/(protected)/dashboard/notifications/+page.svelte
@@ -15,7 +15,7 @@
 		formatDailySummaryFromMetadata,
 		isDailySummaryMetadata
 	} from '$lib/utils/notification-formatters';
-	import { Bell, Loader2 } from 'lucide-svelte';
+	import { Bell, Loader2 } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 

--- a/src/routes/(protected)/dashboard/profile/+page.svelte
+++ b/src/routes/(protected)/dashboard/profile/+page.svelte
@@ -23,7 +23,7 @@
 	import { fontSize } from '$lib/stores/fontSize.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { submitLogoutForm } from '$lib/utils/auth';
-	import { LogOut, Download, Loader2, Trash2, Sun, Moon, Minus, Plus } from 'lucide-svelte';
+	import { LogOut, Download, Loader2, Trash2, Sun, Moon, Minus, Plus } from '@lucide/svelte';
 
 	let { data }: { data: LayoutData } = $props();
 

--- a/src/routes/(protected)/dashboard/revisions/+page.svelte
+++ b/src/routes/(protected)/dashboard/revisions/+page.svelte
@@ -18,7 +18,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
-	import { Plus, BookOpen, Trophy, Target } from 'lucide-svelte';
+	import { Plus, BookOpen, Trophy, Target } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import type { Deck } from '$lib/srs/types';
 

--- a/src/routes/(protected)/dashboard/revisions/create/+page.svelte
+++ b/src/routes/(protected)/dashboard/revisions/create/+page.svelte
@@ -21,7 +21,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import CustomCardEditor from '$lib/components/srs/CustomCardEditor.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Save, Plus, Trash2, ArrowLeft, BookOpen } from 'lucide-svelte';
+	import { Save, Plus, Trash2, ArrowLeft, BookOpen } from '@lucide/svelte';
 	import { RETENTION_PROFILES } from '$lib/srs/config';
 	import type { CreateDeckRequest, CreateCardRequest } from '$lib/srs/types';
 	import type { TemplateMarkdown } from '$lib/ubumark';

--- a/src/routes/(protected)/dashboard/revisions/decks/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/revisions/decks/[id]/+page.svelte
@@ -16,7 +16,15 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Badge } from '$lib/components/ui/badge';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { ChevronLeft, Plus, PlayCircle, Pencil, Trash2, BookOpen, FileText } from 'lucide-svelte';
+	import {
+		ChevronLeft,
+		Plus,
+		PlayCircle,
+		Pencil,
+		Trash2,
+		BookOpen,
+		FileText
+	} from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { PageData } from './$types';
 	import type { DeckSection, DeckCardLite } from './+page.server';

--- a/src/routes/(protected)/dashboard/revisions/decks/[id]/study/+page.svelte
+++ b/src/routes/(protected)/dashboard/revisions/decks/[id]/study/+page.svelte
@@ -15,7 +15,7 @@
 	import { goto } from '$app/navigation';
 	import ReviewSession from '$lib/components/srs/ReviewSession.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	const deckId = $derived(page.params.id);
 	const states = $derived(page.url.searchParams.get('states') ?? undefined);

--- a/src/routes/(protected)/dashboard/revisions/decks/programme/+page.svelte
+++ b/src/routes/(protected)/dashboard/revisions/decks/programme/+page.svelte
@@ -19,7 +19,7 @@
 		ChevronLeft,
 		PlayCircle,
 		Target
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { ProgrammeBadge } from './+page.server';
 

--- a/src/routes/(protected)/dashboard/student/assessments/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/assessments/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import AssessmentCard from '$lib/components/assessments/AssessmentCard.svelte';
 	import * as Card from '$lib/components/ui/card';
-	import { FileQuestion } from 'lucide-svelte';
+	import { FileQuestion } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/student/assessments/[id]/results/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/assessments/[id]/results/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
-	import { ArrowLeft, TrendingUp, Target, Clock, Calendar } from 'lucide-svelte';
+	import { ArrowLeft, TrendingUp, Target, Clock, Calendar } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/student/cahier-texte/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/cahier-texte/+page.svelte
@@ -17,7 +17,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import { JournalDatePicker, HomeworkCard } from '$lib/components/journal';
-	import { BookOpen, Calendar, ClipboardList, ChevronRight } from 'lucide-svelte';
+	import { BookOpen, Calendar, ClipboardList, ChevronRight } from '@lucide/svelte';
 	import { GRADES, type GradeCode } from '$lib/types/grades';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/student/cahier-texte/[entryId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/cahier-texte/[entryId]/+page.svelte
@@ -24,7 +24,7 @@
 		Calendar,
 		User,
 		Clock
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/student/competences/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/competences/+page.svelte
@@ -4,7 +4,7 @@
 	 */
 
 	import * as Card from '$lib/components/ui/card';
-	import { Brain, ChevronRight } from 'lucide-svelte';
+	import { Brain, ChevronRight } from '@lucide/svelte';
 	import {
 		formatMathCompetenceLevel,
 		getMathCompetenceLevelVisual,

--- a/src/routes/(protected)/dashboard/student/competences/[code]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/competences/[code]/+page.svelte
@@ -6,7 +6,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { ChevronLeft, Check, Circle } from 'lucide-svelte';
+	import { ChevronLeft, Check, Circle } from '@lucide/svelte';
 	import {
 		formatMathCompetenceLevel,
 		getMathCompetenceLevelVisual,

--- a/src/routes/(protected)/dashboard/student/cours/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/cours/+page.svelte
@@ -11,7 +11,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { ChapterCard } from '$lib/components/cours';
-	import { Book, FolderOpen, GraduationCap } from 'lucide-svelte';
+	import { Book, FolderOpen, GraduationCap } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/student/cours/[chapterId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/cours/[chapterId]/+page.svelte
@@ -30,7 +30,7 @@
 		BookOpen,
 		BookMarked,
 		ClipboardList
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import WorksheetCard from '$lib/components/student/worksheets/WorksheetCard.svelte';
 	import type { PageData, ActionData } from './$types';
 

--- a/src/routes/(protected)/dashboard/student/devoirs/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/devoirs/+page.svelte
@@ -16,7 +16,7 @@
 		GraduationCap,
 		ChevronLeft,
 		ChevronRight
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/student/inventory/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/inventory/+page.svelte
@@ -16,7 +16,7 @@
 	import VipCard from '$lib/components/VipCard.svelte';
 	import VipCardSellModal from '$lib/components/vip-cards/VipCardSellModal.svelte';
 	import Badge from '$lib/components/ui/badge/badge.svelte';
-	import { Lock, Trophy, Sparkles, Gem } from 'lucide-svelte';
+	import { Lock, Trophy, Sparkles, Gem } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 	import type { VipCard as VipCardType, VipCardRarity, StudentVipCards } from '$lib/types/vip-card';
 	import type { CardCollectionStatus } from './+page.server';

--- a/src/routes/(protected)/dashboard/student/journal/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/journal/+page.svelte
@@ -14,7 +14,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Card from '$lib/components/ui/card';
-	import { BookOpen, RefreshCw, ChevronDown, AlertCircle, Inbox } from 'lucide-svelte';
+	import { BookOpen, RefreshCw, ChevronDown, AlertCircle, Inbox } from '@lucide/svelte';
 	import type { RewardType } from '$lib/types/reward-journal';
 
 	// Local state for filter

--- a/src/routes/(protected)/dashboard/student/marketplace/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/marketplace/+page.svelte
@@ -4,7 +4,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import ConsentButton from '$lib/components/ConsentButton.svelte';
-	import { Plus, ShoppingBag, Package, Store, Bell, RefreshCw } from 'lucide-svelte';
+	import { Plus, ShoppingBag, Package, Store, Bell, RefreshCw } from '@lucide/svelte';
 	import gidouilleImage from '$lib/assets/images/gidouille.png';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';
 

--- a/src/routes/(protected)/dashboard/student/marketplace/trade/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/marketplace/trade/[id]/+page.svelte
@@ -20,7 +20,7 @@
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { studentCache } from '$lib/stores/studentDashboardCache.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft, MessageCircle, X, Check, Pencil } from 'lucide-svelte';
+	import { ArrowLeft, MessageCircle, X, Check, Pencil } from '@lucide/svelte';
 
 	// Components
 	import TradeOfferPanel from '$lib/components/marketplace/trade/TradeOfferPanel.svelte';

--- a/src/routes/(protected)/dashboard/student/materials/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/materials/+page.svelte
@@ -11,14 +11,14 @@
 		FileText,
 		ExternalLink,
 		FolderOpen,
-		Youtube,
+		Video,
 		Link as LinkIcon,
 		FileQuestion,
 		ChevronLeft,
 		ChevronRight,
 		GraduationCap,
 		Tag
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -169,7 +169,7 @@
 	function getAttachmentIcon(
 		attachment: GroupedMaterial['material']['attachments'][0]
 	): typeof FileText {
-		if (attachment.material_type === 'YOUTUBE_VIDEO') return Youtube;
+		if (attachment.material_type === 'YOUTUBE_VIDEO') return Video;
 		if (attachment.material_type === 'LINK') return LinkIcon;
 		if (attachment.material_type === 'FORM') return FileQuestion;
 		return FileText;

--- a/src/routes/(protected)/dashboard/student/objectifs/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/objectifs/+page.svelte
@@ -12,7 +12,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { Target, Sparkles, CheckCircle2, Circle, LifeBuoy, ChevronRight } from 'lucide-svelte';
+	import { Target, Sparkles, CheckCircle2, Circle, LifeBuoy, ChevronRight } from '@lucide/svelte';
 	import {
 		formatObjectiveLevel,
 		getObjectiveLevelVisual,

--- a/src/routes/(protected)/dashboard/student/objectifs/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/objectifs/[id]/+page.svelte
@@ -21,7 +21,7 @@
 		Sparkles,
 		BookOpen,
 		MessageCircleQuestion
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { formatObjectiveLevel, getObjectiveLevelVisual } from '$lib/types/skills';
 	import CapacityFsrsBadge from '$lib/components/srs/CapacityFsrsBadge.svelte';
 	import type { PageData } from './$types';

--- a/src/routes/(protected)/dashboard/student/riddles/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/riddles/+page.svelte
@@ -9,7 +9,7 @@
 	import RiddleOfTheDayCard from '$lib/components/riddles/RiddleOfTheDayCard.svelte';
 	import RiddleCard from '$lib/components/riddles/RiddleCard.svelte';
 	import * as Card from '$lib/components/ui/card';
-	import { Sparkles, BookOpen } from 'lucide-svelte';
+	import { Sparkles, BookOpen } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 </script>

--- a/src/routes/(protected)/dashboard/student/riddles/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/riddles/[id]/+page.svelte
@@ -8,7 +8,7 @@
 	import type { PageData } from './$types';
 	import RiddleCard from '$lib/components/riddles/RiddleCard.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { goto as _goto } from '$app/navigation';
 	import { syncGidouilles } from '$lib/utils/cache-sync';

--- a/src/routes/(protected)/dashboard/student/riddles/archive/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/riddles/archive/+page.svelte
@@ -10,7 +10,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
-	import { History, ArrowLeft, Trophy, XCircle, Clock } from 'lucide-svelte';
+	import { History, ArrowLeft, Trophy, XCircle, Clock } from '@lucide/svelte';
 	import { format } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/routes/(protected)/dashboard/student/riddles/history/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/riddles/history/+page.svelte
@@ -14,7 +14,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Progress from '$lib/components/ui/progress';
-	import { BookOpen, ArrowLeft, Trophy, Target, Award } from 'lucide-svelte';
+	import { BookOpen, ArrowLeft, Trophy, Target, Award } from '@lucide/svelte';
 	import { format } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import { goto } from '$app/navigation';

--- a/src/routes/(protected)/dashboard/student/riddles/leaderboard/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/riddles/leaderboard/+page.svelte
@@ -10,7 +10,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { Trophy, ArrowLeft, Crown } from 'lucide-svelte';
+	import { Trophy, ArrowLeft, Crown } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/student/work/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/work/+page.svelte
@@ -17,7 +17,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Inbox, BookOpen, Code } from 'lucide-svelte';
+	import { Inbox, BookOpen, Code } from '@lucide/svelte';
 	import WorkInboxSection from '$lib/components/student-inbox/WorkInboxSection.svelte';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/student/worksheets/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/worksheets/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import WorksheetCard from '$lib/components/student/worksheets/WorksheetCard.svelte';
-	import { FileText, ChevronLeft, ChevronRight, Filter } from 'lucide-svelte';
+	import { FileText, ChevronLeft, ChevronRight, Filter } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/student/worksheets/[assignmentId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/student/worksheets/[assignmentId]/+page.svelte
@@ -6,7 +6,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { FileText, AlertTriangle, Star } from 'lucide-svelte';
+	import { FileText, AlertTriangle, Star } from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { MasteryStatus, ExerciseMasteryListResponse } from '$lib/types/exercise-mastery';
 	import type {

--- a/src/routes/(protected)/dashboard/teacher/assessments/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/assessments/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import { Plus } from 'lucide-svelte';
+	import { Plus } from '@lucide/svelte';
 	import AssessmentCard from '$lib/components/assessments/AssessmentCard.svelte';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/assessments/[id]/assign/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/assessments/[id]/assign/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Badge } from '$lib/components/ui/badge';
-	import { ArrowLeft, Users, Check, X } from 'lucide-svelte';
+	import { ArrowLeft, Users, Check, X } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/assessments/[id]/edit/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/assessments/[id]/edit/+page.svelte
@@ -3,7 +3,7 @@
 	import { enhance as _enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import AssessmentConfigForm from '$lib/components/assessments/AssessmentConfigForm.svelte';
 	import type { PageData } from './$types';

--- a/src/routes/(protected)/dashboard/teacher/assessments/[id]/results/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/assessments/[id]/results/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
-	import { ArrowLeft, TrendingUp, Users, CheckCircle2, Clock, AlertCircle } from 'lucide-svelte';
+	import { ArrowLeft, TrendingUp, Users, CheckCircle2, Clock, AlertCircle } from '@lucide/svelte';
 	import { getStatusColor, getStatusLabel } from '$lib/types/assessment';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/assessments/new/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/assessments/new/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowLeft, Check } from 'lucide-svelte';
+	import { ArrowLeft, Check } from '@lucide/svelte';
 	import { questionCart } from '$lib/stores/questionCart.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import AssessmentConfigForm from '$lib/components/assessments/AssessmentConfigForm.svelte';

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/+page.svelte
@@ -17,7 +17,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import JournalWeekGrid from '$lib/components/journal/JournalWeekGrid.svelte';
 	import JournalDatePicker from '$lib/components/journal/JournalDatePicker.svelte';
-	import { BookOpen, GraduationCap, Calendar } from 'lucide-svelte';
+	import { BookOpen, GraduationCap, Calendar } from '@lucide/svelte';
 	import { GRADES, type GradeCode } from '$lib/types/grades';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
@@ -32,7 +32,7 @@
 		Globe,
 		EyeOff,
 		Calendar
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
@@ -55,7 +55,7 @@
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
-	import { Mail, CheckCircle2, BookOpen, GraduationCap, Loader2, ScrollText } from 'lucide-svelte';
+	import { Mail, CheckCircle2, BookOpen, GraduationCap, Loader2, ScrollText } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/classes/[classId]/analytics/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/classes/[classId]/analytics/+page.svelte
@@ -11,7 +11,7 @@
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { ChevronLeft, RefreshCw, EyeOff, Eye } from 'lucide-svelte';
+	import { ChevronLeft, RefreshCw, EyeOff, Eye } from '@lucide/svelte';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { Button } from '$lib/components/ui/button';
 	import MySelect from '$lib/components/MySelect.svelte';

--- a/src/routes/(protected)/dashboard/teacher/competences/export/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/competences/export/+page.svelte
@@ -10,7 +10,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Download, Info } from 'lucide-svelte';
+	import { Download, Info } from '@lucide/svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { formatNiveau, type NiveauFormat } from '$lib/competences/niveau-format';

--- a/src/routes/(protected)/dashboard/teacher/consent/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/consent/+page.svelte
@@ -22,7 +22,7 @@
 		Edit2,
 		Save,
 		X
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/+layout.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import GroupedRouteLayout from '$lib/components/navigation/GroupedRouteLayout.svelte';
-	import { Layers, BookOpen, Lightbulb, FileSpreadsheet, NotebookPen } from 'lucide-svelte';
+	import { Layers, BookOpen, Lightbulb, FileSpreadsheet, NotebookPen } from '@lucide/svelte';
 	import type { Component } from 'svelte';
 
 	let { children } = $props();

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/+page.svelte
@@ -29,7 +29,7 @@
 		Eye,
 		FileCheck,
 		Lightbulb
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/of-the-day/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/of-the-day/+page.svelte
@@ -15,7 +15,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Alert from '$lib/components/ui/alert';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Sparkles, Calendar, History, Trash2, Plus } from 'lucide-svelte';
+	import { Sparkles, Calendar, History, Trash2, Plus } from '@lucide/svelte';
 	import { format } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 	import { enhance } from '$app/forms';

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/stats/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/stats/+page.svelte
@@ -10,7 +10,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { BarChart3, Trophy, Users, Target, TrendingUp, FileCheck } from 'lucide-svelte';
+	import { BarChart3, Trophy, Users, Target, TrendingUp, FileCheck } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/+page.svelte
@@ -16,7 +16,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
-	import { Clock, FileCheck } from 'lucide-svelte';
+	import { Clock, FileCheck } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/[id]/+page.svelte
@@ -20,7 +20,7 @@
 	import * as Alert from '$lib/components/ui/alert';
 	import { MarkdownRenderer } from '$lib/components/markdown';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { CheckCircle2, XCircle, AlertTriangle, ArrowLeft } from 'lucide-svelte';
+	import { CheckCircle2, XCircle, AlertTriangle, ArrowLeft } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/exercices/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/exercices/+page.svelte
@@ -14,7 +14,7 @@
 	import ExerciseDisplay from '$lib/components/exercises/ExerciseDisplay.svelte';
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';
 	import GradeBadgeSelector from '$lib/components/GradeBadgeSelector.svelte';
-	import { Send, Pencil, Trash2, Loader2, ArrowUp, ArrowDown, Eye, Globe } from 'lucide-svelte';
+	import { Send, Pencil, Trash2, Loader2, ArrowUp, ArrowDown, Eye, Globe } from '@lucide/svelte';
 	import type { Exercise, ExerciseCategory } from '$lib/exercises/types';
 	import { EXERCISE_CATEGORIES } from '$lib/exercises/types';
 	import type { PageData } from './$types';

--- a/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.svelte
@@ -24,7 +24,7 @@
 		Globe,
 		Download,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { generateExerciseTypst } from '$lib/exercises/typst/exercise-typst-generator';
 	import { getTypstService, PRIORITY } from '$lib/typst/service';
 	import {

--- a/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/assign/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/assign/+page.svelte
@@ -12,7 +12,7 @@
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { formatUserError } from '$lib/utils/errors';
 	import { formatDeadlineFull } from '$lib/utils/dates';
-	import { ArrowLeft, Users, User, Globe, X, Calendar } from 'lucide-svelte';
+	import { ArrowLeft, Users, User, Globe, X, Calendar } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/teacher/contenu/notebooks/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/notebooks/+page.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { PlusCircle, Trash2, BookOpen, BarChart3, Sparkles } from 'lucide-svelte';
+	import { PlusCircle, Trash2, BookOpen, BarChart3, Sparkles } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/teacher/contenu/notebooks/templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/notebooks/templates/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 	import TemplateGallery from '$lib/components/notebook/templates/TemplateGallery.svelte';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/templates/+page.svelte
@@ -18,7 +18,7 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card';
-	import { Plus, Search, FileText, HelpCircle, CheckSquare, BookOpen } from 'lucide-svelte';
+	import { Plus, Search, FileText, HelpCircle, CheckSquare, BookOpen } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/teacher/contenu/templates/[templateId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/templates/[templateId]/+page.svelte
@@ -34,7 +34,7 @@
 		Archive,
 		PlayCircle,
 		Clock
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { getContentCounts } from '$lib/types/chapter-templates';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();

--- a/src/routes/(protected)/dashboard/teacher/contenu/templates/new/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/templates/new/+page.svelte
@@ -21,7 +21,7 @@
 	} from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	let { form }: { form: ActionData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/+page.svelte
@@ -21,7 +21,7 @@
 		HelpCircle,
 		Home,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { WorksheetType, WorksheetStatus } from '$lib/types/worksheets';
 	import { formatGradeShort } from '$lib/utils/grades';

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/+page.svelte
@@ -30,7 +30,7 @@
 		UserPlus,
 		AlertCircle,
 		Eye
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type {
 		WorksheetWithRelations,

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/preview/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/preview/+page.svelte
@@ -41,7 +41,7 @@
 		Download,
 		Pencil,
 		Star
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type {
 		StudentWorksheetView,

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/reports/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/reports/+page.svelte
@@ -14,7 +14,7 @@
 	import type { PageData } from './$types';
 	import { Button } from '$lib/components/ui/button';
 	import ErrorReportsPanel from '$lib/components/worksheets/teacher/ErrorReportsPanel.svelte';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/reports/[reportId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/[id]/assignments/[assignmentId]/reports/[reportId]/+page.svelte
@@ -30,7 +30,7 @@
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, Check, X, Loader2, AlertTriangle } from 'lucide-svelte';
+	import { ArrowLeft, Check, X, Loader2, AlertTriangle } from '@lucide/svelte';
 	import type { ExerciseVariation } from '$lib/exercises/types';
 
 	// Types

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/new/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/new/+page.svelte
@@ -12,7 +12,7 @@
 	import TagBadgeSelector from '$lib/components/TagBadgeSelector.svelte';
 	import TemplateSelector from '$lib/components/worksheets/TemplateSelector.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, ChevronDown, ChevronUp, Loader2, Save, FileText } from 'lucide-svelte';
+	import { ArrowLeft, ChevronDown, ChevronUp, Loader2, Save, FileText } from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type {
 		WorksheetType,

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/templates/+page.svelte
@@ -22,7 +22,7 @@
 		Lock,
 		Sparkles,
 		Loader2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 	import type { DefaultTemplate } from '$lib/worksheets/default-templates';
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/worksheets/templates/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/worksheets/templates/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, Save, Loader2, Globe, Lock } from 'lucide-svelte';
+	import { ArrowLeft, Save, Loader2, Globe, Lock } from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 	import TypstEditor from '$lib/components/worksheets/TypstEditor.svelte';
 	import { COMMON_PLACEHOLDERS, STANDARD_TEMPLATE } from '$lib/worksheets/default-templates';

--- a/src/routes/(protected)/dashboard/teacher/cours/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cours/+page.svelte
@@ -12,7 +12,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { ChapterCard } from '$lib/components/cours';
-	import { Book, FolderOpen, GraduationCap, Plus, EyeOff } from 'lucide-svelte';
+	import { Book, FolderOpen, GraduationCap, Plus, EyeOff } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/cours/[classId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cours/[classId]/+page.svelte
@@ -40,7 +40,7 @@
 		ClipboardList,
 		Dumbbell,
 		Copy
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 	import type { TemplateSummary } from '$lib/types/chapter-templates';
 

--- a/src/routes/(protected)/dashboard/teacher/cours/[classId]/[chapterId]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cours/[classId]/[chapterId]/+page.svelte
@@ -42,7 +42,7 @@
 		BookMarked,
 		Eye,
 		EyeOff
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/documents/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/documents/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { DocumentManager } from '$lib/components/documents';
-	import { FileText } from 'lucide-svelte';
+	import { FileText } from '@lucide/svelte';
 </script>
 
 <svelte:head>

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/+page.svelte
@@ -9,7 +9,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { ClipboardList, Plus, ChevronRight, Calendar, Users } from 'lucide-svelte';
+	import { ClipboardList, Plus, ChevronRight, Calendar, Users } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/+page.svelte
@@ -12,7 +12,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { ChevronLeft, ClipboardList, Save, Trash2, PenLine } from 'lucide-svelte';
+	import { ChevronLeft, ClipboardList, Save, Trash2, PenLine } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { PageData, ActionData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/saisie/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/saisie/+page.svelte
@@ -11,7 +11,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
-	import { ChevronLeft, Save, Check } from 'lucide-svelte';
+	import { ChevronLeft, Save, Check } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { PageData, ActionData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/new/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/new/+page.svelte
@@ -9,7 +9,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { ChevronLeft, ClipboardList } from 'lucide-svelte';
+	import { ChevronLeft, ClipboardList } from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/gamification/+layout.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import GroupedRouteLayout from '$lib/components/navigation/GroupedRouteLayout.svelte';
-	import { Gift, Sparkles, ShoppingBag, Users } from 'lucide-svelte';
+	import { Gift, Sparkles, ShoppingBag, Users } from '@lucide/svelte';
 	import type { LayoutData } from './$types';
 	import type { Component, Snippet } from 'svelte';
 

--- a/src/routes/(protected)/dashboard/teacher/gamification/buddies/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/buddies/+page.svelte
@@ -10,7 +10,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Star, Flame, ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { Star, Flame, ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { xpProgress, MAX_LEVEL } from '$lib/utils/buddy-xp';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/teacher/gamification/marketplace/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/marketplace/+page.svelte
@@ -50,7 +50,7 @@
 		Package,
 		BarChart3,
 		ArrowLeftRight
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/dashboard/teacher/gamification/rewards/ActivationRequestsTab.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/rewards/ActivationRequestsTab.svelte
@@ -33,7 +33,7 @@
 		Loader2,
 		Check,
 		X
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import {
 		vipCardTemplates,
 		getTemplateById,

--- a/src/routes/(protected)/dashboard/teacher/gamification/rewards/GidouillesTab.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/rewards/GidouillesTab.svelte
@@ -15,7 +15,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { getStudentCardCounts } from '$lib/utils/vip-cards';

--- a/src/routes/(protected)/dashboard/teacher/gamification/rewards/StudentRewardRow.svelte
+++ b/src/routes/(protected)/dashboard/teacher/gamification/rewards/StudentRewardRow.svelte
@@ -18,7 +18,7 @@
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { canAffordVipCard } from '$lib/utils/vip-cards';
-	import { Sparkles, Eye, Loader2, Plus, Star } from 'lucide-svelte';
+	import { Sparkles, Eye, Loader2, Plus, Star } from '@lucide/svelte';
 	import { getTemplateById, vipCardTemplates } from '$lib/stores/vipCardTemplates.svelte';
 	import gidouilleImg from '$lib/assets/images/gidouille.png';
 

--- a/src/routes/(protected)/dashboard/teacher/google/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/google/+page.svelte
@@ -55,7 +55,7 @@
 		FileVideo,
 		Link2,
 		File
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import ShareCourseworkDialog from '$lib/components/google/ShareCourseworkDialog.svelte';
 	import ManageSharedCourseworkDialog from '$lib/components/google/ManageSharedCourseworkDialog.svelte';

--- a/src/routes/(protected)/dashboard/teacher/message-templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/message-templates/+page.svelte
@@ -24,7 +24,7 @@
 		ChevronDown,
 		ChevronUp,
 		Eye
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type {
 		MessageTemplate,

--- a/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/+page.svelte
@@ -10,7 +10,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import { Plus, Calendar, Users, Trophy, Clock } from 'lucide-svelte';
+	import { Plus, Calendar, Users, Trophy, Clock } from '@lucide/svelte';
 	import { DIFFICULTY_LABELS, type TournamentStatus } from '$lib/types/minesweeper';
 	import type { PageData } from './$types';
 	import type { TournamentWithCount } from './+page.server';

--- a/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/[id]/+page.svelte
@@ -13,7 +13,7 @@
 	import * as Alert from '$lib/components/ui/alert';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, Users, Trophy, RefreshCw, XCircle, AlertTriangle } from 'lucide-svelte';
+	import { ArrowLeft, Users, Trophy, RefreshCw, XCircle, AlertTriangle } from '@lucide/svelte';
 	import { DIFFICULTY_LABELS, type TournamentStatus } from '$lib/types/minesweeper';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/new/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/minesweeper/tournaments/new/+page.svelte
@@ -16,7 +16,7 @@
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, AlertTriangle, Trophy } from 'lucide-svelte';
+	import { ArrowLeft, AlertTriangle, Trophy } from '@lucide/svelte';
 	import { DIFFICULTY_LABELS, type Difficulty } from '$lib/types/minesweeper';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/moderation/+layout.svelte
+++ b/src/routes/(protected)/dashboard/teacher/moderation/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import GroupedRouteLayout from '$lib/components/navigation/GroupedRouteLayout.svelte';
-	import { AlertTriangle, ShieldAlert } from 'lucide-svelte';
+	import { AlertTriangle, ShieldAlert } from '@lucide/svelte';
 	import type { LayoutData } from './$types';
 	import type { Component, Snippet } from 'svelte';
 

--- a/src/routes/(protected)/dashboard/teacher/moderation/avertissements/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/moderation/avertissements/+page.svelte
@@ -46,7 +46,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Separator } from '$lib/components/ui/separator';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { History, AlertCircle, Plus } from 'lucide-svelte';
+	import { History, AlertCircle, Plus } from '@lucide/svelte';
 	import type { StudentWarningCounts } from '$lib/server/warnings';
 	import { getWarningTypeLabel } from '$lib/types/warnings';
 	import { teacherCache } from '$lib/stores/teacherDashboardCache.svelte';

--- a/src/routes/(protected)/dashboard/teacher/moderation/gestion/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/moderation/gestion/+page.svelte
@@ -22,7 +22,7 @@
 	import ModerationLogsTable from '$lib/components/moderation/ModerationLogsTable.svelte';
 	import MessageReportsTable from '$lib/components/moderation/MessageReportsTable.svelte';
 	import RestrictUserDialog from '$lib/components/moderation/RestrictUserDialog.svelte';
-	import { ShieldAlert, Flag, UserX } from 'lucide-svelte';
+	import { ShieldAlert, Flag, UserX } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	// Page Props

--- a/src/routes/(protected)/dashboard/teacher/notifications/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/notifications/+page.svelte
@@ -8,7 +8,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Separator } from '$lib/components/ui/separator';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Plus, Trash2, Send } from 'lucide-svelte';
+	import { Plus, Trash2, Send } from '@lucide/svelte';
 	import {
 		NOTIFICATION_TYPE_LABELS,
 		NOTIFICATION_PRIORITY_LABELS,

--- a/src/routes/(protected)/dashboard/teacher/presques-evaluations/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/presques-evaluations/+page.svelte
@@ -9,7 +9,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import GradeBadgeSelector from '$lib/components/GradeBadgeSelector.svelte';
 	import TagBadgeSelector from '$lib/components/TagBadgeSelector.svelte';
-	import { FileText, Upload, Pencil, Trash2, Calendar, User, Loader2, Eye } from 'lucide-svelte';
+	import { FileText, Upload, Pencil, Trash2, Calendar, User, Loader2, Eye } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { formatGradeShort } from '$lib/utils/grades';
 	import { GRADE_CODES, type GradeCode } from '$lib/types/grades';

--- a/src/routes/(protected)/dashboard/teacher/srs/decks/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/srs/decks/+page.svelte
@@ -31,7 +31,7 @@
 		Sparkles,
 		Lock,
 		Users
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { Deck } from '$lib/srs/types';
 
 	interface Props {

--- a/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/assign/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/assign/+page.svelte
@@ -20,7 +20,7 @@
 	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
 	import { Badge } from '$lib/components/ui/badge';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft, Users, UserCheck, Send, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Users, UserCheck, Send, Loader2 } from '@lucide/svelte';
 	import type { AssignDeckRequest, FSRSConfig } from '$lib/srs/types';
 
 	interface Student {

--- a/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/assignments/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/assignments/+page.svelte
@@ -27,7 +27,7 @@
 		RefreshCw,
 		Calendar,
 		Target
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	interface Student {

--- a/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/edit/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/srs/decks/[id]/edit/+page.svelte
@@ -22,7 +22,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import CustomCardEditor from '$lib/components/srs/CustomCardEditor.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Save, Plus, Trash2, ArrowLeft, Sparkles, BookOpen } from 'lucide-svelte';
+	import { Save, Plus, Trash2, ArrowLeft, Sparkles, BookOpen } from '@lucide/svelte';
 	import { RETENTION_PROFILES } from '$lib/srs/config';
 	import type { FSRSConfig } from '$lib/srs/types';
 	import type { TemplateMarkdown } from '$lib/ubumark';

--- a/src/routes/(protected)/dashboard/teacher/srs/decks/create/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/srs/decks/create/+page.svelte
@@ -23,7 +23,7 @@
 	import CustomCardEditor from '$lib/components/srs/CustomCardEditor.svelte';
 	import TemplateSelector from '$lib/components/srs/TemplateSelector.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Save, Plus, Trash2, BookOpen, ArrowLeft } from 'lucide-svelte';
+	import { Save, Plus, Trash2, BookOpen, ArrowLeft } from '@lucide/svelte';
 	import { RETENTION_PROFILES } from '$lib/srs/config';
 	import type { CreateDeckRequest, CreateCardRequest } from '$lib/srs/types';
 	import type { TemplateMarkdown } from '$lib/ubumark';

--- a/src/routes/(protected)/dashboard/teacher/students/[studentId]/journal/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/students/[studentId]/journal/+page.svelte
@@ -34,7 +34,7 @@
 		ChevronLeft,
 		ChevronRight,
 		Users
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { RewardType } from '$lib/types/reward-journal';
 	import type { PageData } from './$types';
 

--- a/src/routes/(protected)/dashboard/teacher/welcome-email/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/welcome-email/+page.svelte
@@ -17,7 +17,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Alert from '$lib/components/ui/alert';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Mail, AlertTriangle, CheckCircle2, ExternalLink, Send } from 'lucide-svelte';
+	import { Mail, AlertTriangle, CheckCircle2, ExternalLink, Send } from '@lucide/svelte';
 	import { WELCOME_EMAIL_SUBJECT, getWelcomeEmailText } from '$lib/email-templates/welcome';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(protected)/dashboard/tutor-stats/+page.svelte
+++ b/src/routes/(protected)/dashboard/tutor-stats/+page.svelte
@@ -18,7 +18,7 @@
 		Target,
 		HelpCircle,
 		RefreshCw
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data }: { data: PageData } = $props();
 

--- a/src/routes/(protected)/games/leaderboards/+page.svelte
+++ b/src/routes/(protected)/games/leaderboards/+page.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { Card } from '$lib/components/ui/card';
 	import { Separator } from '$lib/components/ui/separator';
-	import { Trophy } from 'lucide-svelte';
+	import { Trophy } from '@lucide/svelte';
 	import UnifiedLeaderboardTable from '$lib/components/game/leaderboard/UnifiedLeaderboardTable.svelte';
 	import MinesweeperDetailTable from '$lib/components/game/leaderboard/MinesweeperDetailTable.svelte';
 	import { LEADERBOARD_GAMES, LEADERBOARD_SCOPES, gameLabel } from '$lib/games/leaderboards';

--- a/src/routes/(protected)/messages/+layout.svelte
+++ b/src/routes/(protected)/messages/+layout.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { privateMessages } from '$lib/stores/privateMessages.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Inbox, Send, PencilLine, Archive, Trash2, Menu } from 'lucide-svelte';
+	import { Inbox, Send, PencilLine, Archive, Trash2, Menu } from '@lucide/svelte';
 	import MobileNavDrawer, { type NavItem } from '$lib/components/navigation/MobileNavDrawer.svelte';
 	import type { Snippet } from 'svelte';
 

--- a/src/routes/(protected)/messages/[id]/+page.svelte
+++ b/src/routes/(protected)/messages/[id]/+page.svelte
@@ -19,7 +19,7 @@
 		FileAudio,
 		File,
 		Paperclip
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';

--- a/src/routes/(protected)/messages/archived/+page.svelte
+++ b/src/routes/(protected)/messages/archived/+page.svelte
@@ -15,7 +15,7 @@
 		X,
 		Eye,
 		EyeOff
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { cn } from '$lib/utils';

--- a/src/routes/(protected)/messages/compose/+page.svelte
+++ b/src/routes/(protected)/messages/compose/+page.svelte
@@ -5,7 +5,17 @@
 	import { Label } from '$lib/components/ui/label';
 	import RichTextEditor from '$lib/components/rich-text/RichTextEditor.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
-	import { Loader2, Send, X, Save, Check, Paperclip, FileIcon, Trash2, Reply } from 'lucide-svelte';
+	import {
+		Loader2,
+		Send,
+		X,
+		Save,
+		Check,
+		Paperclip,
+		FileIcon,
+		Trash2,
+		Reply
+	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';

--- a/src/routes/(protected)/messages/drafts/+page.svelte
+++ b/src/routes/(protected)/messages/drafts/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { privateMessages } from '$lib/stores/privateMessages.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2, FileEdit, Trash2, PencilLine } from 'lucide-svelte';
+	import { Loader2, FileEdit, Trash2, PencilLine } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 

--- a/src/routes/(protected)/messages/inbox/+page.svelte
+++ b/src/routes/(protected)/messages/inbox/+page.svelte
@@ -15,7 +15,7 @@
 		X,
 		Eye,
 		EyeOff
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { cn } from '$lib/utils';

--- a/src/routes/(protected)/messages/sent/+page.svelte
+++ b/src/routes/(protected)/messages/sent/+page.svelte
@@ -2,7 +2,7 @@
 	import { privateMessages } from '$lib/stores/privateMessages.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Loader2, Send, PencilLine, MessageSquare, Search, X } from 'lucide-svelte';
+	import { Loader2, Send, PencilLine, MessageSquare, Search, X } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 

--- a/src/routes/(protected)/messages/thread/[id]/+page.svelte
+++ b/src/routes/(protected)/messages/thread/[id]/+page.svelte
@@ -14,7 +14,7 @@
 		FileVideo,
 		FileAudio,
 		File
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import RichTextDisplay from '$lib/components/rich-text/RichTextDisplay.svelte';

--- a/src/routes/(protected)/organisation/+layout.svelte
+++ b/src/routes/(protected)/organisation/+layout.svelte
@@ -12,7 +12,7 @@
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
-	import { LayoutDashboard } from 'lucide-svelte';
+	import { LayoutDashboard } from '@lucide/svelte';
 
 	let { children }: { children: Snippet } = $props();
 

--- a/src/routes/(protected)/organisation/kanban/+page.svelte
+++ b/src/routes/(protected)/organisation/kanban/+page.svelte
@@ -16,7 +16,7 @@
 	import { resolve } from '$app/paths';
 	import { formatDistanceToNow } from 'date-fns';
 	import { fr } from 'date-fns/locale';
-	import { Plus, MoreVertical, Trash2, LayoutDashboard, Users, User } from 'lucide-svelte';
+	import { Plus, MoreVertical, Trash2, LayoutDashboard, Users, User } from '@lucide/svelte';
 
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';

--- a/src/routes/(protected)/organisation/kanban/[boardId]/+page.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/+page.svelte
@@ -36,8 +36,8 @@
 	} from 'svelte-dnd-action';
 	import { flip } from 'svelte/animate';
 	import { resolve } from '$app/paths';
-	import { ArrowLeft, Plus, Users, User } from 'lucide-svelte';
-	import { Filter, Tag } from 'lucide-svelte';
+	import { ArrowLeft, Plus, Users, User } from '@lucide/svelte';
+	import { Filter, Tag } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';

--- a/src/routes/(protected)/organisation/kanban/[boardId]/CardEditDialog.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/CardEditDialog.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <script lang="ts">
-	import { Trash2 } from 'lucide-svelte';
+	import { Trash2 } from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { ConfirmDialog } from '$lib/components/ui/confirm-dialog';

--- a/src/routes/(protected)/organisation/kanban/[boardId]/CardEditForm.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/CardEditForm.svelte
@@ -13,7 +13,7 @@
 -->
 
 <script lang="ts">
-	import { CalendarDays, Settings2, X } from 'lucide-svelte';
+	import { CalendarDays, Settings2, X } from '@lucide/svelte';
 	import { CalendarDate, type DateValue } from '@internationalized/date';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';

--- a/src/routes/(protected)/organisation/kanban/[boardId]/KanbanCard.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/KanbanCard.svelte
@@ -20,7 +20,7 @@
 -->
 
 <script lang="ts">
-	import { CalendarDays, ChevronDown } from 'lucide-svelte';
+	import { CalendarDays, ChevronDown } from '@lucide/svelte';
 	import * as Card from '$lib/components/ui/card';
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import type {

--- a/src/routes/(protected)/organisation/kanban/[boardId]/KanbanColumn.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/KanbanColumn.svelte
@@ -26,7 +26,7 @@
 		type DndEvent
 	} from 'svelte-dnd-action';
 	import { flip } from 'svelte/animate';
-	import { MoreVertical, Plus, Trash2 } from 'lucide-svelte';
+	import { MoreVertical, Plus, Trash2 } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';

--- a/src/routes/(protected)/organisation/kanban/[boardId]/ManageTagsDialog.svelte
+++ b/src/routes/(protected)/organisation/kanban/[boardId]/ManageTagsDialog.svelte
@@ -16,7 +16,7 @@
 -->
 
 <script lang="ts">
-	import { Plus, Trash2, Check } from 'lucide-svelte';
+	import { Plus, Trash2, Check } from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';

--- a/src/routes/(protected)/organisation/pomodoro/PomodoroControls.svelte
+++ b/src/routes/(protected)/organisation/pomodoro/PomodoroControls.svelte
@@ -7,7 +7,7 @@
 -->
 
 <script lang="ts">
-	import { Play, Pause, SkipForward, RotateCcw } from 'lucide-svelte';
+	import { Play, Pause, SkipForward, RotateCcw } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { ConfirmDialog } from '$lib/components/ui/confirm-dialog';
 	import { pomodoroStore } from '$lib/stores/pomodoro/pomodoro.svelte';

--- a/src/routes/(protected)/organisation/pomodoro/PomodoroSettings.svelte
+++ b/src/routes/(protected)/organisation/pomodoro/PomodoroSettings.svelte
@@ -11,7 +11,7 @@
 -->
 
 <script lang="ts">
-	import { ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { pomodoroStore } from '$lib/stores/pomodoro/pomodoro.svelte';

--- a/src/routes/(protected)/python-notebook/+page.svelte
+++ b/src/routes/(protected)/python-notebook/+page.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { PlusCircle, Trash2, ExternalLink, BookOpen } from 'lucide-svelte';
+	import { PlusCircle, Trash2, ExternalLink, BookOpen } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/python-notebook/[id]/+page.svelte
+++ b/src/routes/(protected)/python-notebook/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import NotebookView from '$lib/components/notebook/NotebookView.svelte';
 	import ShareNotebookDialog from '$lib/components/notebook/ShareNotebookDialog.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft, Share2, BarChart3, Eye, Pencil } from 'lucide-svelte';
+	import { ArrowLeft, Share2, BarChart3, Eye, Pencil } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/python-notebook/[id]/present/+page.svelte
+++ b/src/routes/(protected)/python-notebook/[id]/present/+page.svelte
@@ -24,7 +24,7 @@
 	import { Deck, Slide, UbuMarkSlide } from '$lib/slides';
 	import { NotebookStore } from '$lib/stores/notebookStore.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowLeft, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Loader2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import NotebookCodeSlide from '$lib/components/notebook/presentation/NotebookCodeSlide.svelte';
 	import NotebookCheckpointSlide from '$lib/components/notebook/presentation/NotebookCheckpointSlide.svelte';

--- a/src/routes/(protected)/python-notebook/[id]/results/+page.svelte
+++ b/src/routes/(protected)/python-notebook/[id]/results/+page.svelte
@@ -13,7 +13,7 @@
 		CircleDashed,
 		Sparkles,
 		Lightbulb
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { CheckpointDetail } from '$lib/types/database-helpers';
 

--- a/src/routes/(protected)/spreadsheet/+page.svelte
+++ b/src/routes/(protected)/spreadsheet/+page.svelte
@@ -15,7 +15,7 @@
 	import { goto } from '$app/navigation';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import { Plus, FileSpreadsheet, Trash2, Calendar } from 'lucide-svelte';
+	import { Plus, FileSpreadsheet, Trash2, Calendar } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(protected)/spreadsheet/[id]/+page.svelte
+++ b/src/routes/(protected)/spreadsheet/[id]/+page.svelte
@@ -16,7 +16,7 @@
 	import { spreadsheetStore } from '$lib/spreadsheet/store.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import { ArrowLeft, Save, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Save, Loader2 } from '@lucide/svelte';
 
 	let { data } = $props();
 

--- a/src/routes/(public)/auth/login/+page.svelte
+++ b/src/routes/(public)/auth/login/+page.svelte
@@ -27,7 +27,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import * as Card from '$lib/components/ui/card';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2 } from '@lucide/svelte';
 
 	// Form action result (contains error if login failed)
 	let { form }: { form: ActionData } = $props();

--- a/src/routes/(public)/auth/pending-approval/+page.svelte
+++ b/src/routes/(public)/auth/pending-approval/+page.svelte
@@ -8,7 +8,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Clock } from 'lucide-svelte';
+	import { Clock } from '@lucide/svelte';
 
 	let isLoggingOut = $state(false);
 	let dialogOpen = $state(true);

--- a/src/routes/(public)/automaths/panier/+page.svelte
+++ b/src/routes/(public)/automaths/panier/+page.svelte
@@ -10,7 +10,7 @@
 		Rocket,
 		Share2,
 		ClipboardList
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { questionCart } from '$lib/stores/questionCart.svelte';
 	import { questionTemplatesCache } from '$lib/stores/questionTemplates.svelte';
 	import CartQuestionCard from '$lib/components/CartQuestionCard.svelte';

--- a/src/routes/(public)/automaths/test/+page.svelte
+++ b/src/routes/(public)/automaths/test/+page.svelte
@@ -8,7 +8,7 @@
 	import type { CartItem } from '$lib/stores/questionCart.svelte';
 	import type { QuestionInstance } from '$lib/questions/types';
 	import type { TestMode, TestSession } from '$lib/types/test';
-	import { AlertCircle } from 'lucide-svelte';
+	import { AlertCircle } from '@lucide/svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 

--- a/src/routes/(public)/consent/[token]/+page.svelte
+++ b/src/routes/(public)/consent/[token]/+page.svelte
@@ -2,7 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
-	import { AlertCircle, CheckCircle2, Clock, GraduationCap, School, User } from 'lucide-svelte';
+	import { AlertCircle, CheckCircle2, Clock, GraduationCap, School, User } from '@lucide/svelte';
 
 	let { data, form } = $props();
 

--- a/src/routes/(public)/consent/success/+page.svelte
+++ b/src/routes/(public)/consent/success/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { CheckCircle2, ExternalLink } from 'lucide-svelte';
+	import { CheckCircle2, ExternalLink } from '@lucide/svelte';
 </script>
 
 <svelte:head>

--- a/src/routes/(public)/demo/+page.svelte
+++ b/src/routes/(public)/demo/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
-	import { Sparkles, Palette, FileText, Gamepad2, Presentation, Circle } from 'lucide-svelte';
+	import { Sparkles, Palette, FileText, Gamepad2, Presentation, Circle } from '@lucide/svelte';
 	import MathField from '$lib/components/MathField.svelte';
 	import DynamicMathField from '$lib/components/DynamicMathField.svelte';
 	import FlipCard from '$lib/components/FlipCard.svelte';

--- a/src/routes/(public)/demo/question-display-demo/+page.svelte
+++ b/src/routes/(public)/demo/question-display-demo/+page.svelte
@@ -15,7 +15,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import * as Card from '$lib/components/ui/card';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 
 	// Sample question instances
 	const numericalQuestion: QuestionInstance = {

--- a/src/routes/(public)/demo/theme-test/+page.svelte
+++ b/src/routes/(public)/demo/theme-test/+page.svelte
@@ -19,7 +19,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import { theme } from '$lib/stores/theme.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
-	import { Info, Copy, Search } from 'lucide-svelte';
+	import { Info, Copy, Search } from '@lucide/svelte';
 
 	let progressValue = $state(60);
 	let sliderValue = $state([50]);

--- a/src/routes/(public)/demo/trig-circle-demo/+page.svelte
+++ b/src/routes/(public)/demo/trig-circle-demo/+page.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
 	import MarkdownRenderer from '$lib/components/markdown/MarkdownRenderer.svelte';
 	import * as Card from '$lib/components/ui/card';
-	import { Circle } from 'lucide-svelte';
+	import { Circle } from '@lucide/svelte';
 
 	// Demo examples with different configurations
 	const examples = [

--- a/src/routes/(public)/exercice/[slug]/+page.svelte
+++ b/src/routes/(public)/exercice/[slug]/+page.svelte
@@ -32,12 +32,12 @@
 	import TutorDrawer from '$lib/components/student/worksheets/TutorDrawer.svelte';
 
 	// Icons
-	import Check from 'lucide-svelte/icons/check';
-	import RefreshCw from 'lucide-svelte/icons/refresh-cw';
-	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
-	import Link from 'lucide-svelte/icons/link';
-	import Download from 'lucide-svelte/icons/download';
-	import Loader2 from 'lucide-svelte/icons/loader-2';
+	import Check from '@lucide/svelte/icons/check';
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import Link from '@lucide/svelte/icons/link';
+	import Download from '@lucide/svelte/icons/download';
+	import Loader2 from '@lucide/svelte/icons/loader-2';
 
 	let { data }: { data: PageData } = $props();
 	// svelte-ignore state_referenced_locally

--- a/src/routes/(public)/games/+page.svelte
+++ b/src/routes/(public)/games/+page.svelte
@@ -3,7 +3,7 @@
 		// Sword,
 		Lock
 		// Target
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(public)/games/2048/+page.svelte
+++ b/src/routes/(public)/games/2048/+page.svelte
@@ -6,7 +6,7 @@
 	import Game2048 from './Game2048.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Trophy } from 'lucide-svelte';
+	import { Trophy } from '@lucide/svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();

--- a/src/routes/(public)/games/mathemo/+page.svelte
+++ b/src/routes/(public)/games/mathemo/+page.svelte
@@ -26,7 +26,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { Trophy, Lightbulb, Undo2, Eye, Zap } from 'lucide-svelte';
+	import { Trophy, Lightbulb, Undo2, Eye, Zap } from '@lucide/svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import type { PageData } from './$types';
 

--- a/src/routes/(public)/games/trio/Trio.svelte
+++ b/src/routes/(public)/games/trio/Trio.svelte
@@ -13,7 +13,7 @@
 	 */
 
 	import Tile from './Tile.svelte';
-	import { X, Plus, Minus, HelpCircle } from 'lucide-svelte';
+	import { X, Plus, Minus, HelpCircle } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import confetti from 'canvas-confetti';
 	import { untrack } from 'svelte';

--- a/src/routes/(public)/glossaire/+page.svelte
+++ b/src/routes/(public)/glossaire/+page.svelte
@@ -11,7 +11,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { Search, BookOpen, RotateCcw } from 'lucide-svelte';
+	import { Search, BookOpen, RotateCcw } from '@lucide/svelte';
 
 	// ===== Constants =====
 

--- a/src/routes/(public)/pere-ubu/+page.svelte
+++ b/src/routes/(public)/pere-ubu/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ChatBot from '$lib/components/ChatBot.svelte';
-	import { ArrowLeft } from 'lucide-svelte';
+	import { ArrowLeft } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import pereUbuImage from '$lib/assets/images/pereubu.png';
 

--- a/src/routes/(public)/presques-evaluations/+page.svelte
+++ b/src/routes/(public)/presques-evaluations/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import GradeBadgeSelector from '$lib/components/GradeBadgeSelector.svelte';
 	import TagBadgeSelector from '$lib/components/TagBadgeSelector.svelte';
-	import { FileText, Eye, Download, Calendar, User, X } from 'lucide-svelte';
+	import { FileText, Eye, Download, Calendar, User, X } from '@lucide/svelte';
 	import { formatGradeShort } from '$lib/utils/grades';
 	import { GRADE_CODES, type GradeCode } from '$lib/types/grades';
 	import type { PageData } from './$types';

--- a/src/routes/(public)/python-exercises/+page.svelte
+++ b/src/routes/(public)/python-exercises/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { Plus, BookOpen, FileCode2 } from 'lucide-svelte';
+	import { Plus, BookOpen, FileCode2 } from '@lucide/svelte';
 
 	let { data } = $props();
 </script>

--- a/src/routes/(public)/python-exercises/[id]/+page.svelte
+++ b/src/routes/(public)/python-exercises/[id]/+page.svelte
@@ -25,7 +25,7 @@
 		FunctionSquare,
 		Link2,
 		Pencil
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 
 	let { data } = $props();
 	const exercise = $derived(data.exercise);

--- a/src/routes/(public)/python-exercises/[id]/results/+page.svelte
+++ b/src/routes/(public)/python-exercises/[id]/results/+page.svelte
@@ -15,7 +15,7 @@
 		X,
 		ArrowUp,
 		ArrowDown
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { MasteryStatus, StudentRow } from './+page.server';
 

--- a/src/routes/(public)/python-exercises/[id]/results/[student_id]/+page.svelte
+++ b/src/routes/(public)/python-exercises/[id]/results/[student_id]/+page.svelte
@@ -12,7 +12,7 @@
 		ChevronRight,
 		Copy,
 		LayoutGrid
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { ExerciseValidationResult as ValidationResult } from '$lib/shared/python';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import type { PageData } from './$types';

--- a/src/routes/(public)/python-exercises/mine/+page.svelte
+++ b/src/routes/(public)/python-exercises/mine/+page.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { ConfirmDialog } from '$lib/components/ui/confirm-dialog';
-	import { ExternalLink, Trash2, Plus, Copy, Pencil } from 'lucide-svelte';
+	import { ExternalLink, Trash2, Plus, Copy, Pencil } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 
 	let { data } = $props();

--- a/src/routes/(public)/python-exercises/my-progress/+page.svelte
+++ b/src/routes/(public)/python-exercises/my-progress/+page.svelte
@@ -14,7 +14,7 @@
 		X,
 		ArrowUp,
 		ArrowDown
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { MasteryStatus } from './+page.server';
 

--- a/src/routes/(public)/python-exercises/students/[student_id]/+page.svelte
+++ b/src/routes/(public)/python-exercises/students/[student_id]/+page.svelte
@@ -15,7 +15,7 @@
 		X,
 		ArrowUp,
 		ArrowDown
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { MasteryStatus } from './+page.server';
 

--- a/src/routes/(public)/upsilon/+page.svelte
+++ b/src/routes/(public)/upsilon/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Calculator, Maximize2, Minimize2, ExternalLink } from 'lucide-svelte';
+	import { Calculator, Maximize2, Minimize2, ExternalLink } from '@lucide/svelte';
 	import { theme } from '$lib/stores/theme.svelte';
 
 	let isLoaded = $state(false);


### PR DESCRIPTION
## Pourquoi

L'analyse de bundle (visualizer, PR #21) a révélé que **`lucide-svelte@0.545` (déprécié) était la 1ʳᵉ dépendance par le poids (~528 kB gz)**, en **doublon** avec `@lucide/svelte@1.16` (tiré transitivement par bits-ui/shadcn). On consolide sur le paquet maintenu.

## Quoi

- **482 fichiers** : imports `'lucide-svelte'` → `'@lucide/svelte'` (named + sous-chemins `/icons/*` + type import).
- **`lucide-svelte` retiré** de `package.json`.
- Les **190 icônes** utilisées restent dispo sous leur ancien nom via les **alias** de `@lucide/svelte` (table de renommage vide — vérifié en Phase 0).

## 2 différences d'API (attrapées par svelte-check)

1. **Type** : `icon: ComponentType` (Svelte 4) → `icon: LucideIcon` (= `Component<LucideProps>`, Svelte 5) dans `dashboard-nav.ts`, `Header`, `Sidebar`, `MobileNavDrawer`.
2. **Icône retirée** : `Youtube` (supprimée de Lucide, trademark) → **`Video`** dans `materials/+page.svelte` (matériel `YOUTUBE_VIDEO`).

## Gain / non-gain

✅ Supprime la dépréciation · ✅ lib d'icônes unique. ⚠️ **Ne réduit pas les ~528 kB** (mêmes icônes ; on utilise les alias dépréciés — nettoyage canonique = chantier séparé optionnel).

## Vérif

- `pnpm check:incremental` = **0 erreur** (1697 fichiers).
- CI (Type Check + **Build** + tests) ci-dessous.
- Détails : `docs/wip/lucide-migration-progress.md`.

## Risque

Mécanique (find-replace) + filet TS. 482 fichiers mais 0 changement de logique de composant.