### PR TITLE
docs(claude): rewrite 6 synthetic reference docs (grounded in current code)

### DIFF
--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -1,0 +1,148 @@
+# Architecture
+
+Référence synthétique pour Claude : **structure**, **routing & data fetching**, **SSR/hydratation** (dont la contrainte Safari TDZ). Détail : [docs/architecture/](../architecture/) · règles condensées dans [CLAUDE.md](../../CLAUDE.md).
+
+---
+
+## Project Structure
+
+```
+src/
+├── hooks.server.ts          # handle = sequence(requestId, maintenance, supabase, …) → peuple locals
+├── hooks.client.ts          # error monitoring client
+├── app.d.ts                 # App.Locals (user, profile, supabase, safeGetSession…)
+├── routes/
+│   ├── +layout.server.ts    # racine SSR : vérifie l'auth (getUser), expose cookies/user/profile
+│   ├── +layout.ts           # racine universel : crée le client Supabase (import DYNAMIQUE, cf. TDZ)
+│   ├── (public)/            # pages publiques (auth, legal, demos, glossaire, games…) — pas d'auth
+│   ├── (protected)/        # auth REQUISE (garde dans (protected)/+layout.server.ts)
+│   └── api/                 # endpoints REST (+server.ts), validés Zod
+└── lib/
+    ├── components/          # composants UI (ui/ = Shadcn, MySelect/MyCheckbox custom…)
+    ├── server/             # code server-only : auth.ts, middleware/, validation/ (Zod), errorMonitoring…
+    ├── stores/              # état partagé runes (toaster.svelte, caches…)
+    ├── utils/ · types/      # helpers · types (database.ts auto-généré, database-helpers.ts dérivés)
+    ├── questions/ · mathAST/ # système de questions & AST symbolique (cf. plus bas)
+    └── geometry-core/ · constructions-v2/ · games/ · srs/ · spreadsheet/ · whiteboard/ …
+```
+
+**Ordre dans un fichier** : Imports → Types → Constantes → Variables → Functions → Component (cf. CLAUDE.md).
+
+---
+
+## Route groups
+
+Les parenthèses créent des **layout groups** SvelteKit : elles n'apparaissent **pas** dans l'URL (`(protected)/dashboard/+page.svelte` → `/dashboard`).
+
+| Groupe         | Sens                                   | Garde                                                                 |
+| -------------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `(public)/`    | pas d'auth (login, legal, démos, jeux) | aucune                                                                |
+| `(protected)/` | **auth requise**                       | `(protected)/+layout.server.ts` : `requireAuth(user)` + statut profil |
+| `api/`         | endpoints REST `+server.ts`            | par endpoint (`requireRoles(locals, [...])`), validation **Zod**      |
+
+La garde `(protected)/+layout.server.ts` tourne **avant** toute route enfant, impossible à contourner : `requireAuth` (redirige `/login` si `user` null), profil obligatoire (sinon 500 + `logError`), puis **deny-by-default** sur `profile.status` (`pending` → `/auth/pending-approval` ; tout ce qui n'est pas `approved` → `signOut()` + redirect). Accès par rôle plus fin **dans** l'endpoint/la page via `requireRoles`.
+
+> Détail rôles/redirections : [docs/architecture/](../architecture/).
+
+---
+
+## Routing & data fetching
+
+**`locals` est la source unique d'auth.** `hooks.server.ts` peuple `event.locals` une fois par requête (`userProfileHandle` charge `user` + `profile`). Les `load` lisent `locals` — **pas besoin de `await parent()`** dans les enfants.
+
+```typescript
+// (protected)/.../+page.server.ts
+export const load: PageServerLoad = async ({ locals }) => {
+	const { user, profile, supabase } = locals; // user/profile garantis sous (protected)
+	const { data, error: e } = await supabase
+		.from('schools')
+		.select('*')
+		.eq('id', profile.school_id)
+		.single();
+	if (e) throw error(500, 'Failed to load school');
+	return { school: data };
+};
+```
+
+**API endpoint** (`api/.../+server.ts`) : garde de rôle + Zod sur l'entrée, puis requête via `locals.supabase`.
+
+```typescript
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+	const supabase = locals.supabase;
+	// … requête + json(...)
+};
+```
+
+- `GET` = lecture ; mutations en `POST`/`PATCH`/`DELETE`. Toute entrée externe validée Zod (`safeParse` → `error(400)`) — cf. [quality-standards.md](quality-standards.md#input-validation-with-zod).
+- Le client Supabase utilisé par les composants vient de `+layout.ts` (`data.supabase`), authentifié par cookies en SSR / localStorage en navigateur.
+
+---
+
+## SSR & hydratation
+
+Double `load` racine, dans l'ordre :
+
+1. **`+layout.server.ts`** (server only) : `safeGetSession()` → `getUser()` (vérifié), renvoie `cookies`, `user`, `profile`.
+2. **`+layout.ts`** (universel : SSR puis hydratation navigateur) : reçoit `data`, crée le client Supabase (`createServerClient` via cookies en SSR / `createBrowserClient` en navigateur), `depends('supabase:auth')`.
+
+**Flux auth réactif** : `onAuthStateChange` (navigateur) ne consomme **jamais** la session du callback (non vérifiée) → il appelle `invalidate('supabase:auth')`, ce qui ré-exécute le `load` racine et re-vérifie côté serveur. `SIGNED_IN` même utilisateur (HMR/refocus) et `TOKEN_REFRESHED` < 30 min sont **throttlés** via `sessionStorage` pour éviter des reloads inutiles (3-5 requêtes DB chacun).
+
+### ⚠️ Contrainte critique — Safari/WebKit TDZ (root layout)
+
+Le **chunk du root layout doit rester < 100 KB**, sinon iPad/Safari lève `Cannot access 'universal' before initialization` (WebKit bug [#242740](https://bugs.webkit.org/show_bug.cgi?id=242740), chaîne d'imports statiques trop complexe dans le module d'entrée de route).
+
+- **`@supabase/ssr` est importé DYNAMIQUEMENT** dans `src/routes/+layout.ts` (`await import('@supabase/ssr')`), jamais en import statique. Idem `$app/navigation` (`invalidate`) chargé dynamiquement.
+- **Garde CI** (`.github/workflows/quality.yml`) : après `pnpm build`, vérifie `nodes/0.*.js` ≤ `102400` octets → **fail si dépassé**.
+- **NE JAMAIS** ajouter d'import statique de lib lourde dans `+layout.ts`.
+
+> Détail : [docs/ref/safari-webkit-tdz.md](../ref/safari-webkit-tdz.md).
+
+---
+
+## Dev server
+
+**Toujours `--port 5175`** ; `5173` est réservé à l'utilisateur, **ne pas l'utiliser**.
+
+```bash
+pnpm dev -- --port 5175
+```
+
+---
+
+## Performance patterns
+
+**Optimistic UI + debouncing** — pour les updates serveur fréquentes (compteurs, quantités) : MAJ optimiste immédiate + envoi serveur batché (fenêtre de debounce ~500 ms), rollback sur erreur. Réel dans `src/routes/(protected)/dashboard/teacher/gamification/rewards/+page.svelte` (cache teacher + `debouncedUpdate*`), aussi `dashboard/student/inventory/`.
+
+```typescript
+function debouncedUpdate(id: string, delta: number) {
+	optimistic[id] = (optimistic[id] ?? 0) + delta; // 1. feedback UI instantané
+	clearTimeout(timers[id]);
+	timers[id] = setTimeout(async () => {
+		try {
+			await updateServer(id, optimistic[id]); // 2. envoi batché
+		} catch {
+			optimistic[id] = 0; // rollback
+			toaster.error('Échec de la mise à jour');
+		}
+	}, 500);
+}
+```
+
+Réactivité = **event → handler → maj du state → maj du DOM** (runes ; `$effect` réservé aux side-effects). Autres leviers : index DB sur les chemins chauds, élimination des N+1 (joins), RPC PostgreSQL pour les agrégations.
+
+---
+
+## Question/template system (pointeur)
+
+Système métier volumineux — **ne pas deep-diver ici** :
+
+- **`src/lib/questions/`** (~70 fichiers) — banque de questions / templates. API publique : `src/lib/questions/index.ts` (`generateInstance`, `resolveVariables`, `random-generator`…) ; génération dans `generator/` (`instance-generator`, `variable-resolver`, `correction-generator`, `condition-evaluator`…). Agent dédié : **`pedagogy-expert`**.
+- **`src/lib/mathAST/`** (~700 fichiers) — AST symbolique : parsing, normalize, pattern matching (`P`/`tryMatch`/`parsePattern`), `cosmetic-transforms`, génération LaTeX, paliers pédagogiques. Invariants structurels stricts → agent dédié : **`mathast-expert`**.
+
+---
+
+> Voir aussi : [best-practices.md](best-practices.md) (Svelte 5, TS) · [database.md](database.md) · [ui-components.md](ui-components.md) · [realtime.md](realtime.md) · [git-workflow.md](git-workflow.md).

--- a/docs/claude/best-practices.md
+++ b/docs/claude/best-practices.md
@@ -1,0 +1,398 @@
+# Best Practices
+
+Référence synthétique pour Claude : **Svelte 5 runes**, **TypeScript**, **SvelteKit patterns**, **organisation du code**. Règles non négociables dans [CLAUDE.md](../../CLAUDE.md). Tests/Zod : [quality-standards.md](quality-standards.md).
+
+---
+
+## Svelte 5 Runes
+
+> ⚠️ Règle n°3 CLAUDE.md : runes **uniquement**. Jamais `export let`, jamais `$:`.
+
+### Primitives
+
+```svelte
+<script lang="ts">
+	// State: réactivité locale
+	let count = $state(0);
+	let isOpen = $state(false);
+
+	// Derived: valeur calculée — jamais de $:
+	let doubled = $derived(count * 2);
+	let label = $derived(isOpen ? 'Fermer' : 'Ouvrir');
+
+	// Props: interface typée + déstructuration
+	interface Props {
+		title: string;
+		maxItems?: number;
+		onclose?: () => void;
+	}
+	let { title, maxItems = 10, onclose }: Props = $props();
+
+	// Bindable: liaison bidirectionnelle
+	interface BindableProps {
+		value: string[];
+	}
+	let { value = $bindable([]) }: BindableProps = $props();
+</script>
+```
+
+Exemple réel — `GradeBadgeSelector.svelte` :
+
+```svelte
+<script lang="ts">
+	interface Props {
+		value: GradeCode[];
+		maxSelections?: number;
+		onchange?: (value: GradeCode[]) => void;
+		restrictTo?: GradeCode[];
+	}
+
+	let { value = $bindable([]), maxSelections, onchange, restrictTo }: Props = $props();
+
+	let isModalOpen = $state(false);
+	let pendingSelection = $state<GradeCode[]>([]);
+</script>
+```
+
+### $effect — réservé aux side-effects
+
+`$effect` sert uniquement à synchroniser avec des APIs extérieures (DOM, timers, subscriptions). **Ne pas l'utiliser pour de la logique dérivée** — utiliser `$derived` à la place.
+
+```svelte
+<script lang="ts">
+	import { untrack } from 'svelte';
+
+	let inputRef: HTMLInputElement | null = $state(null);
+	let autoFocus = $state(false);
+
+	// ✅ Side-effect légitime : interaction DOM
+	$effect(() => {
+		if (autoFocus && inputRef) {
+			inputRef.focus();
+		}
+	});
+
+	// ✅ untrack() pour lire un état sans créer de dépendance réactive
+	// (cf. ConstructionPlayer.svelte, MultiClassStudentSelector.svelte)
+	let data = $state<string[]>([]);
+	$effect(() => {
+		// trigger sur `autoFocus` uniquement, pas sur `data`
+		if (autoFocus) {
+			untrack(() => {
+				console.log('current data:', data);
+			});
+		}
+	});
+
+	// ✅ Nettoyage (cleanup) — toujours retourner une fonction si on subscribe
+	$effect(() => {
+		const handler = () => console.log('resized');
+		window.addEventListener('resize', handler);
+		return () => window.removeEventListener('resize', handler);
+	});
+</script>
+```
+
+### Modèle de réactivité
+
+```
+event (onclick, oninput…) → handler → maj $state → DOM mis à jour
+```
+
+- Les handlers sont des **fonctions minuscules** en Svelte 5 : `onclick`, `oninput`, `onchange`, `onsubmit`.
+- `$derived` se recalcule automatiquement quand ses dépendances changent.
+- `$effect` s'exécute **après** le rendu ; ne pas l'utiliser pour contrôler le rendu.
+
+### Snippets (remplacent les slots)
+
+```svelte
+<!-- Composant parent -->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	let { children }: { children: Snippet } = $props();
+</script>
+
+{@render children?.()}
+```
+
+Exemple réel — `(protected)/+layout.svelte` :
+
+```svelte
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<PomodoroEffects />
+{@render children?.()}
+```
+
+### Module-level state partagé
+
+Pour du state partagé entre toutes les instances d'un composant, utiliser `<script module>` avec `SvelteSet` / `SvelteMap` (pas des primitives JS nues) — exemple réel `UserAvatar.svelte` :
+
+```svelte
+<script lang="ts" module>
+	import { SvelteSet } from 'svelte/reactivity';
+	// Partagé entre toutes les instances ; SvelteSet déclenche la réactivité
+	const failedUrls = new SvelteSet<string>();
+</script>
+```
+
+### Anti-patterns interdits
+
+```svelte
+<!-- ❌ Svelte 4 — jamais -->
+<script>
+	export let title; // → let { title } = $props()
+	$: doubled = x * 2; // → let doubled = $derived(x * 2)
+	$: {
+		doSomething(x);
+	} // → $effect(() => { doSomething(x); })
+</script>
+
+<!-- ❌ svelte:component inutile en Svelte 5 -->
+<svelte:component this={MyComp} /> // → <MyComp />
+```
+
+---
+
+## TypeScript
+
+### Jamais `any`
+
+```typescript
+// ❌
+function process(data: any) { ... }
+
+// ✅ unknown + type guard
+function process(data: unknown) {
+  if (isProfile(data)) { /* typé */ }
+}
+
+// ✅ type guard
+function isProfile(v: unknown): v is Profile {
+  return typeof v === 'object' && v !== null && 'role' in v;
+}
+```
+
+### Types de base de données
+
+- `Database`, `Tables<>`, `TablesInsert<>`, `TablesUpdate<>`, `Json` → importer depuis `$lib/types/database` (auto-généré, **ne jamais y toucher**).
+- Alias de tables, unions, interfaces composites → **uniquement** dans `$lib/types/database-helpers.ts`.
+
+```typescript
+// ✅ Alias dans database-helpers.ts
+import type { Tables } from '$lib/types/database';
+export type Profile = Tables<'profiles'>;
+export type ProfileRole = 'teacher' | 'student' | 'admin';
+
+// ✅ Importation dans le code applicatif
+import type { Profile } from '$lib/types/database-helpers';
+```
+
+---
+
+## Organisation d'un fichier
+
+Ordre **obligatoire** dans tout fichier `.ts` ou `<script lang="ts">` :
+
+```
+1. Imports
+2. Types / interfaces
+3. Constantes (module-level, immutables)
+4. Variables ($state, $derived, let locaux)
+5. Functions (helpers, handlers)
+6. (dans .svelte) markup
+```
+
+```svelte
+<script lang="ts">
+	// 1. Imports
+	import { Badge } from '$lib/components/ui/badge';
+	import type { GradeCode } from '$lib/types/grades';
+
+	// 2. Types
+	interface Props {
+		value: GradeCode[];
+		disabled?: boolean;
+	}
+
+	// 3. Constantes
+	const MAX_VISIBLE = 5;
+
+	// 4. Props + state
+	let { value = $bindable([]), disabled = false }: Props = $props();
+	let isOpen = $state(false);
+	let filtered = $derived(value.slice(0, MAX_VISIBLE));
+
+	// 5. Functions
+	function handleToggle() {
+		isOpen = !isOpen;
+	}
+</script>
+
+<!-- 6. Markup -->
+<button onclick={handleToggle}>…</button>
+```
+
+---
+
+## Supabase — clients SSR-compatibles
+
+> ⚠️ Ne jamais utiliser `supabaseClient.ts` (déprécié, singleton non SSR). Doc complète : [database.md](database.md).
+
+**Trois contextes, trois patterns :**
+
+### 1. Hook serveur (`hooks.server.ts`)
+
+Crée un client par requête avec gestion des cookies :
+
+```typescript
+// src/lib/server/supabase.ts — appelé depuis hooks.server.ts
+import { createServerClient } from '@supabase/ssr';
+
+event.locals.supabase = createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+	cookies: {
+		getAll: () => event.cookies.getAll(),
+		setAll: (cookiesToSet) => {
+			cookiesToSet.forEach(({ name, value, options }) =>
+				event.cookies.set(name, value, { ...options, path: '/' })
+			);
+		}
+	}
+});
+```
+
+### 2. `+layout.ts` (universel, SSR + browser)
+
+Import **dynamique** obligatoire pour éviter le bug WebKit TDZ (voir [docs/ref/safari-webkit-tdz.md](../ref/safari-webkit-tdz.md)) :
+
+```typescript
+// src/routes/+layout.ts
+export const load: LayoutLoad = async ({ data, depends, fetch }) => {
+	depends('supabase:auth');
+
+	// ⚠️ Import dynamique — NE PAS passer en import statique (chunk > 100 KB → bug Safari)
+	const { createBrowserClient, createServerClient, isBrowser } = await import('@supabase/ssr');
+
+	const supabase = isBrowser()
+		? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, { global: { fetch } })
+		: createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+				global: { fetch },
+				cookies: { getAll: () => data.cookies }
+			});
+
+	return { supabase, user: data.user, profile: data.profile };
+};
+```
+
+### 3. `+page.server.ts` / `+layout.server.ts` — `event.locals`
+
+`user` et `profile` sont chargés en amont par `userProfileHandle` (dans `hooks.server.ts`) et disponibles directement dans `locals` :
+
+```typescript
+// src/routes/(protected)/python-notebook/+page.server.ts
+export const load: PageServerLoad = async ({ locals }) => {
+	const { user, profile } = locals; // déjà vérifiés par le hook
+	if (!user || !profile) throw error(401, 'Non autorisé');
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('python_notebooks')
+		.select('id, title, updated_at')
+		.eq('author_id', user.id);
+
+	if (dbErr) throw error(500, 'Erreur de chargement');
+	return { notebooks: data ?? [] };
+};
+```
+
+`(protected)/+layout.server.ts` appelle `requireAuth(user)` puis renvoie `{ user, profile, consentStatus }` — les routes enfants héritent via `parent()` **ou** via `locals` directement.
+
+---
+
+## Toaster (notifications)
+
+```typescript
+import { toaster } from '$lib/stores/toaster.svelte';
+
+toaster.success('Sauvegardé');
+toaster.error('Erreur lors de la sauvegarde');
+toaster.warning('Session bientôt expirée');
+toaster.info('Mise à jour disponible');
+```
+
+---
+
+## Composants UI — règles obligatoires
+
+> Règle n°2 CLAUDE.md : jamais `<select>` natif ni Shadcn `Select` direct.
+
+```svelte
+<!-- ✅ -->
+<MySelect type="single" bind:value={selected} {items} />
+<MyCheckbox bind:checked={isEnabled} label="Activer" />
+
+<!-- ❌ -->
+<select bind:value={selected}>…</select>
+<input type="checkbox" bind:checked={isEnabled} />
+```
+
+Composants : `src/lib/components/MySelect.svelte` · `src/lib/components/MyCheckbox.svelte`.
+
+---
+
+## Contexte Svelte
+
+Passer le contexte via **fonctions** (pas de valeur nue — la valeur nue ne réagit pas aux mises à jour) :
+
+```typescript
+// ✅ Producteur — fonctions getter
+setContext('deck', { getStore: () => deckStore });
+
+// ✅ Consommateur
+const { getStore } = getContext<{ getStore: () => DeckStore }>('deck');
+const store = getStore();
+```
+
+---
+
+## SvelteKit — form actions et `use:enhance`
+
+```svelte
+<script lang="ts">
+	import { enhance } from '$app/forms';
+</script>
+
+<form
+	method="POST"
+	action="?/reorderChecklistItem"
+	use:enhance={() => {
+		// retourner une fonction pour override le comportement par défaut
+		return async ({ update }) => {
+			await update({ reset: false });
+		};
+	}}
+>
+	…
+</form>
+```
+
+---
+
+## Anti-patterns clés (récapitulatif)
+
+| ❌ À éviter                                      | ✅ Correct                                              |
+| ------------------------------------------------ | ------------------------------------------------------- |
+| `export let x`                                   | `let { x } = $props()`                                  |
+| `$: doubled = x * 2`                             | `let doubled = $derived(x * 2)`                         |
+| `$: { sideEffect(x); }`                          | `$effect(() => { sideEffect(x); })`                     |
+| `<svelte:component this={C} />`                  | `<C />`                                                 |
+| `import { supabase } from '$lib/supabaseClient'` | `locals.supabase` (serveur) ou `data.supabase` (client) |
+| Types dans `database.ts`                         | Types dans `database-helpers.ts`                        |
+| `data: any`                                      | `data: unknown` + type guard                            |
+| `<select>` / `<input type="checkbox">`           | `<MySelect>` / `<MyCheckbox>`                           |
+
+---
+
+> Voir aussi : [quality-standards.md](quality-standards.md) · [database.md](database.md) · [architecture.md](architecture.md) · [ui-components.md](ui-components.md).

--- a/docs/claude/database.md
+++ b/docs/claude/database.md
@@ -1,0 +1,123 @@
+# Database (Supabase)
+
+Référence synthétique pour Claude : **workflow migrations**, **règle des types**, **RLS mono-professeur**, **tests d'intégration**. Détail schéma : [docs/architecture/database-schema.md](../architecture/database-schema.md) · règles condensées dans [CLAUDE.md](../../CLAUDE.md).
+
+---
+
+## Infra (EU / RGPD)
+
+- **Postgres 17** (`supabase/config.toml` → `major_version = 17`), hébergé **EU / eu-west-3** (RGPD : vraies données d'**élèves mineurs**).
+- Project ref prod : **`cnevnzsvixxpnurautls`** (cible de `db:types` et du MCP read-only). ⚠️ `config.toml` porte `project_id = "ubumaths"` — c'est le **nom local** du stack, **pas** le ref prod.
+- Vercel déploie en `cdg1`. Bascule historique **us-east-2 → eu-west-3** (RGPD mineurs + latence).
+
+---
+
+## Workflow migrations
+
+| Étape               | Action                                                                                                                                                                       |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Créer            | `.sql` dans `supabase/migrations/`, nommé **`<timestamp>_<description>.sql`** (ex. `20260616240000_fix_private_messages_sender_fk.sql`). Le timestamp ordonne l'application. |
+| 2. Schéma **+** RLS | Mettre changement de schéma **ET** policies/triggers RLS associés **dans la même migration**.                                                                                |
+| 3. Tester en local  | `pnpm db:start` (Docker) → `pnpm test:integration` (cf. §Tests).                                                                                                             |
+| 4. Pousser          | **`pnpm db:migrate`** (= `supabase db push`) → applique vers la prod EU. **Uniquement depuis la branche mergée, avec accord explicite.**                                     |
+| 5. Régénérer types  | **`pnpm db:types`** → réécrit `src/lib/types/database.ts`. Commit.                                                                                                           |
+| 6. Documenter       | Mettre à jour [docs/architecture/database-schema.md](../architecture/database-schema.md) si cluster de tables feature-level.                                                 |
+
+```bash
+pnpm db:start      # supabase start (stack local, Docker requis)
+pnpm db:stop       # supabase stop
+pnpm db:reset      # supabase db reset → recrée la base depuis le baseline + seed
+pnpm db:migrate    # supabase db push → applique migrations en attente vers EU
+pnpm db:types      # supabase gen types typescript --project-id cnevnzsvixxpnurautls > database.ts
+pnpm db:status     # diagnostic : profiles manquants vs auth.users
+```
+
+- ⛔ **JAMAIS modifier le schéma via le Dashboard Supabase.** Toute évolution passe par une migration versionnée (reproductible, reviewable).
+- ⚠️ **OOM** : ne pas lancer `db:migrate` / `db:reset` en agent ou sans accord (touche la prod / lourd).
+- État actuel des migrations : **1 baseline** (`20260616220000_baseline_schema.sql`, ~46 k lignes, schéma EU complet) **+ correctifs** post-baseline. Les **619** anciennes migrations sont archivées dans `supabase/migrations_archive/` (ne pas les rejouer).
+
+### Timing additif vs destructif
+
+| Type                       | Exemples                                                                                       | Quand `db:migrate` ?                                                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Additif** (non-breaking) | `CREATE TABLE`, `ADD COLUMN` (nullable / défaut), `CREATE INDEX`, `CREATE OR REPLACE FUNCTION` | **Avant / avec** le déploiement du code qui l'utilise (le nouveau code a besoin du schéma).                   |
+| **Destructif** (breaking)  | `DROP COLUMN`/`TABLE`, `RENAME`, `NOT NULL` sur colonne existante, suppression de fonction     | **Après** que le code n'utilisant plus l'ancien schéma soit déployé (sinon la prod casse pendant le rollout). |
+
+---
+
+## Règle des types (non négociable)
+
+> CLAUDE.md règle #6.
+
+| Type                                                                 | Origine                           | Où le définir                                                                           |
+| -------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `Database`, `Tables<>`, `Json`                                       | **Auto-généré** (`pnpm db:types`) | `src/lib/types/database.ts` — **NE JAMAIS éditer à la main** (écrasé à la régénération) |
+| Alias (`type Profile = Tables<'profiles'>`)                          | Dérivé                            | `src/lib/types/database-helpers.ts`                                                     |
+| Composite (`interface FriendshipWithProfile {…}`)                    | Custom                            | `src/lib/types/database-helpers.ts`                                                     |
+| Union contrainte (`type CheckpointRunStatus = 'passed' \| 'failed'`) | Custom                            | `src/lib/types/database-helpers.ts`                                                     |
+
+```ts
+// ✅ import des types
+import type { Tables } from '$lib/types/database';
+import type { Profile, FriendProfile } from '$lib/types/database-helpers';
+```
+
+`database-helpers.ts` existe précisément pour survivre aux régénérations : tout type fait-main y vit.
+
+---
+
+## RLS — modèle mono-professeur (Option B)
+
+> Refactor « professeur unique » : mergé (PR #11). Doc : `docs/wip/single-teacher-refactor.md`.
+
+- **Un seul prof (+ admin)** : la **classe n'est plus une frontière d'accès**. Le prof unique voit les données pédagogiques de **TOUS les élèves**, y compris ceux **hors classe**.
+- **L'école (`profiles.school_id`) = frontière sociale / safeguarding** ; la classe = sous-groupe d'organisation. Les classements de jeux, le social, etc. sont **bornés par l'école** (défense en profondeur — `p.school_id = public.my_school()`).
+- Source de vérité des inscriptions : **`class_members`** (PAS un tableau `class_ids`).
+
+**Helpers `SECURITY DEFINER` pivots** (référencés par les ~13 policies de lecture prof) :
+
+| Fonction                      | Rôle                                                                           |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| `is_teacher_or_admin()`       | bypass RLS, vrai si l'appelant est teacher/admin                               |
+| `is_my_student(p_student_id)` | pivot Option B : un élève est-il « à moi » (inclut hors-classe)                |
+| `my_school()`                 | `profiles.school_id` de l'appelant (NULL si non rattaché) — borne safeguarding |
+
+**Bonnes pratiques policies** : RLS activé sur **toute** table ; une policy **par opération** (SELECT/INSERT/UPDATE/DELETE) ; `auth.uid()` pour l'identité ; `SECURITY DEFINER` pour l'autorisation complexe ; commenter l'intention (`COMMENT ON FUNCTION/POLICY`).
+
+---
+
+## Tests d'intégration (OBLIGATOIRES pour la DB)
+
+> Architecture : [docs/ref/tests/](../ref/tests/) · standards : [quality-standards.md](quality-standards.md#testing-standards).
+
+**Toute RLS / fonction `SECURITY DEFINER` / trigger / policy → test d'intégration obligatoire** avant merge.
+
+```bash
+pnpm db:start            # stack local
+pnpm test:integration    # vitest run --config vitest.integration.config.ts
+```
+
+- Tests dans `tests/integration/` (ex. `single-teacher-rls.test.ts`, `kanban-rls.test.ts`, `game-leaderboards.test.ts`), helpers dans `tests/helpers/database/`.
+- Pattern : **vrais clients authentifiés** (`createAuthenticatedClient(email)`) → RLS réellement appliqué, pas un client service-role qui bypasse tout.
+- ⚠️ **JAMAIS valider une fonction `SECURITY DEFINER` par un smoke-test avec `auth.uid()` NULL** : la quasi-totalité de nos RPC ouvrent sur `IF auth.uid() IS NULL THEN RETURN error` → le garde **sort avant la vraie requête** → **faux positif** (a déjà laissé partir une RPC cassée en prod). Tester avec un contexte authentifié réel.
+- La suite a déjà attrapé des bugs prod (ex. `ORDER BY rank` → `rk` dans `game_leaderboard`, 0A000). ~285 tests d'intégration.
+
+---
+
+## Auth (Supabase Auth)
+
+- Google OAuth restreint au domaine `@voltairedoha.com`.
+- Avatar : priorité `profile.avatar_url` → `user.user_metadata.picture` → `user.user_metadata.avatar_url` → fallback rôle/genre → initiales.
+- ⚠️ **Edge case import élève** : login **avant** import → insertion directe dans `class_members` (l'auto-enrollment ne s'est pas déclenché). Toujours considérer les deux flux (import→login vs login→import).
+- ⚠️ **Safari/WebKit TDZ** : pas d'import statique lourd dans `+layout.ts` ; `@supabase/ssr` en `await import()` dynamique (chunk root layout < 100 KB). Doc : [docs/ref/safari-webkit-tdz.md](../ref/safari-webkit-tdz.md).
+
+---
+
+## Interroger la prod
+
+- **MCP Supabase read-only** (EU, `--read-only --project-ref=cnevnzsvixxpnurautls` dans `.mcp.json`) : lecture seule pour inspecter le schéma/les données prod (`list_tables`, `execute_sql` SELECT, `get_advisors`, `get_logs`).
+- ⛔ **Ne JAMAIS appeler un outil MCP d'écriture** (`apply_migration`, `execute_sql` mutant, `create_branch`…). Toute écriture passe par une migration `.sql` + `db:migrate`.
+
+---
+
+> Voir aussi : [quality-standards.md](quality-standards.md) · [best-practices.md](best-practices.md) · [git-workflow.md](git-workflow.md) · schéma : [database-schema.md](../architecture/database-schema.md).

--- a/docs/claude/quality-standards.md
+++ b/docs/claude/quality-standards.md
@@ -1,0 +1,85 @@
+# Quality Standards
+
+Référence synthétique pour Claude : **linting/checks (sous contrainte OOM)**, **validation Zod**, **tests**. Détail : [docs/ref/tests/](../ref/tests/) · règles condensées dans [CLAUDE.md](../../CLAUDE.md).
+
+---
+
+## Linting & checks (machine à faible RAM)
+
+> ⚠️ Contrainte OOM (cf. `CLAUDE.md §Contrainte mémoire`). **NE JAMAIS** lancer sur tout le projet : `pnpm check` · `pnpm build` · `pnpm lint` (eslint) · `svelte-check` sans `--incremental`.
+
+| Outil                        | Où                    | Détail                                                                                                                                         |
+| ---------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **oxlint** (Rust, ~0 RAM)    | pre-commit local      | `.lintstagedrc.js` : `oxlint --fix` sur `.{js,ts}` staged + `prettier`. Bloque sur **erreurs** seulement (warnings non bloquants).             |
+| **prettier**                 | pre-commit + CI       | `prettier --check .` en CI (job _Lint_) ; `--write` au commit.                                                                                 |
+| **eslint** (complet)         | **CI uniquement**     | OOM en local (type-aware). Couvre `eslint-plugin-svelte` + la règle custom Zod. Round-trip CI assumé.                                          |
+| **`pnpm check:incremental`** | local, **avant push** | TS + Svelte, memory-safe (heap 4096, `svelte-kit sync` conditionnel ; `FRESH=1` pour forcer après suppression/renommage). **0 erreur exigée**. |
+
+- Le hook pre-commit est **léger** → `--no-verify` **n'est plus nécessaire**.
+- eslint local seulement en ciblé si la machine tient : `npx eslint <fichiers>`.
+- `pnpm format "src/**/*.{ts,svelte}"` = `prettier --write`.
+
+---
+
+## Input Validation with Zod
+
+**Règle n°1 (non négociable)** : toute entrée externe d'une route API est validée par **Zod** — `request.json()`, query params, params dynamiques. Toujours borner : `.min()`/`.max()`, tailles de tableaux, `.uuid()`.
+
+**Application automatique** : la règle eslint custom **`custom/require-zod-validation`** est en **`error`** sur `src/routes/api/**/*.ts` (`eslint.config.js`). Une route API sans validation **casse la CI** (et `eslint-rules/require-zod-validation.js` a ses propres tests : `pnpm test:lint-rules`).
+
+**Lib** : `src/lib/server/validation/` — ~69 fichiers **par domaine** (`assessments.ts`, `classes.ts`, `auth.ts`, …) + `common.ts` (schémas partagés : `uuidSchema`, `dateSchema`, `hexColorSchema`…) + `response-utils.ts` + `__tests__/`. **Messages d'erreur en français.**
+
+**Pattern canonique** (`safeParse` → `error(400)`, jamais `.parse()` qui throw brut) :
+
+```ts
+import { z } from 'zod';
+import { error } from '@sveltejs/kit';
+import { createAssessmentSchema } from '$lib/server/validation/assessments';
+
+const v = createAssessmentSchema.safeParse(await request.json());
+if (!v.success) throw error(400, v.error.issues[0].message);
+const data = v.data; // typé, sûr
+```
+
+Query params — construire un objet depuis `url.searchParams` puis valider :
+
+```ts
+const q = listAssessmentsQuerySchema.safeParse({ page: url.searchParams.get('page') ?? '1' });
+if (!q.success) throw error(400, q.error.issues[0].message);
+```
+
+**Anti-patterns** :
+
+- ❌ `await request.json()` consommé sans `safeParse`.
+- ❌ Validation manuelle ad-hoc (`if (typeof x !== 'string')`) au lieu d'un schéma.
+- ❌ Schéma sans bornes (`z.number()` nu, `z.array()` sans `.max()`) → risque DoS.
+- ❌ `z.any()` / `z.unknown()` pour contourner la validation.
+
+---
+
+## Testing standards
+
+> Architecture complète + TDD collaboratif : [docs/ref/tests/](../ref/tests/).
+
+| Type                       | Emplacement                               | Commande                  |
+| -------------------------- | ----------------------------------------- | ------------------------- |
+| Unit (serveur / logique)   | `src/**/__tests__/`                       | `pnpm test:server <path>` |
+| Client (composants Svelte) | `src/**/*.svelte.test.ts`                 | `pnpm test:client <path>` |
+| Intégration (DB / RLS)     | `tests/integration/` (+ `tests/helpers/`) | `pnpm test:integration`   |
+| E2E                        | `e2e/`                                    | `pnpm test:e2e`           |
+
+- **RLS / `SECURITY DEFINER` / triggers / policies → tests d'intégration OBLIGATOIRES** (`pnpm db:start` puis `pnpm test:integration`).
+- ⚠️ **JAMAIS** valider une fonction `SECURITY DEFINER` par un smoke-test avec `auth.uid()` NULL : le garde sort **avant** la vraie requête → **faux positif** (a déjà laissé partir une RPC cassée en prod). Tester avec un vrai contexte authentifié.
+- Tests **ciblés** > suite complète (contrainte RAM). `pnpm test:changed` pour les fichiers touchés.
+- La CI exécute tout (server shardé ×4, client browser, intégration).
+
+---
+
+## État qualité (repères)
+
+- `pnpm check` (CI, scope `tsconfig.check.json`) : **0 erreur** exigée.
+- Svelte : 0 erreur ; ~25 warnings a11y SVG masqués par `svelte-ignore` (dette connue → [docs/ref/warning-svelte.md](../ref/warning-svelte.md)).
+
+---
+
+> Voir aussi : [best-practices.md](best-practices.md) · [database.md](database.md) · [git-workflow.md](git-workflow.md).

--- a/docs/claude/realtime.md
+++ b/docs/claude/realtime.md
@@ -1,0 +1,138 @@
+# Realtime (Supabase)
+
+Référence synthétique pour Claude : **canaux Realtime Supabase** (presence amis, notifications, achievements, chat, troc/marketplace, multijoueur). Tout vit côté client (`.svelte.ts`), jamais en SSR (garde `browser`). Implémentation : `src/lib/stores/*Realtime.svelte.ts` + `presence.svelte.ts` + `chat.svelte.ts` + `tradeRealtime.svelte.ts` + `multiplayer.svelte.ts`.
+
+---
+
+## Deux mécanismes utilisés (pas de Presence API native)
+
+| Mécanisme              | Quota                              | Latence | Usage dans le code                                                                     |
+| ---------------------- | ---------------------------------- | ------- | -------------------------------------------------------------------------------------- |
+| **`postgres_changes`** | **compte** vers le quota free tier | ~300 ms | Presence amis, notifications, achievements, chat (source de vérité), match multijoueur |
+| **`broadcast`**        | **gratuit**, éphémère              | ~50 ms  | Chat (UX instantanée), troc (offres/validation/chat/presence partenaire)               |
+
+> ⚠️ L'**API Presence native** de Supabase (`channel.track()` / event `presence`) **n'est PAS utilisée**. La « presence » des amis passe par `postgres_changes` sur `user_presence` ; celle du troc par un **event broadcast custom** `'presence'`. Ne pas confondre avec `src/lib/stores/pomodoro/broadcast.ts` qui utilise le **`BroadcastChannel` du navigateur** (sync entre onglets), sans rapport avec Supabase.
+
+---
+
+## Manager central : `supabaseRealtimeManager`
+
+`src/lib/stores/supabaseRealtime.svelte.ts` — singleton qui possède une `Map<string, RealtimeChannel>` et centralise le cycle de vie. **Tous** les stores realtime passent par lui (sauf `multiplayer`, cf. ci-dessous).
+
+```ts
+import { supabaseRealtimeManager } from '$lib/stores/supabaseRealtime.svelte';
+
+supabaseRealtimeManager.init(supabase, userId); // une fois (idempotent — appelé par chaque store)
+const channel = supabaseRealtimeManager.createChannel(channelName); // crée OU renvoie l'existant
+channel.on(
+	'postgres_changes',
+	{ event: 'INSERT', schema: 'public', table: 'notifications', filter },
+	cb
+);
+await supabaseRealtimeManager.subscribeChannel(channelName); // Promise → SUBSCRIBED | reject sur CLOSED/ERROR/TIMED_OUT
+// ...
+await supabaseRealtimeManager.unsubscribeChannel(channelName); // removeChannel + delete de la Map
+await supabaseRealtimeManager.disconnect(); // tous les canaux (cleanup global)
+```
+
+- `createChannel` est **idempotent** : un canal déjà présent dans la Map est renvoyé (pas de double souscription).
+- `subscribeChannel` enveloppe `channel.subscribe(status => …)` dans une **Promise** : `SUBSCRIBED` → `resolve` ; `CLOSED`/`CHANNEL_ERROR`/`TIMED_OUT` → `reject` (évite la Promise pendante). `connectionStatus` est un `$state` (`'connected' | 'disconnected' | 'connecting'`), exposé via `isConnected`.
+
+---
+
+## Convention de nommage des canaux
+
+| Concern                 | Nom du canal                                     | Type                                          |
+| ----------------------- | ------------------------------------------------ | --------------------------------------------- |
+| Presence amis           | `'user-presence-updates'` (const `CHANNEL_NAME`) | postgres_changes                              |
+| Notifications           | `'user-notifications'`                           | postgres_changes                              |
+| Achievements            | `'achievements-realtime'`                        | postgres_changes                              |
+| Chat (par conversation) | `` `chat-${conversationId}` ``                   | broadcast + postgres_changes                  |
+| Troc (par trade)        | `` `trade:${tradeId}` ``                         | broadcast                                     |
+| Match multijoueur       | `` `match:${matchId}` ``                         | postgres_changes (canal direct, hors manager) |
+
+**Un canal par concern** : presence/notifs/achievements ont chacun **un** canal nommé constant ; chat et troc sont **scopés par entité** (`chat-<id>`, `trade:<id>`).
+
+---
+
+## Stores spécialisés
+
+### `presenceManager` — `presence.svelte.ts`
+
+Online/offline des amis via `postgres_changes` sur `user_presence`, filtré `user_id=in.(...)`. **Heartbeat** RPC `upsert_user_presence` toutes les **180 s** (`HEARTBEAT_INTERVAL`, exporté).
+
+```ts
+export const HEARTBEAT_INTERVAL = 180000; // 180 s — CRITIQUE billing, NE PAS changer sans recalculer le quota
+```
+
+- `init(supabase, userId)` → `startPresenceTracking(friendIds)` → `getFriendPresence(id)` (`'online' | 'offline'`, défaut `'offline'`) → `stopPresenceTracking()` (marque offline + clear interval + unsubscribe).
+- Reconnexion auto avec **backoff exponentiel** (`MAX_RECONNECT_ATTEMPTS = 5`, `RECONNECT_DELAY_MS = 5000`) sur les events `system` ≠ `ok`.
+
+### `notificationsRealtimeManager` — `notificationsRealtime.svelte.ts`
+
+`postgres_changes` INSERT/UPDATE sur `notifications` filtré `user_id=eq.${userId}`. **Couche fine** : sur INSERT, déclenche `notificationStore.fetchUnread()` (refetch avec JOINs) plutôt que d'utiliser `payload.new` (brut, sans JOINs). UPDATE = no-op (optimistic déjà appliqué). `startListening()` / `stopListening()`.
+
+### `achievementsRealtimeManager` — `achievementsRealtime.svelte.ts`
+
+`postgres_changes` INSERT sur `student_achievements` filtré `student_id=eq.${userId}`. **Valide le payload** (`isValidPayload`, type guard runtime) avant traitement, puis `achievementsStore.showUnlockToast(...)` + `clearCache()`.
+
+### `chatStore` — `chat.svelte.ts` (hybride)
+
+Stratégie **duale** par conversation : broadcast (50 ms, UX) **+** `postgres_changes` (300 ms, source de vérité avec JOINs), avec **déduplication**.
+
+```
+Envoi    : UI optimiste → broadcast (50 ms) → INSERT DB (200 ms) → postgres_changes (300 ms)
+Réception: broadcast (affiche tout de suite, flag is_broadcast) → postgres_changes (remplace par la version DB)
+```
+
+- **Payloads broadcast validés par Zod** côté réception : `broadcastMessagePayloadSchema`, `broadcastReactionPayloadSchema`, `broadcastReadReceiptPayloadSchema`. Events : `'new_message'`, `'message_reaction'`, `'message_read'`.
+- Dédup : un message broadcast (`is_broadcast: true`) est remplacé par la ligne DB (même `id` ou même `created_at`) à l'arrivée du `postgres_changes`. On ignore son propre broadcast (`sender_id === userId`).
+- API : `subscribeToConversation(id)` / `unsubscribeFromConversation(id)` · `loadConversationHistory(id, limit?)` · `sendMessage(id, content, attachments?)` · `setActiveConversation(id)` · `create1on1Chat(friendId): Promise<string | null>` (null si pas amis) · `reportMessage(messageId, reason, details?): Promise<boolean>` (POST `/api/chat/reports`).
+- Reconnexion par conversation avec backoff (même pattern que presence).
+
+### `tradeRealtime` — `tradeRealtime.svelte.ts` (broadcast pur)
+
+Canal `` `trade:${tradeId}` ``, **100 % broadcast** (le DB sert au chargement initial). Events : `'offer_updated'`, `'validation_changed'`, `'confirmation'`, `'chat_message'`, `'trade_cancelled'`, `'trade_completed'`, `'presence'`.
+
+```ts
+channel.send({ type: 'broadcast', event: 'offer_updated', payload }); // pattern d'émission
+```
+
+- Émissions debouncées : `DEBOUNCE_DELAY = 300` (offre). Heartbeat presence partenaire : `PRESENCE_INTERVAL = 30_000` ; `partnerOnline` est un `$state`. `destroy()` au démontage (pause sur tab caché via `visibilitychange`).
+
+### `multiplayer` — `multiplayer.svelte.ts` (exception)
+
+⚠️ **N'utilise PAS** `supabaseRealtimeManager` : canal direct `supabase.channel(\`match:${matchId}\`)`+`postgres_changes`, nettoyé via `supabase.removeChannel(this.channel)`. C'est documenté dans son en-tête — ne pas « corriger » sans raison.
+
+---
+
+## Cycle de vie & wiring (où c'est branché)
+
+- **Notifications** : `src/routes/(protected)/dashboard/+layout.svelte` — `onMount` → `init` + `startListening` ; cleanup dans un `$effect(() => () => stopListening())`.
+- **Presence amis** : `src/routes/(protected)/dashboard/friends/+page.svelte` — `onMount` → `presenceManager.init(...)` (le tracking démarre dans `friendsManager.loadFriendships()`) ; cleanup `$effect` → `stopPresenceTracking()` **+ `supabaseRealtimeManager.disconnect()`**.
+
+Pattern de cleanup canonique (jamais d'`onMount` retournant un callback en Svelte 5 ici — on utilise `$effect`) :
+
+```svelte
+onMount(() => {
+	manager.init(data.supabase, data.user.id);
+	manager.startListening();
+});
+$effect(() => () => manager.stopListening()); // teardown au démontage
+```
+
+---
+
+## Best practices (non négociables)
+
+1. **Toujours cleanup** au démontage (`$effect(() => () => …)`) — un canal non désinscrit fuit et consomme du quota.
+2. **Garde `browser`** : tous les `init`/`subscribe`/`send` sortent tôt si `!browser` (pas de Realtime en SSR).
+3. **Un canal par concern**, nommage stable (cf. table) — `createChannel` étant idempotent, ne pas recréer manuellement.
+4. **Valider tout payload broadcast avec Zod** côté réception (cf. chat) — un broadcast vient d'un autre client, c'est une **entrée non fiable**.
+5. **`broadcast` pour l'éphémère, `postgres_changes` pour la vérité** : ne pas gaspiller le quota `postgres_changes` sur des signaux transitoires (frappe, presence, curseurs).
+6. **Quota / billing** : `HEARTBEAT_INTERVAL` (180 s) et `PRESENCE_INTERVAL` (30 s) sont calibrés sur le free tier — recalculer avant toute modif.
+7. **Reconnexion** : backoff exponentiel sur events `system` ≠ `ok` (ignorer `status: 'ok'`) ; Supabase gère le bas niveau, mais re-fetch l'état après reconnexion.
+
+---
+
+> Voir aussi : [architecture.md](architecture.md) · [database.md](database.md) · [best-practices.md](best-practices.md).

--- a/docs/claude/ui-components.md
+++ b/docs/claude/ui-components.md
@@ -1,0 +1,247 @@
+# UI Components
+
+Référence synthétique pour Claude : **composants UI obligatoires**, imports Shadcn-svelte, conventions Tailwind 4. Règles non négociables : [CLAUDE.md](../../CLAUDE.md#règles-de-code-non-négociables).
+
+---
+
+## MySelect — sélecteurs (OBLIGATOIRE)
+
+**Règle n°2** : toujours `MySelect` — jamais `<select>` natif, jamais `import * as Select from '$lib/components/ui/select'`.
+
+**Fichier** : `src/lib/components/MySelect.svelte` (construit sur Bits UI `Select`, SSR-compatible, touch-friendly 44 px).
+
+### Props
+
+| Prop                                                                         | Type                                                     | Défaut        | Notes                                    |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------- |
+| `type`                                                                       | `'single' \| 'multiple'`                                 | `'single'`    | Discriminant obligatoire pour `multiple` |
+| `value`                                                                      | `string` (single) \| `string[]` (multiple)               | `$bindable`   | Bind ou callback                         |
+| `items`                                                                      | `{ value: string; label: string; disabled?: boolean }[]` | —             | Requis                                   |
+| `placeholder`                                                                | `string`                                                 | `'Select...'` |                                          |
+| `variant`                                                                    | `'default' \| 'invisible'`                               | `'default'`   | `invisible` = sans bordure visible       |
+| `fitContent`                                                                 | `boolean`                                                | `false`       | Largeur du trigger = label le plus large |
+| `triggerClass`                                                               | `string`                                                 | —             | Remplace la classe calculée              |
+| `onValueChange`                                                              | `(value) => void`                                        | —             | Callback à préférer                      |
+| `onchange`                                                                   | `(value) => void`                                        | —             | Alias rétro-compatible                   |
+| `disabled`, `required`, `name`, `id`, `open`, `onOpenChange`, `contentProps` | —                                                        | —             | Passés à Bits UI                         |
+
+### Usages canoniques
+
+```svelte
+<!-- Single select with bind (most common) -->
+<MySelect type="single" bind:value={grade} {items} placeholder="Sélectionner un niveau" />
+
+<!-- Single select with callback -->
+<MySelect type="single" bind:value={questionType} items={QUESTION_TYPES} />
+
+<!-- Multiple select -->
+<MySelect
+	type="multiple"
+	bind:value={selectedClassIds}
+	{items}
+	placeholder="Sélectionnez une ou plusieurs classes"
+/>
+
+<!-- Invisible variant (inline, no visible border) -->
+<MySelect type="single" bind:value={tempRole} {items} placeholder="Rôle" variant="invisible" />
+
+<!-- fitContent: trigger width matches widest label -->
+<MySelect type="single" bind:value={mode} {items} fitContent />
+```
+
+Exemples réels : `AssessmentConfigForm.svelte` (single + triggerClass), `WorksheetAssignmentForm.svelte` (multiple), `src/routes/(protected)/dashboard/admin/users/+page.svelte` (variant invisible).
+
+---
+
+## MyCheckbox — cases à cocher (OBLIGATOIRE)
+
+**Règle n°2** : toujours `MyCheckbox` — jamais `<input type="checkbox">` natif, jamais `import { Checkbox } from '$lib/components/ui/checkbox'` en direct.
+
+**Fichier** : `src/lib/components/MyCheckbox.svelte` (wrapper Shadcn Checkbox + Label auto-connecté, touch-friendly 44 px).
+
+### Props
+
+| Prop                      | Type                                      | Défaut             | Notes                                     |
+| ------------------------- | ----------------------------------------- | ------------------ | ----------------------------------------- |
+| `checked`                 | `boolean`                                 | `$bindable(false)` | Bind                                      |
+| `label`                   | `string`                                  | —                  | Texte du label (sinon snippet `children`) |
+| `labelClass`              | `string`                                  | `''`               | Classes supplémentaires pour le Label     |
+| `disabled`                | `boolean`                                 | `false`            |                                           |
+| `required`                | `boolean`                                 | `false`            |                                           |
+| `onCheckedChange`         | `(v: boolean \| 'indeterminate') => void` | —                  | Callback complet                          |
+| `onchange`                | `(v: boolean) => void`                    | —                  | Alias simplifié (booléen seulement)       |
+| `checkboxRef`, `labelRef` | `$bindable`                               | —                  | Refs DOM optionnelles                     |
+| `children`                | snippet                                   | —                  | Rendu personnalisé du label               |
+
+### Usages canoniques
+
+```svelte
+<!-- Basic labeled checkbox -->
+<MyCheckbox bind:checked={shuffleTerms} label="Mélanger les termes (sommes)" />
+
+<!-- Checkbox without bind, with callback -->
+<MyCheckbox checked={soundEnabled} label="Son de fin" onchange={handleSoundChange} />
+
+<!-- Indeterminate state (select-all pattern) -->
+<MyCheckbox checked={allVisibleSelected} onCheckedChange={toggleSelectAll} />
+
+<!-- Checkbox with custom label content (snippet) -->
+<MyCheckbox bind:checked={agree}>
+	J'accepte les <a href="/cgu">conditions</a>
+</MyCheckbox>
+```
+
+Exemples réels : `DisplayOptionsEditor.svelte` (série de checkboxes), `ChecklistSection.svelte` (onCheckedChange sans bind), `PomodoroSettings.svelte` (onchange alias).
+
+---
+
+## Shadcn-svelte — inventaire et imports
+
+**Emplacement** : `src/lib/components/ui/<composant>/`
+
+**Règle d'import** : composants « simples » → import nommé ; composants « composés » (sous-parties) → import namespace `* as X`.
+
+```svelte
+<!-- Named import for atomic components -->
+import {Button} from '$lib/components/ui/button'; import {Input} from '$lib/components/ui/input'; import
+{Label} from '$lib/components/ui/label'; import {Badge} from '$lib/components/ui/badge'; import {Switch}
+from '$lib/components/ui/switch'; import {Textarea} from '$lib/components/ui/textarea'; import {Separator}
+from '$lib/components/ui/separator'; import {Skeleton} from '$lib/components/ui/skeleton'; import {Progress}
+from '$lib/components/ui/progress';
+
+<!-- Namespace import for compound components -->
+import * as Card from '$lib/components/ui/card'; import * as Dialog from '$lib/components/ui/dialog';
+import * as DropdownMenu from '$lib/components/ui/dropdown-menu'; import * as Sheet from '$lib/components/ui/sheet';
+import * as Tabs from '$lib/components/ui/tabs'; import * as Collapsible from '$lib/components/ui/collapsible';
+import * as Avatar from '$lib/components/ui/avatar'; import * as Accordion from '$lib/components/ui/accordion';
+```
+
+**Composants disponibles** (dossiers dans `src/lib/components/ui/`) : accordion · alert · avatar · badge · breadcrumb · button · calendar · card · checkbox · collapsible · confirm-dialog · dialog · dropdown-menu · input · label · popover · progress · radio-group · scroll-area · separator · sheet · skeleton · slider · switch · table · tabs · textarea · tooltip.
+
+### Snippets d'usage fréquents
+
+```svelte
+<!-- DropdownMenu with navigation link -->
+<DropdownMenu.Item>
+	<a href="/dashboard">Tableau de bord</a>
+</DropdownMenu.Item>
+
+<!-- Card compound -->
+<Card.Root>
+	<Card.Header><Card.Title>Titre</Card.Title></Card.Header>
+	<Card.Content>…</Card.Content>
+</Card.Root>
+
+<!-- Dialog -->
+<Dialog.Root bind:open>
+	<Dialog.Trigger asChild let:builder>…</Dialog.Trigger>
+	<Dialog.Content>
+		<Dialog.Header><Dialog.Title>…</Dialog.Title></Dialog.Header>
+		…
+	</Dialog.Content>
+</Dialog.Root>
+```
+
+### ConfirmDialog (composant custom)
+
+Boîte de confirmation réutilisable (titre + description + variante destructive).
+
+```svelte
+import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte'; // ou : import {ConfirmDialog}
+from '$lib/components/ui/confirm-dialog';
+
+<ConfirmDialog
+	bind:open={showConfirm}
+	title="Supprimer ?"
+	description="Cette action est irréversible."
+	variant="destructive"
+	onConfirm={handleDelete}
+/>
+```
+
+---
+
+## UserAvatar — avatars utilisateurs
+
+Ne pas utiliser directement les primitives Shadcn Avatar. Utiliser **`UserAvatar`** :
+
+```svelte
+import UserAvatar from '$lib/components/UserAvatar.svelte';
+
+<UserAvatar
+  avatar_url={user.avatar_url}
+  role={user.role}
+  firstname={user.firstname}
+  lastname={user.lastname}
+  class="h-8 w-8"
+  decorative={true}   <!-- set true when parent already provides a11y name -->
+/>
+```
+
+`loading="lazy"` par défaut (évite les batchs 429 sur l'API Google avatars quand de nombreux avatars sont montés en même temps).
+
+---
+
+## Éditeur de texte riche
+
+**Composant** : `src/lib/components/rich-text/RichTextEditor.svelte` — unifié form + chat.
+
+```svelte
+import RichTextEditor from '$lib/components/rich-text/RichTextEditor.svelte';
+
+<!-- Form mode (default) — bidirectionnel via htmlValue -->
+let content = $state('');
+<RichTextEditor bind:htmlValue={content} />
+
+<!-- Chat mode — send callback, vidage après envoi -->
+<RichTextEditor mode="chat" onSend={(json) => handleSend(json)} enterToSend />
+```
+
+Props clés : `preset` (`'full'` par défaut), `toolbar`, `minHeight`, `maxHeight`, `disabled`, `imageUpload`, `onchange`.  
+Pour l'affichage seul : `RichTextDisplay.svelte` (pas d'éditeur).
+
+---
+
+## Notifications toast
+
+```svelte
+import {toaster} from '$lib/stores/toaster.svelte'; toaster.success('Évaluation créée'); toaster.error('Erreur
+lors de la sauvegarde'); toaster.warning('Aucun élève sélectionné'); toaster.info('Synchronisation en
+cours…'); toaster.message('Message neutre'); // sans icône de statut
+```
+
+Wrapper sur `svelte-sonner`. Le Toaster est monté dans le layout racine.
+
+---
+
+## Thème & taille de police
+
+```svelte
+import {theme} from '$lib/stores/theme.svelte'; import {fontSize} from '$lib/stores/fontSize.svelte';
+theme.toggle(); // bascule clair/sombre (via mode-watcher) theme.dark; // boolean réactif fontSize.increase();
+// +12,5 % (max 150 %) fontSize.decrease(); // −12,5 % (min 75 %) fontSize.reset(); // 100 % fontSize.size;
+// scale actuelle (0.75–1.5) fontSize.canIncrease; // boolean
+```
+
+La variable CSS `--font-scale` est appliquée sur `<html>`. Le scaling n'affecte que `<main>` via des règles `calc()` dans `app.css`.
+
+---
+
+## Tailwind 4 — conventions
+
+- **Mobile-first** : classes sans préfixe = mobile ; `sm:` / `md:` / `lg:` pour les breakpoints supérieurs.
+- **Tokens sémantiques** (ne pas hard-coder les couleurs) : `bg-background`, `text-foreground`, `border-border`, `bg-muted`, `text-muted-foreground`, `bg-card`, `text-card-foreground`, `bg-popover`, `bg-accent`, `text-accent-foreground`, `text-destructive`.
+- **`cn()` pour les classes conditionnelles** :
+
+```svelte
+import {cn} from '$lib/utils';
+
+<div class={cn('flex gap-2', isActive && 'bg-accent', className)}>…</div>
+```
+
+- **`prettier-plugin-tailwindcss`** est configuré : les classes sont triées automatiquement au `prettier --write`. Ne pas trier manuellement.
+- Touch targets : les wrappers `MySelect` / `MyCheckbox` appliquent `min-height: 44px` via `@media (pointer: coarse)` — ne pas écraser cette règle.
+
+---
+
+> Voir aussi : [best-practices.md](best-practices.md) · [quality-standards.md](quality-standards.md) · [architecture.md](architecture.md).

--- a/docs/wip/claude-docs-rewrite-progress.md
+++ b/docs/wip/claude-docs-rewrite-progress.md
@@ -1,0 +1,35 @@
+# Réécriture des références `docs/claude/` — progress
+
+> Branche `docs/rewrite-claude-references`. Crash-recovery.
+
+## Contexte
+
+Les 6 docs de référence Claude (`docs/claude/*.md`) avaient été retirés par `5de2c6116 "docs: clean docs"` (2025-12-23), mais `CLAUDE.md` (réécrit juin 2026) les référence toujours → **liens morts**. Décision David : **réécrire** ces docs comme **références synthétiques à jour** (pas restaurer le périmé). Les anciennes versions (`git show 5de2c6116^:docs/claude/<f>.md`) servent de **squelette de sujets uniquement** — tout vérifié sur le code actuel.
+
+## Contraintes
+
+- **Style** : prose FR, code/headings EN, dense, tableaux, exemples réels du code, pointeurs `docs/ref/`, ~85-250 lignes. Calibré sur `quality-standards.md`.
+- **Ancres à préserver** (liens `CLAUDE.md`) : `quality-standards.md#input-validation-with-zod` ✅, `best-practices.md#svelte-5-runes` (heading exact `## Svelte 5 Runes`).
+- Pas de build/lint/check (OOM).
+
+## Statut
+
+- [x] **quality-standards.md** — calibrage, validé (85 l, grounded : oxlint/check:incremental/eslint, lib Zod 69 fichiers + règle `custom/require-zod-validation` error, archi tests).
+- [x] **architecture.md** (144 l) — structure, groupes de routes, SSR/TDZ Safari, perf, système de questions. Corrige des chemins inventés de l'ancienne version.
+- [x] **best-practices.md** (385 l) — `## Svelte 5 Runes` (ancre OK), TS, ordre fichier, 3 patterns clients SSR, locals, anti-patterns. Exemples réels.
+- [x] **ui-components.md** (266 l) — API réelles MySelect/MyCheckbox, 28 dossiers Shadcn, toaster, Tailwind 4. Corrige `FormRichTextEditor`→`RichTextEditor`.
+- [x] **database.md** (123 l) — EU, migrations (additif/destructif), types-helpers, RLS Option B (helpers réels), tests intégration, `auth.uid()` NULL.
+- [x] **realtime.md** (134 l) — postgres_changes/broadcast, manager central, 6 stores réels + constantes exactes, lifecycle.
+
+**Vérif (toutes ✅)** : 2 ancres `CLAUDE.md` présentes · 0 lien cassé · 0 lien-ancre cassé · 0 fuite mémoire (2 liens `(mémoire)` injectés par l'agent supabase → corrigés).
+
+## Reste après les agents
+
+1. Relecture cohérence + **vérif ancres** (`#svelte-5-runes`, `#input-validation-with-zod`).
+2. `pnpm check:incremental` (les .md ne sont pas typés, mais sanity) + liens internes.
+3. Vérifier que les liens `CLAUDE.md` → `docs/claude/*.md` résolvent tous.
+4. Commit + PR (6 fichiers → branche obligatoire) + CI + merge.
+
+## Definition of Done
+
+6 docs à jour + grounded · 2 ancres OK · liens `CLAUDE.md` valides · style cohérent · CI verte.


### PR DESCRIPTION
## Pourquoi

`CLAUDE.md` (réécrit juin 2026) référence 6 docs `docs/claude/*.md` qui avaient été retirés par `5de2c6116 'docs: clean docs'` (2025-12-23) → **liens morts**. Ces docs sont des **références synthétiques pour Claude** : on les **réécrit à jour** (pas restaurer le périmé).

## Quoi

6 docs réécrits, **chacun vérifié sur le code actuel** (les vieilles versions n'ont servi que de squelette de sujets) :

| Doc | Lignes | Contenu |
|---|---|---|
| `quality-standards.md` | 85 | linting (oxlint/check:incremental/eslint CI), Zod, tests |
| `architecture.md` | 144 | structure, routes, SSR/TDZ Safari, perf |
| `best-practices.md` | 385 | Svelte 5 runes, TS, locals, clients SSR, anti-patterns |
| `ui-components.md` | 266 | MySelect/MyCheckbox (API réelles), Shadcn, Tailwind |
| `database.md` | 123 | EU, migrations, types-helpers, RLS Option B, tests |
| `realtime.md` | 134 | postgres_changes/broadcast, manager, 6 stores, lifecycle |

## Style

Synthétique (vs 800-1400 l avant), prose FR + code EN, tableaux + exemples réels du code + pointeurs `docs/ref/`.

## Vérifié

- **2 ancres préservées** (`best-practices.md#svelte-5-runes`, `quality-standards.md#input-validation-with-zod`) — liens `CLAUDE.md` OK.
- 0 lien cassé · 0 lien-ancre cassé · 0 fuite de mémoire.
- Corrections de fond vs l'ancien (chemins inventés, `test:triggers`→`test:integration`, `FormRichTextEditor`→`RichTextEditor`, Presence native inexistante, etc.).

## Portée

Docs uniquement. Progress : `docs/wip/claude-docs-rewrite-progress.md`.