### PR TITLE
chore(db): drop is_public columns on chapter/worksheet templates

### DIFF
--- a/supabase/migrations/20260618100000_drop_is_public_template_columns.sql
+++ b/supabase/migrations/20260618100000_drop_is_public_template_columns.sql
@@ -1,0 +1,23 @@
+-- Drop the now-unused is_public columns on the two template families
+-- ===================================================================
+--
+-- Inter-teacher content sharing was removed (RLS + app code) in migration
+-- 20260618093000 + PR #26, which is deployed. No code reads or writes these
+-- columns anymore. This destructive cleanup runs AFTER that deploy
+-- (additive-before / destructive-after). See docs/wip/option-b-unification-progress.md.
+
+-- A public-library leftover #26 missed: this policy grants teachers cross-creator
+-- access to versions of PUBLIC published templates (it references chapter_templates.is_public,
+-- which also blocks the column drop). The owner-scoped "Teachers can view versions of
+-- their templates" (ct.created_by = auth.uid()) remains, so a teacher keeps access to
+-- versions of their OWN templates.
+DROP POLICY IF EXISTS "Teachers can view versions of public templates" ON public.chapter_template_versions;
+
+-- Indexes (idx_chapter_templates_public_status, idx_worksheet_templates_is_public) and
+-- column defaults auto-drop with the columns.
+ALTER TABLE public.chapter_templates DROP COLUMN IF EXISTS is_public;
+ALTER TABLE public.worksheet_templates DROP COLUMN IF EXISTS is_public;
+
+-- Cosmetic: the is_admin() COMMENT wrongly said "admin or teacher"; the body
+-- checks role = 'admin' only. Fix it while we're here (flagged in #26 review).
+COMMENT ON FUNCTION public.is_admin() IS 'True when the current user has role = admin.';

--- a/tests/integration/inter-teacher-sharing-removed.test.ts
+++ b/tests/integration/inter-teacher-sharing-removed.test.ts
@@ -51,7 +51,7 @@ describe('Inter-teacher sharing removed - Integration Tests', () => {
 	// chapter_templates — public library removed
 	// ========================================================================
 
-	it('the teacher cannot see the admin public published chapter template', async () => {
+	it('the teacher cannot see the admin published chapter template', async () => {
 		const teacher = await TestData.profile().withRole('teacher').create();
 		const admin = await TestData.profile().withRole('admin').create();
 
@@ -59,9 +59,8 @@ describe('Inter-teacher sharing removed - Integration Tests', () => {
 			.from('chapter_templates')
 			.insert({
 				created_by: admin.id,
-				title: 'Public lib template',
-				status: 'published',
-				is_public: true
+				title: 'Admin template',
+				status: 'published'
 			})
 			.select()
 			.single();
@@ -77,7 +76,7 @@ describe('Inter-teacher sharing removed - Integration Tests', () => {
 
 		const { data: tpl } = await service
 			.from('chapter_templates')
-			.insert({ created_by: teacher.id, title: 'Mine', status: 'draft', is_public: false })
+			.insert({ created_by: teacher.id, title: 'Mine', status: 'draft' })
 			.select()
 			.single();
 
@@ -142,7 +141,7 @@ describe('Inter-teacher sharing removed - Integration Tests', () => {
 	// worksheet_templates — public library removed
 	// ========================================================================
 
-	it('the teacher cannot see the admin public worksheet template', async () => {
+	it('the teacher cannot see the admin worksheet template', async () => {
 		const teacher = await TestData.profile().withRole('teacher').create();
 		const admin = await TestData.profile().withRole('admin').create();
 
@@ -150,9 +149,8 @@ describe('Inter-teacher sharing removed - Integration Tests', () => {
 			.from('worksheet_templates')
 			.insert({
 				created_by: admin.id,
-				name: 'Public WS template',
-				template_content: 'content',
-				is_public: true
+				name: 'Admin WS template',
+				template_content: 'content'
 			})
 			.select()
 			.single();


### PR DESCRIPTION
## Quoi

PR de suivi **destructive** du chantier Option B (#26, déjà mergée + déployée + `db:migrate` fait). Retire les colonnes `is_public` devenues inutiles sur `chapter_templates` et `worksheet_templates` (le partage de contenu inter-profs a été supprimé dans #26).

Migration `20260618100000_drop_is_public_template_columns.sql` :
- `DROP POLICY "Teachers can view versions of public templates"` sur `chapter_template_versions` — **reliquat de bibliothèque publique que #26 avait manqué** (il référençait `chapter_templates.is_public` et bloquait le drop). L'owner-scoped *« Teachers can view versions of their templates »* (`ct.created_by = auth.uid()`) reste → le prof garde l'accès aux versions de **ses** templates.
- `DROP COLUMN is_public` sur `chapter_templates` + `worksheet_templates` (les index `idx_*_public*` et defaults se droppent automatiquement avec les colonnes).
- Fix cosmétique du COMMENT de `is_admin()` (signalé en revue #26).

Tests : `inter-teacher-sharing-removed.test.ts` — retrait de `is_public` des inserts des 2 tables (`exercises.is_public` **conservé**). Intégration verte en local (7/7), `check:incremental` 0 erreur.

## ⚠️ Étape post-merge (ordre destructif-après-deploy)

1. Merge (ton accord) → deploy.
2. `pnpm db:migrate` (applique le drop en prod EU).
3. **Puis** `pnpm db:types` (régénère `database.ts` depuis la prod — retire `is_public` proprement) + retirer les rares mocks `is_public` inertes (`templates/__tests__/routes.test.ts`, fixture `worksheet-generator`) → commit.

`database.ts` n'est **pas** modifié dans cette PR : la prod a encore la colonne jusqu'au `db:migrate`, et un regen local introduit du bruit (bloc `graphql_public`). Le regen canonique se fait depuis la prod après migrate (flux standard du projet).