### PR TITLE
feat(auth): server-side admin elevation foundation (step-up, Pattern 2)

### DIFF
--- a/docs/wip/admin-elevation-progress.md
+++ b/docs/wip/admin-elevation-progress.md
@@ -60,6 +60,15 @@ Point clé (vérifié) : le `role` vient de la **DB** (`getUserProfile`, `src/li
   - **Forme** : ops **ciblées** (supprimer une école/un compte/un enregistrement précis) → taper le **nom exact** de la ressource ; ops **globales** (cron destructif, anti-fraude, purge) → taper un **mot-clé fixe** (nom de l'action, ex. `LANCER-CRON`).
   - **Application** : l'endpoint exige un champ `confirm` === valeur attendue (validé **serveur**, pas seulement UI → non contournable par appel API direct).
 
+## Sécurité — durcissement (audit, 2026-06-18)
+
+- **Buckets de rate-limit dédiés** (`ratelimit:elevate:ip:*` / `ratelimit:elevate:email:*`, 5/IP + 3/email par 15 min) — **distincts** des buckets `/auth/login`. Un mot de passe admin mal tapé ne consomme plus le budget de connexion → pas de lockout de l'admin sur la vraie page de login (ni vecteur de lockout ciblé).
+- **Cookie `SameSite=Strict`** (set + delete) : le cookie confère toute l'autorité admin et n'est lu que par des requêtes in-app same-site → aucun besoin cross-site, et atténuation CSRF supplémentaire.
+- **Handle scopé aux chemins admin** : `createAdminElevationHandle` court-circuite (aucun I/O : pas de `getUser()`, pas de requête `profiles`) si le chemin n'est pas `/dashboard/admin*` ni `/api/admin*` → un cookie périmé/forgé ne fait plus payer un round-trip à chaque requête (perf/DoS).
+- **Révocation best-effort côté serveur** : `revoke` tente un `signOut()` sur le client admin (Bearer → logout GoTrue) avant d'effacer le cookie, pour invalider la session côté serveur quand c'est possible (try/catch, échec ignoré).
+- **Fenêtre de fuite acceptée (≤ 1 h)** — **décision consciente** : si le `signOut()` server-side n'a pas lieu (handle n'a pas peuplé `adminSupabase`, ou l'appel échoue), l'**access token** admin reste valide chez GoTrue jusqu'à son expiration naturelle (≤ 1 h). Exposition minimale assumée : access-token **uniquement** (jamais de refresh token stocké), cookie httpOnly + secure + `SameSite=Strict`, **un seul** compte admin. On accepte cette fenêtre plutôt que d'ajouter une infra de révocation de token.
+- **Pas de log du token, ni de l'UUID admin en clair** : `elevate` ne logue qu'un préfixe masqué de l'UUID (`xxxxxxxx***`) ; le token n'est jamais logué.
+
 ## Phasing
 
 1. **Phase 1 — tests d'abord** : intégration (handle d'élévation + `requireAdmin` + RLS admin via `adminSupabase` sur une table admin) + unit (endpoints elevate/revoke, garde de layout). Fixtures : prof, admin.

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,6 +13,17 @@ declare global {
 			user: User | null;
 			profile: Profile | null;
 			requestId: string;
+			/**
+			 * Admin-scoped Supabase client, present only when the request carries a
+			 * valid admin elevation (Pattern 2). Queries through this client run with
+			 * RLS evaluated as `auth.uid() = <admin>`. Set by adminElevationHandle.
+			 */
+			adminSupabase?: SupabaseClient;
+			/**
+			 * Admin elevation state for this request. `null`/absent → not elevated.
+			 * `expiresAt` is a Unix epoch in milliseconds. Set by adminElevationHandle.
+			 */
+			adminElevation?: { active: boolean; adminUserId: string; expiresAt: number } | null;
 		}
 		interface PageData {
 			user: User | null;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { handle as supabaseHandle } from '$lib/server/supabase';
 import { maintenanceHandle } from '$lib/server/maintenance';
+import { adminElevationHandle } from '$lib/server/adminElevation';
 import { sequence } from '@sveltejs/kit/hooks';
 import type { Handle } from '@sveltejs/kit';
 import { logError, getUserContext } from '$lib/server/errorMonitoring';
@@ -514,13 +515,16 @@ const securityHeadersHandle: Handle = async ({ event, resolve }) => {
 
 // Combine hooks in sequence: Request ID first (for tracing), then maintenance gate
 // (BEFORE Supabase so it works with the DB frozen/unreachable), then Supabase, then others
-// Order matters: Request ID -> Maintenance -> Supabase auth -> Redirects -> User/Profile loading -> CSRF validation -> Security Headers -> Error monitoring
+// Order matters: Request ID -> Maintenance -> Supabase auth -> Redirects -> User/Profile loading
+// -> Admin elevation (reads the elevation cookie, builds locals.adminSupabase; AFTER profile
+// loading so DB role is available, BEFORE CSRF) -> CSRF validation -> Security Headers -> Error monitoring
 export const handle: Handle = sequence(
 	requestIdHandle,
 	maintenanceHandle,
 	supabaseHandle,
 	redirectHandle,
 	userProfileHandle,
+	adminElevationHandle,
 	csrfHandle,
 	securityHeadersHandle,
 	errorMonitoringHandle

--- a/src/lib/server/__tests__/adminElevation.test.ts
+++ b/src/lib/server/__tests__/adminElevation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Admin Elevation — Pure Helpers Unit Tests
+ * =========================================
+ *
+ * Covers the UNIT-TESTABLE, side-effect-free parts of the server-side admin
+ * elevation (Pattern 2):
+ *   - encodeElevationCookie / decodeElevationCookie round-trip
+ *   - decode of malformed cookie values → null
+ *   - decode of expired payloads → null
+ *
+ * The handle (createAdminElevationHandle) and the request-scoped admin client
+ * (createAdminClient) are covered elsewhere because they have I/O side effects
+ * (getUser network call, header injection); these helpers are pure.
+ *
+ * @module server/adminElevation.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	ADMIN_ELEVATION_COOKIE,
+	encodeElevationCookie,
+	decodeElevationCookie,
+	type ElevationCookiePayload
+} from '../adminElevation';
+
+const ADMIN_ID = '550e8400-e29b-41d4-a716-446655440002';
+const ACCESS_TOKEN = 'header.payload.signature-pretend-jwt';
+
+/** A payload that expires comfortably in the future (1 hour). */
+function futurePayload(overrides: Partial<ElevationCookiePayload> = {}): ElevationCookiePayload {
+	return {
+		adminUserId: ADMIN_ID,
+		accessToken: ACCESS_TOKEN,
+		expiresAt: Date.now() + 3600_000,
+		...overrides
+	};
+}
+
+describe('ADMIN_ELEVATION_COOKIE', () => {
+	it('is named without the reserved sb- prefix (must stay transparent to @supabase/ssr)', () => {
+		expect(ADMIN_ELEVATION_COOKIE).toBe('ubu-admin-elevation');
+		expect(ADMIN_ELEVATION_COOKIE.startsWith('sb-')).toBe(false);
+	});
+});
+
+describe('encodeElevationCookie / decodeElevationCookie — round-trip', () => {
+	it('decodes back exactly what was encoded', () => {
+		const payload = futurePayload();
+		const encoded = encodeElevationCookie(payload);
+
+		expect(typeof encoded).toBe('string');
+		expect(encoded.length).toBeGreaterThan(0);
+
+		const decoded = decodeElevationCookie(encoded);
+		expect(decoded).not.toBeNull();
+		expect(decoded).toEqual(payload);
+	});
+
+	it('produces an opaque value that does not leak the raw token in plain text', () => {
+		// base64url-encoded JSON: the access token must not appear verbatim.
+		const encoded = encodeElevationCookie(futurePayload());
+		expect(encoded).not.toContain(ACCESS_TOKEN);
+	});
+});
+
+describe('decodeElevationCookie — malformed input → null', () => {
+	it('returns null for an empty string', () => {
+		expect(decodeElevationCookie('')).toBeNull();
+	});
+
+	it('returns null for non-base64 / garbage', () => {
+		expect(decodeElevationCookie('!!!not-base64!!!')).toBeNull();
+	});
+
+	it('returns null for valid base64 that is not JSON', () => {
+		const notJson = Buffer.from('this is not json', 'utf8').toString('base64url');
+		expect(decodeElevationCookie(notJson)).toBeNull();
+	});
+
+	it('returns null when required fields are missing', () => {
+		const missingToken = Buffer.from(
+			JSON.stringify({ adminUserId: ADMIN_ID, expiresAt: Date.now() + 3600_000 }),
+			'utf8'
+		).toString('base64url');
+		expect(decodeElevationCookie(missingToken)).toBeNull();
+	});
+
+	it('returns null when field types are wrong', () => {
+		const wrongTypes = Buffer.from(
+			JSON.stringify({ adminUserId: 42, accessToken: ACCESS_TOKEN, expiresAt: 'soon' }),
+			'utf8'
+		).toString('base64url');
+		expect(decodeElevationCookie(wrongTypes)).toBeNull();
+	});
+});
+
+describe('decodeElevationCookie — expiry', () => {
+	it('returns null when expiresAt is in the past', () => {
+		const expired = encodeElevationCookie(futurePayload({ expiresAt: Date.now() - 1 }));
+		expect(decodeElevationCookie(expired)).toBeNull();
+	});
+
+	it('returns the payload when expiresAt is in the future', () => {
+		const valid = encodeElevationCookie(futurePayload({ expiresAt: Date.now() + 60_000 }));
+		const decoded = decodeElevationCookie(valid);
+		expect(decoded).not.toBeNull();
+		expect(decoded?.adminUserId).toBe(ADMIN_ID);
+	});
+});
+
+describe('decodeElevationCookie — expiresAt is in MILLISECONDS (ms-vs-seconds guard)', () => {
+	// The whole expiry contract (`expiresAt < Date.now()`, the elevate endpoint's
+	// `expiresAtSec * 1000`, the handle's `payload.expiresAt`) assumes ms. If a
+	// refactor ever passed seconds, a "1h" token would look ~50 years in the past
+	// and every elevation would silently fail. Lock the unit here.
+	it('round-trips a known ms value exactly (must NOT be divided/multiplied)', () => {
+		// 2025-06-18T00:00:00Z in ms — a concrete, well-known value.
+		const knownMs = 1_750_204_800_000;
+		const encoded = encodeElevationCookie(futurePayload({ expiresAt: knownMs }));
+		// Decode bypasses the freshness check (knownMs is in the future at test time
+		// only if > now); assert on the raw JSON to be time-independent.
+		const json = Buffer.from(encoded, 'base64url').toString('utf8');
+		const raw = JSON.parse(json) as { expiresAt: number };
+		expect(raw.expiresAt).toBe(knownMs);
+		// Sanity: a millisecond epoch is ~13 digits and well above the 1e12 boundary
+		// that separates it from a seconds epoch (~10 digits, ~1.7e9).
+		expect(raw.expiresAt).toBeGreaterThan(1e12);
+		expect(String(raw.expiresAt).length).toBe(13);
+	});
+
+	it('treats a SECONDS-magnitude expiry as already expired (proves ms semantics)', () => {
+		// A seconds epoch (~1.75e9) is far below Date.now()-in-ms → must decode null,
+		// which is exactly what would happen if someone wrongly stored seconds.
+		const secondsMagnitude = Math.floor(Date.now() / 1000); // ~1.7e9, NOT ms
+		const encoded = encodeElevationCookie(futurePayload({ expiresAt: secondsMagnitude }));
+		expect(decodeElevationCookie(encoded)).toBeNull();
+	});
+});

--- a/src/lib/server/adminElevation.ts
+++ b/src/lib/server/adminElevation.ts
@@ -1,0 +1,264 @@
+/**
+ * Server-Side Admin Elevation (Pattern 2 — "step-up")
+ * ===================================================
+ *
+ * A teacher stays logged in (their own `sb-*` session, `profile.role==='teacher'`).
+ * To act as admin they POST the **admin account's** credentials to
+ * `/api/admin/elevate`; the server verifies them with an EPHEMERAL client and
+ * sets a short-lived httpOnly cookie holding the admin **access token**. On each
+ * subsequent request, {@link createAdminElevationHandle} reads that cookie,
+ * verifies the token with Supabase (`getUser(token)`), confirms the resolved
+ * user is an admin, and exposes a request-scoped admin-context Supabase client
+ * as `locals.adminSupabase` (RLS runs as `auth.uid() = <admin>`).
+ *
+ * The teacher's own JWT never gains admin power — admin authority lives entirely
+ * in this parallel state, gated by {@link createAdminElevationHandle}.
+ *
+ * ## Cookie design (decided)
+ * - Name `ubu-admin-elevation` — deliberately NOT `sb-*` so `@supabase/ssr`
+ *   ignores it and it's filtered out of the client payload by `+layout.server.ts`.
+ * - Value: base64url-encoded JSON `{ adminUserId, accessToken, expiresAt }`.
+ *   The access token is a real Supabase JWT — its integrity comes from the
+ *   token's own signature (verified by `getUser(token)`), exactly like the
+ *   `sb-*` cookies, so NO custom crypto/secret is needed. `adminUserId` +
+ *   `expiresAt` are stored alongside for cheap pre-checks; `getUser(token)`
+ *   remains the source of truth.
+ * - httpOnly + secure(!dev) + sameSite=lax; TTL ≈ access-token lifetime (~1h).
+ *   On expiry → not elevated → re-elevate (no silent refresh).
+ *
+ * ## Security boundaries
+ * - This module NEVER touches `locals.supabase` or the `sb-*` cookies.
+ * - `createAdminClient` / `createEphemeralAuthClient` never persist a session
+ *   (`persistSession:false`, `autoRefreshToken:false`) and never write cookies.
+ *
+ * @module server/adminElevation
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+import type { Handle } from '@sveltejs/kit';
+import type { Database } from '$lib/types/database';
+import { createLogger } from '$lib/utils/logger';
+
+const logger = createLogger('server/adminElevation.ts');
+
+/**
+ * Name of the elevation cookie. MUST NOT start with `sb-` (otherwise
+ * `@supabase/ssr` would try to interpret it as part of the auth session).
+ */
+export const ADMIN_ELEVATION_COOKIE = 'ubu-admin-elevation';
+
+/**
+ * Decoded contents of the elevation cookie.
+ * - `accessToken`: the admin's Supabase access token (a signed JWT).
+ * - `adminUserId`: the admin's `auth.users.id` (for cheap pre-checks).
+ * - `expiresAt`: Unix epoch in **milliseconds** (token expiry).
+ */
+export interface ElevationCookiePayload {
+	adminUserId: string;
+	accessToken: string;
+	expiresAt: number;
+}
+
+// ============================================================================
+// PURE COOKIE HELPERS (unit-testable, no I/O)
+// ============================================================================
+
+/**
+ * Encode an elevation payload into an opaque cookie value (base64url JSON).
+ * No encryption: the payload's integrity is the access token's JWT signature,
+ * verified later by {@link createAdminElevationHandle} via `getUser(token)`.
+ */
+export function encodeElevationCookie(payload: ElevationCookiePayload): string {
+	const json = JSON.stringify(payload);
+	return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+/**
+ * Decode an elevation cookie value.
+ *
+ * Returns `null` (treated as "not elevated") when the value is:
+ * - malformed (not base64url / not JSON / missing or wrong-typed fields), or
+ * - expired (`expiresAt < now`).
+ *
+ * This is a structural + freshness check only; the token signature is still
+ * verified separately by `getUser(token)` before any elevation is granted.
+ */
+export function decodeElevationCookie(value: string): ElevationCookiePayload | null {
+	if (!value) return null;
+
+	let parsed: unknown;
+	try {
+		const json = Buffer.from(value, 'base64url').toString('utf8');
+		parsed = JSON.parse(json);
+	} catch {
+		return null;
+	}
+
+	if (typeof parsed !== 'object' || parsed === null) return null;
+	const candidate = parsed as Record<string, unknown>;
+
+	const { adminUserId, accessToken, expiresAt } = candidate;
+	if (
+		typeof adminUserId !== 'string' ||
+		typeof accessToken !== 'string' ||
+		typeof expiresAt !== 'number' ||
+		!Number.isFinite(expiresAt)
+	) {
+		return null;
+	}
+
+	// Expired → not elevated.
+	if (expiresAt < Date.now()) return null;
+
+	return { adminUserId, accessToken, expiresAt };
+}
+
+// ============================================================================
+// REQUEST-SCOPED CLIENTS (no session persistence, no cookie writes)
+// ============================================================================
+
+/**
+ * Build a request-scoped Supabase client that authenticates AS the admin by
+ * sending `Authorization: Bearer <accessToken>` on every request, so RLS runs
+ * with `auth.uid() = <admin>`.
+ *
+ * The client does NOT persist a session and does NOT manage cookies — it lives
+ * only for the duration of the current request.
+ */
+export function createAdminClient(accessToken: string): SupabaseClient<Database> {
+	return createClient<Database>(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+		auth: {
+			persistSession: false,
+			autoRefreshToken: false,
+			detectSessionInUrl: false
+		},
+		global: {
+			headers: { Authorization: `Bearer ${accessToken}` }
+		}
+	});
+}
+
+/**
+ * Build an EPHEMERAL client used solely to verify admin credentials in the
+ * elevate endpoint (`signInWithPassword`). Crucially it persists nothing and
+ * writes no cookies, so verifying the admin's password NEVER touches the
+ * caller's (teacher's) `sb-*` session.
+ *
+ * The plain `@supabase/supabase-js` `createClient` (not the SSR/cookie variant)
+ * is used on purpose: there is no cookie store to mutate.
+ */
+export function createEphemeralAuthClient(): SupabaseClient<Database> {
+	return createClient<Database>(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+		auth: {
+			persistSession: false,
+			autoRefreshToken: false,
+			detectSessionInUrl: false
+		}
+	});
+}
+
+// ============================================================================
+// HANDLE
+// ============================================================================
+
+/**
+ * Build the elevation Handle. Wire it into `hooks.server.ts` AFTER
+ * `userProfileHandle` and BEFORE `csrfHandle`.
+ *
+ * Behaviour:
+ * 1. Read the `ubu-admin-elevation` cookie. Absent / malformed / expired →
+ *    leave `locals` untouched (not elevated) and continue.
+ * 2. Verify the access token with Supabase (`getUser(token)`). Invalid → ignore.
+ * 3. Confirm the resolved user's `profiles.role === 'admin'` (role from DB,
+ *    never the JWT). Not an admin → ignore (defence in depth; the cookie should
+ *    only ever hold an admin token, but we re-check).
+ * 4. On success: set `locals.adminSupabase` (admin-context client) and
+ *    `locals.adminElevation = { active: true, adminUserId, expiresAt }`.
+ *
+ * This handle NEVER reads/writes `sb-*` cookies and NEVER touches
+ * `locals.supabase`.
+ *
+ * The `verifyToken` dependency is injected (defaults to a one-shot admin client)
+ * so the handle is unit-testable without a live Supabase.
+ */
+export function createAdminElevationHandle(
+	deps: {
+		verifyToken?: (
+			accessToken: string
+		) => Promise<{ userId: string | null; client: SupabaseClient<Database> }>;
+	} = {}
+): Handle {
+	const verifyToken =
+		deps.verifyToken ??
+		(async (accessToken: string) => {
+			const client = createAdminClient(accessToken);
+			const {
+				data: { user },
+				error
+			} = await client.auth.getUser(accessToken);
+			return { userId: error ? null : (user?.id ?? null), client };
+		});
+
+	return async ({ event, resolve }) => {
+		// Perf/DoS guard: this handle runs on EVERY request, but elevation only
+		// matters for admin routes. Early-return BEFORE any I/O (no cookie read, no
+		// getUser(), no profiles query) when the path isn't an admin path, so a
+		// stale/forged cookie can't make every unrelated request pay a getUser() +
+		// DB round-trip. The elevate endpoint lives under /api/admin, so the handle
+		// still runs there (fine: the cookie isn't set yet on that request).
+		const { pathname } = event.url;
+		if (!pathname.startsWith('/dashboard/admin') && !pathname.startsWith('/api/admin')) {
+			event.locals.adminElevation = null;
+			return resolve(event);
+		}
+
+		const raw = event.cookies.get(ADMIN_ELEVATION_COOKIE);
+
+		if (raw) {
+			const payload = decodeElevationCookie(raw);
+
+			if (payload) {
+				try {
+					const { userId, client } = await verifyToken(payload.accessToken);
+
+					// The token must verify AND resolve to the same user the cookie claims.
+					if (userId && userId === payload.adminUserId) {
+						// Re-check the role from the DB (never trust the JWT for role).
+						const { data: profile, error: profileError } = await client
+							.from('profiles')
+							.select('role')
+							.eq('id', userId)
+							.single();
+
+						if (!profileError && profile?.role === 'admin') {
+							event.locals.adminSupabase = client;
+							event.locals.adminElevation = {
+								active: true,
+								adminUserId: userId,
+								expiresAt: payload.expiresAt
+							};
+						} else {
+							logger.warn('Elevation cookie token is not an admin; ignoring', {
+								adminUserId: userId
+							});
+						}
+					}
+				} catch (err) {
+					// Network/verification failure → treat as not elevated (fail closed).
+					logger.error('Failed to verify admin elevation token:', err);
+				}
+			}
+		}
+
+		// Default: not elevated unless the block above set it.
+		if (!event.locals.adminElevation) {
+			event.locals.adminElevation = null;
+		}
+
+		return resolve(event);
+	};
+}
+
+/** Production handle, wired into hooks.server.ts after userProfileHandle. */
+export const adminElevationHandle: Handle = createAdminElevationHandle();

--- a/src/lib/server/middleware/__tests__/requireAdmin.test.ts
+++ b/src/lib/server/middleware/__tests__/requireAdmin.test.ts
@@ -1,0 +1,132 @@
+/**
+ * requireAdmin Middleware — Unit Tests
+ * ====================================
+ *
+ * Server-side admin elevation (Pattern 2). `requireAdmin(locals)` is the gate
+ * for admin routes. It returns an admin-scoped Supabase client + the admin's
+ * user id, regardless of whether admin power comes from:
+ *   - a step-up *elevation* (a teacher who elevated → locals.adminSupabase), or
+ *   - a real admin login (profile.role === 'admin' → locals.supabase).
+ *
+ * Cases:
+ *   - elevated locals → ok, returns locals.adminSupabase + adminUserId
+ *   - real admin login (no elevation) → ok, returns locals.supabase + user.id
+ *   - authenticated non-admin, not elevated → 403
+ *   - unauthenticated → 401
+ *
+ * Uses the mock-locals pattern (role lives on locals.profile, populated by
+ * userProfileHandle in hooks.server.ts).
+ *
+ * @module server/middleware/requireAdmin.test
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect } from 'vitest';
+import { createMockSupabase, createMockLocals } from '$tests/helpers';
+import { requireAdmin } from '../auth';
+
+const TEST_IDS = {
+	teacher: '550e8400-e29b-41d4-a716-446655440001',
+	admin: '550e8400-e29b-41d4-a716-446655440002',
+	student: '550e8400-e29b-41d4-a716-446655440003',
+	elevatedAdmin: '550e8400-e29b-41d4-a716-446655440099'
+};
+
+/** Build mock locals with an explicit role on locals.profile (as hooks do). */
+function localsWithRole(
+	userId: string,
+	role: 'teacher' | 'admin' | 'student',
+	supabase: ReturnType<typeof createMockSupabase>
+) {
+	const locals = createMockLocals(userId, supabase, role) as any;
+	locals.user = { id: userId };
+	locals.profile = { id: userId, role };
+	return locals;
+}
+
+describe('requireAdmin — elevated (step-up) path', () => {
+	it('returns the admin-scoped client + adminUserId when elevation is active', async () => {
+		const callerSupabase = createMockSupabase();
+		const adminSupabase = createMockSupabase();
+
+		// Caller is a teacher who has elevated.
+		const locals = localsWithRole(TEST_IDS.teacher, 'teacher', callerSupabase);
+		locals.adminSupabase = adminSupabase;
+		locals.adminElevation = {
+			active: true,
+			adminUserId: TEST_IDS.elevatedAdmin,
+			expiresAt: Date.now() + 3600_000
+		};
+
+		const result = await requireAdmin(locals);
+
+		// Privileged writes must go through the admin-scoped client, NOT the teacher's.
+		expect(result.supabase).toBe(adminSupabase);
+		expect(result.supabase).not.toBe(callerSupabase);
+		expect(result.adminUserId).toBe(TEST_IDS.elevatedAdmin);
+	});
+});
+
+describe('requireAdmin — real admin login path', () => {
+	it('returns locals.supabase + user.id for a genuine admin with no elevation', async () => {
+		const supabase = createMockSupabase();
+		const locals = localsWithRole(TEST_IDS.admin, 'admin', supabase);
+		// No adminElevation / adminSupabase set.
+
+		const result = await requireAdmin(locals);
+
+		expect(result.supabase).toBe(supabase);
+		expect(result.adminUserId).toBe(TEST_IDS.admin);
+	});
+
+	it('ignores an inactive elevation object and falls back to the admin login', async () => {
+		const supabase = createMockSupabase();
+		const locals = localsWithRole(TEST_IDS.admin, 'admin', supabase);
+		locals.adminElevation = { active: false, adminUserId: '', expiresAt: 0 } as any;
+
+		const result = await requireAdmin(locals);
+		expect(result.supabase).toBe(supabase);
+		expect(result.adminUserId).toBe(TEST_IDS.admin);
+	});
+});
+
+describe('requireAdmin — denial', () => {
+	it('throws 403 for an authenticated teacher who has NOT elevated', async () => {
+		const supabase = createMockSupabase();
+		const locals = localsWithRole(TEST_IDS.teacher, 'teacher', supabase);
+
+		try {
+			await requireAdmin(locals);
+			expect.fail('Should have thrown 403');
+		} catch (err: any) {
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe('Admin elevation required');
+		}
+	});
+
+	it('throws 403 for an authenticated student', async () => {
+		const supabase = createMockSupabase();
+		const locals = localsWithRole(TEST_IDS.student, 'student', supabase);
+
+		try {
+			await requireAdmin(locals);
+			expect.fail('Should have thrown 403');
+		} catch (err: any) {
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe('Admin elevation required');
+		}
+	});
+
+	it('throws 401 when the caller is not authenticated at all', async () => {
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(undefined, supabase) as any; // no user, no profile
+
+		try {
+			await requireAdmin(locals);
+			expect.fail('Should have thrown 401');
+		} catch (err: any) {
+			expect(err.status).toBe(401);
+		}
+	});
+});

--- a/src/lib/server/middleware/auth.ts
+++ b/src/lib/server/middleware/auth.ts
@@ -28,6 +28,7 @@
  */
 
 import { error } from '@sveltejs/kit';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '$lib/types/database';
 
 // ============================================================================
@@ -322,4 +323,72 @@ export async function requireRoles(locals: App.Locals, roles: UserRole[]): Promi
 	}
 
 	return { user, profile };
+}
+
+// ============================================================================
+// ADMIN ELEVATION (Pattern 2 — step-up)
+// ============================================================================
+
+/**
+ * Result of a successful admin authorization: an admin-scoped Supabase client
+ * (RLS runs as `auth.uid() = <admin>`) and the admin's user id.
+ */
+export interface AdminAuthResult {
+	supabase: SupabaseClient;
+	adminUserId: string;
+}
+
+/**
+ * Gate an admin-only route, supporting BOTH ways of holding admin power:
+ *
+ * 1. **Step-up elevation** — a teacher (or anyone) who elevated via
+ *    `/api/admin/elevate`. The `adminElevationHandle` has populated
+ *    `locals.adminSupabase` + `locals.adminElevation`. Privileged writes MUST
+ *    use the returned `supabase` (the admin-context client), so RLS and audit
+ *    attribute the action to the admin.
+ * 2. **Real admin login** — a genuine `profile.role === 'admin'` session. No
+ *    elevation needed; the returned `supabase` is `locals.supabase`.
+ *
+ * The role is read from `locals.profile` (sourced from the DB by
+ * `userProfileHandle`), never from the JWT.
+ *
+ * **Error responses**:
+ * - `401` — caller is not authenticated at all.
+ * - `403` — authenticated but neither elevated nor a real admin
+ *   (message: `Admin elevation required`).
+ *
+ * @param locals - SvelteKit request locals
+ * @returns `{ supabase, adminUserId }` — admin-scoped client + admin id
+ * @throws `401` if unauthenticated, `403` if not an admin / not elevated
+ *
+ * @example
+ * ```typescript
+ * export const DELETE: RequestHandler = async ({ locals, params }) => {
+ *   const { supabase, adminUserId } = await requireAdmin(locals);
+ *   await supabase.from('schools').delete().eq('id', params.id);
+ *   return json({ success: true, by: adminUserId });
+ * };
+ * ```
+ */
+export async function requireAdmin(locals: App.Locals): Promise<AdminAuthResult> {
+	// 1) Active step-up elevation wins — use the admin-context client.
+	if (locals.adminElevation?.active && locals.adminSupabase) {
+		return {
+			supabase: locals.adminSupabase,
+			adminUserId: locals.adminElevation.adminUserId
+		};
+	}
+
+	// 2) Not authenticated at all → 401.
+	if (!locals.user) {
+		throw error(401, 'Non autorisé - Authentification requise');
+	}
+
+	// 3) Genuine admin login → use the caller's own client.
+	if (locals.profile?.role === 'admin') {
+		return { supabase: locals.supabase, adminUserId: locals.user.id };
+	}
+
+	// 4) Authenticated, but neither elevated nor a real admin → 403.
+	throw error(403, 'Admin elevation required');
 }

--- a/src/lib/server/rateLimiter.ts
+++ b/src/lib/server/rateLimiter.ts
@@ -431,6 +431,87 @@ export async function checkLoginRateLimitByEmail(email: string): Promise<RateLim
 }
 
 /**
+ * Check admin-elevation rate limit by IP address
+ *
+ * Mirrors {@link checkLoginRateLimitByIP} (same 5 / 15 min threshold) but uses a
+ * DISTINCT bucket (`ratelimit:elevate:ip:*`) so that failed admin-elevation
+ * attempts never consume the `/auth/login` budget. Sharing the login bucket
+ * would let a fat-fingered admin password lock the admin out of the real login
+ * page, and would be a targeted-lockout vector against the login flow.
+ *
+ * **Rate Limit**: 5 attempts per 15 minutes per IP
+ *
+ * **Use Case**: Call this in `/api/admin/elevate/+server.ts` before verifying
+ * the admin credentials.
+ *
+ * @param ip - Client IP address from `event.getClientAddress()`
+ * @returns Rate limit result object
+ * @returns result.allowed - `true` if request should be allowed, `false` if rate limited
+ * @returns result.message - User-friendly French error message (only if `allowed: false`)
+ */
+export async function checkElevationRateLimitByIP(ip: string): Promise<RateLimitResult> {
+	if (!ip) {
+		logger.warn('Missing IP address for elevation rate limit check');
+		return { allowed: true }; // Fail open rather than blocking legitimate users
+	}
+
+	const key = `ratelimit:elevate:ip:${ip}`;
+	const result = await checkRateLimitWithMessage(
+		key,
+		5,
+		900, // 15 minutes
+		'Trop de tentatives. Réessayez dans 15 minutes.'
+	);
+
+	if (!result.allowed) {
+		logger.warn('Elevation rate limit exceeded by IP', { ip: maskKey(key) });
+	}
+
+	return result;
+}
+
+/**
+ * Check admin-elevation rate limit by email address
+ *
+ * Mirrors {@link checkLoginRateLimitByEmail} (same stricter 3 / 15 min threshold)
+ * but uses a DISTINCT bucket (`ratelimit:elevate:email:*`) so failed
+ * admin-elevation attempts never consume the `/auth/login` budget for that email
+ * (see {@link checkElevationRateLimitByIP} for the lockout rationale).
+ *
+ * **Rate Limit**: 3 attempts per 15 minutes per email (stricter than IP)
+ *
+ * **Email Normalization**: lowercased + trimmed to prevent case-variation bypass.
+ *
+ * @param email - Admin email from the elevation form (normalized to lowercase)
+ * @returns Rate limit result object
+ * @returns result.allowed - `true` if request should be allowed, `false` if rate limited
+ * @returns result.message - User-friendly French error message (only if `allowed: false`)
+ */
+export async function checkElevationRateLimitByEmail(email: string): Promise<RateLimitResult> {
+	if (!email) {
+		logger.warn('Missing email for elevation rate limit check');
+		return { allowed: true }; // Fail open
+	}
+
+	// Normalize email to lowercase for consistent tracking
+	const normalizedEmail = email.toLowerCase().trim();
+	const key = `ratelimit:elevate:email:${normalizedEmail}`;
+
+	const result = await checkRateLimitWithMessage(
+		key,
+		3,
+		900, // 15 minutes
+		'Trop de tentatives pour cet email. Réessayez dans 15 minutes.'
+	);
+
+	if (!result.allowed) {
+		logger.warn('Elevation rate limit exceeded by email', { email: maskKey(key) });
+	}
+
+	return result;
+}
+
+/**
  * Check signup rate limit by IP address
  *
  * Prevents spam account creation by limiting signups from a single IP address.

--- a/src/lib/server/validation/admin-elevation.ts
+++ b/src/lib/server/validation/admin-elevation.ts
@@ -1,0 +1,27 @@
+/**
+ * Admin elevation validation schemas
+ * ==================================
+ *
+ * Server-side step-up elevation (Pattern 2): an authenticated teacher/admin
+ * POSTs the **admin account's** credentials to /api/admin/elevate. These are
+ * verified by an ephemeral Supabase client; on success a short-lived httpOnly
+ * cookie is set granting an admin-scoped Supabase client for the request.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Body schema for POST /api/admin/elevate.
+ *
+ * - `email`: the admin account's email (validated, length-capped).
+ * - `password`: the admin account's password (non-empty, length-capped to
+ *   prevent oversized-payload abuse). We deliberately do NOT enforce a
+ *   minimum-length policy here — the credential is checked against Supabase
+ *   auth, not created — so a `.min(1)` is the correct guard.
+ */
+export const adminElevateSchema = z.object({
+	email: z.string().trim().email('Email invalide').max(254, 'Email trop long'),
+	password: z.string().min(1, 'Mot de passe requis').max(200, 'Mot de passe trop long')
+});
+
+export type AdminElevateInput = z.infer<typeof adminElevateSchema>;

--- a/src/routes/api/admin/elevate/+server.ts
+++ b/src/routes/api/admin/elevate/+server.ts
@@ -1,0 +1,153 @@
+/**
+ * POST /api/admin/elevate
+ * =======================
+ *
+ * Server-side admin elevation (Pattern 2 — "step-up"). An authenticated
+ * teacher/admin POSTs the **admin account's** email + password. The server:
+ *
+ *   1. confirms the CALLER is a teacher/admin (requireRoles),
+ *   2. validates the body (Zod) + rate-limits like the login route,
+ *   3. verifies the admin credentials with an EPHEMERAL client
+ *      (`signInWithPassword`) — this NEVER touches the caller's `sb-*` session
+ *      because the ephemeral client persists nothing and writes no cookies,
+ *   4. confirms the signed-in user's `profiles.role === 'admin'` (role from DB),
+ *   5. on success, sets the short-lived httpOnly `ubu-admin-elevation` cookie
+ *      carrying the admin access token (TTL ≈ token lifetime, ≤ 1h).
+ *
+ * The caller's own JWT is never modified and gains no admin power; admin
+ * authority lives entirely in the elevation cookie + `adminElevationHandle`.
+ *
+ * Responses:
+ * - 200: elevation granted (cookie set)
+ * - 400: invalid body / JSON
+ * - 401: caller not authenticated, OR admin credentials invalid
+ * - 403: caller not a teacher/admin, OR credentials belong to a non-admin
+ * - 429: rate limited
+ */
+
+import { json, error } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import type { RequestHandler } from './$types';
+import { adminElevateSchema } from '$lib/server/validation/admin-elevation';
+import {
+	ADMIN_ELEVATION_COOKIE,
+	createEphemeralAuthClient,
+	encodeElevationCookie
+} from '$lib/server/adminElevation';
+import {
+	checkElevationRateLimitByIP,
+	checkElevationRateLimitByEmail
+} from '$lib/server/rateLimiter';
+import { createLogger } from '$lib/utils/logger';
+
+const logger = createLogger('api/admin/elevate');
+
+/** Hard ceiling on the elevation cookie lifetime (seconds) — ~1h. */
+const MAX_ELEVATION_MAX_AGE = 3600;
+
+export const POST: RequestHandler = async ({ request, locals, cookies, getClientAddress }) => {
+	// 1. The caller must already be an authenticated teacher or admin. We read
+	//    the role from locals.profile (populated by userProfileHandle in
+	//    hooks.server.ts) rather than re-querying — it's the same source of truth
+	//    used elsewhere (e.g. /api/moderation/restrict-user).
+	if (!locals.user) {
+		throw error(401, 'Non autorisé - Authentification requise');
+	}
+	if (!locals.profile || !['teacher', 'admin'].includes(locals.profile.role ?? '')) {
+		throw error(403, 'Interdit - Enseignants et administrateurs uniquement');
+	}
+
+	// 2. Parse + validate body.
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		throw error(400, 'Invalid JSON');
+	}
+
+	const validation = adminElevateSchema.safeParse(body);
+	if (!validation.success) {
+		throw error(400, validation.error.issues[0].message);
+	}
+	const { email, password } = validation.data;
+
+	// 3. Rate limit. Same dual IP + email scheme as the login route, but on
+	//    DEDICATED buckets (ratelimit:elevate:*) so a fat-fingered admin password
+	//    can't burn the /auth/login budget and lock the admin out of the real
+	//    login page (also avoids a targeted-lockout vector against login).
+	const ip = getClientAddress();
+	const ipLimit = await checkElevationRateLimitByIP(ip);
+	if (!ipLimit.allowed) {
+		throw error(429, ipLimit.message ?? 'Trop de tentatives. Réessayez plus tard.');
+	}
+	const emailLimit = await checkElevationRateLimitByEmail(email);
+	if (!emailLimit.allowed) {
+		throw error(429, emailLimit.message ?? 'Trop de tentatives. Réessayez plus tard.');
+	}
+
+	// 4. Verify the ADMIN credentials with an ephemeral client. This client
+	//    persists no session and writes no cookies → the caller's sb-* session
+	//    is untouched.
+	const ephemeral = createEphemeralAuthClient();
+	const { data: signInData, error: signInError } = await ephemeral.auth.signInWithPassword({
+		email,
+		password
+	});
+
+	if (signInError || !signInData.session || !signInData.user) {
+		// Do not reveal whether the account exists — generic invalid-credentials.
+		throw error(401, 'Identifiants administrateur invalides');
+	}
+
+	const adminUserId = signInData.user.id;
+	const accessToken = signInData.session.access_token;
+	// Supabase session expires_at is a Unix epoch in SECONDS.
+	const expiresAtSec =
+		signInData.session.expires_at ?? Math.floor(Date.now() / 1000) + MAX_ELEVATION_MAX_AGE;
+
+	// 5. Confirm the signed-in account is actually an admin (role from the DB).
+	//    We read the role through the EPHEMERAL client — which is now authed as
+	//    the candidate — so the check uses the candidate's own "view own profile"
+	//    RLS path and never depends on the caller's (teacher's) RLS visibility of
+	//    the admin row. Role always comes from the DB, never the JWT.
+	const { data: profile, error: profileError } = await ephemeral
+		.from('profiles')
+		.select('id, role')
+		.eq('id', adminUserId)
+		.single();
+
+	if (profileError || !profile) {
+		logger.error('Failed to confirm role for elevation candidate:', profileError);
+		throw error(403, 'Compte non administrateur');
+	}
+
+	if (profile.role !== 'admin') {
+		logger.warn('Non-admin credentials presented to /api/admin/elevate', { role: profile.role });
+		throw error(403, 'Compte non administrateur');
+	}
+
+	// 6. Mint the elevation cookie. Cap the TTL at the token lifetime (≤ 1h).
+	const expiresAtMs = expiresAtSec * 1000;
+	const maxAge = Math.min(
+		MAX_ELEVATION_MAX_AGE,
+		Math.max(0, Math.floor((expiresAtMs - Date.now()) / 1000))
+	);
+
+	const cookieValue = encodeElevationCookie({ adminUserId, accessToken, expiresAt: expiresAtMs });
+
+	cookies.set(ADMIN_ELEVATION_COOKIE, cookieValue, {
+		path: '/',
+		httpOnly: true,
+		secure: !dev,
+		// Strict: this cookie grants full admin authority and is only ever read by
+		// same-site, in-app navigations/fetches → no legitimate cross-site need.
+		// Strict also blunts CSRF (no cross-site request ever carries it).
+		sameSite: 'strict',
+		maxAge
+	});
+
+	// Mask the admin UUID — never log the raw id (PII / correlation) or the token.
+	logger.info('Admin elevation granted', { adminUserId: `${adminUserId.slice(0, 8)}***` });
+
+	return json({ success: true, expiresAt: expiresAtMs });
+};

--- a/src/routes/api/admin/elevate/__tests__/elevate.test.ts
+++ b/src/routes/api/admin/elevate/__tests__/elevate.test.ts
@@ -1,0 +1,306 @@
+/**
+ * POST /api/admin/elevate — API Unit Tests
+ * ========================================
+ *
+ * Server-side admin elevation (Pattern 2). An authenticated teacher/admin POSTs
+ * the **admin account's** email+password; the server verifies the credentials
+ * with an EPHEMERAL Supabase client (so the caller's own sb-* session cookies
+ * are never touched), confirms the credentials belong to an admin, and on
+ * success sets the short-lived httpOnly `ubu-admin-elevation` cookie.
+ *
+ * Cases:
+ *   - 400 invalid body (bad email / missing password)
+ *   - 401 bad credentials (signInWithPassword fails)
+ *   - 403 credentials belong to a NON-admin account
+ *   - 200 + cookie set on valid admin credentials
+ *   - 401/403 when the CALLER is not an authenticated teacher/admin
+ *
+ * The ephemeral client is mocked at the @supabase/supabase-js boundary; the
+ * role-confirmation query runs through the mock locals.supabase.
+ *
+ * @module api/admin/elevate.test
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockSupabase, createMockLocals, createMockRequest } from '$tests/helpers';
+
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted)
+// ---------------------------------------------------------------------------
+
+// Silence rate limiter (fail-open / allow) and let us assert it was consulted.
+// NOTE: the endpoint uses the DEDICATED elevation buckets, not the login ones,
+// so we mock the elevation-specific functions here.
+vi.mock('$lib/server/rateLimiter', () => ({
+	checkElevationRateLimitByIP: vi.fn().mockResolvedValue({ allowed: true }),
+	checkElevationRateLimitByEmail: vi.fn().mockResolvedValue({ allowed: true })
+}));
+
+// Control the ephemeral verification client created via createClient(...).
+// The ephemeral client both signs in AND reads its own profile role, so the
+// mock exposes a chainable from().select().eq().single().
+const signInWithPassword = vi.fn();
+const ephemeralSingle = vi.fn();
+vi.mock('@supabase/supabase-js', () => {
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: (...args: unknown[]) => ephemeralSingle(...args)
+	};
+	return {
+		createClient: vi.fn(() => ({
+			auth: {
+				signInWithPassword,
+				signOut: vi.fn().mockResolvedValue({ error: null })
+			},
+			from: vi.fn(() => chain)
+		}))
+	};
+});
+
+const TEST_IDS = {
+	teacher: '550e8400-e29b-41d4-a716-446655440001',
+	admin: '550e8400-e29b-41d4-a716-446655440002'
+};
+
+const ADMIN_EMAIL = 'admin@voltairedoha.com';
+const ADMIN_PASSWORD = 'correct-horse-battery-staple';
+
+/** Caller locals: an authenticated teacher (the common elevation initiator). */
+function teacherCaller(supabase: ReturnType<typeof createMockSupabase>) {
+	const locals = createMockLocals(TEST_IDS.teacher, supabase, 'teacher') as any;
+	locals.user = { id: TEST_IDS.teacher };
+	locals.profile = { id: TEST_IDS.teacher, role: 'teacher' };
+	return locals;
+}
+
+/** A SvelteKit-ish event with the request, locals, cookies, and client addr. */
+function makeEvent(request: Request, locals: any) {
+	const cookieSet = vi.fn();
+	return {
+		event: {
+			request,
+			locals,
+			cookies: { set: cookieSet, get: vi.fn(), delete: vi.fn() },
+			getClientAddress: () => '203.0.113.7',
+			url: new URL('http://localhost/api/admin/elevate')
+		} as any,
+		cookieSet
+	};
+}
+
+/** A signInWithPassword success returning a session for the given user id. */
+function signInSuccess(userId: string, email: string) {
+	const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+	return {
+		data: {
+			user: { id: userId, email },
+			session: {
+				access_token: 'admin.jwt.token',
+				refresh_token: 'admin-refresh',
+				expires_at: expiresAt,
+				user: { id: userId, email }
+			}
+		},
+		error: null
+	};
+}
+
+describe('POST /api/admin/elevate', () => {
+	beforeEach(() => {
+		signInWithPassword.mockReset();
+		ephemeralSingle.mockReset();
+		return import.meta.hot?.invalidate();
+	});
+
+	// -------------------------------------------------------------------------
+	// Caller authorization
+	// -------------------------------------------------------------------------
+
+	it('rejects an unauthenticated caller with 401', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(undefined, supabase) as any; // no user
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const { event } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 401');
+		} catch (err: any) {
+			expect(err.status).toBe(401);
+		}
+		expect(signInWithPassword).not.toHaveBeenCalled();
+	});
+
+	it('rejects a student caller with 403', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(TEST_IDS.teacher, supabase, 'student') as any;
+		locals.user = { id: TEST_IDS.teacher };
+		locals.profile = { id: TEST_IDS.teacher, role: 'student' };
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const { event } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 403');
+		} catch (err: any) {
+			expect(err.status).toBe(403);
+		}
+		expect(signInWithPassword).not.toHaveBeenCalled();
+	});
+
+	// -------------------------------------------------------------------------
+	// Body validation
+	// -------------------------------------------------------------------------
+
+	it('returns 400 for a malformed body (bad email)', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+		const request = createMockRequest({ email: 'not-an-email', password: ADMIN_PASSWORD });
+		const { event } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 400');
+		} catch (err: any) {
+			expect(err.status).toBe(400);
+		}
+		expect(signInWithPassword).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 for invalid JSON', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+		const request = { json: vi.fn().mockRejectedValue(new Error('bad json')) } as any;
+		const { event } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 400');
+		} catch (err: any) {
+			expect(err.status).toBe(400);
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Credential verification
+	// -------------------------------------------------------------------------
+
+	it('returns 401 when the admin credentials are wrong', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+
+		signInWithPassword.mockResolvedValueOnce({
+			data: { user: null, session: null },
+			error: { message: 'Invalid login credentials' }
+		});
+
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: 'wrong' });
+		const { event } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 401');
+		} catch (err: any) {
+			expect(err.status).toBe(401);
+		}
+		expect(signInWithPassword).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns 403 when the credentials belong to a NON-admin account', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+
+		// Credentials are valid but for a teacher account.
+		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.teacher, ADMIN_EMAIL));
+		// Role confirmation via the ephemeral (candidate) client → role 'teacher'.
+		ephemeralSingle.mockResolvedValueOnce({
+			data: { id: TEST_IDS.teacher, role: 'teacher' },
+			error: null
+		});
+
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const { event, cookieSet } = makeEvent(request, locals);
+
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 403');
+		} catch (err: any) {
+			expect(err.status).toBe(403);
+		}
+		// No elevation cookie may be set for a non-admin.
+		expect(cookieSet).not.toHaveBeenCalled();
+	});
+
+	// -------------------------------------------------------------------------
+	// Success
+	// -------------------------------------------------------------------------
+
+	it('sets the ubu-admin-elevation cookie and returns 200 on valid admin creds', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+
+		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.admin, ADMIN_EMAIL));
+		ephemeralSingle.mockResolvedValueOnce({
+			data: { id: TEST_IDS.admin, role: 'admin' },
+			error: null
+		});
+
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const { event, cookieSet } = makeEvent(request, locals);
+
+		const response = await POST(event);
+		expect(response.status).toBe(200);
+
+		// httpOnly elevation cookie was set with the right name and options.
+		expect(cookieSet).toHaveBeenCalledTimes(1);
+		const [name, value, options] = cookieSet.mock.calls[0];
+		expect(name).toBe('ubu-admin-elevation');
+		expect(typeof value).toBe('string');
+		expect(value.length).toBeGreaterThan(0);
+		// SameSite=Strict: this cookie grants full admin authority and is only ever
+		// read by same-site in-app requests (also blunts CSRF).
+		expect(options).toMatchObject({ httpOnly: true, sameSite: 'strict', path: '/' });
+		expect(options.maxAge).toBeGreaterThan(0);
+		expect(options.maxAge).toBeLessThanOrEqual(3600);
+	});
+
+	it('does NOT write or modify any sb-* (teacher session) cookie', async () => {
+		// The teacher's own session must be untouched: the elevate endpoint verifies
+		// admin creds via an EPHEMERAL client (mocked, no cookie store) and only ever
+		// writes the dedicated `ubu-admin-elevation` cookie. Guard against a refactor
+		// that would accidentally mutate the caller's `sb-*` auth cookies.
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = teacherCaller(supabase);
+
+		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.admin, ADMIN_EMAIL));
+		ephemeralSingle.mockResolvedValueOnce({
+			data: { id: TEST_IDS.admin, role: 'admin' },
+			error: null
+		});
+
+		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const { event, cookieSet } = makeEvent(request, locals);
+
+		await POST(event);
+
+		// Every cookie write must be the elevation cookie — never an sb-* one.
+		for (const [cookieName] of cookieSet.mock.calls) {
+			expect(cookieName).toBe('ubu-admin-elevation');
+			expect(String(cookieName).startsWith('sb-')).toBe(false);
+		}
+		// cookies.delete is also never used to drop an sb-* cookie here.
+		const cookieDelete = event.cookies.delete as ReturnType<typeof vi.fn>;
+		expect(cookieDelete).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/api/admin/elevate/revoke/+server.ts
+++ b/src/routes/api/admin/elevate/revoke/+server.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/admin/elevate/revoke
+ * ==============================
+ *
+ * Clears the admin elevation cookie ("quitter le mode admin"). After this the
+ * caller is no longer elevated and admin routes return 403 until they
+ * re-elevate. Clearing an absent cookie is idempotent.
+ *
+ * Any authenticated user may revoke their OWN elevation (the cookie is scoped
+ * to their browser); we still require authentication to avoid drive-by clears
+ * from cross-site requests (CSRF is also enforced globally in hooks).
+ *
+ * ## Server-side invalidation & accepted risk window
+ * When the caller is currently elevated, we make a BEST-EFFORT `signOut()` on
+ * the admin-context client so the admin's GoTrue session is invalidated
+ * server-side, not just dropped from the browser. This is best-effort: if it
+ * fails (network/GoTrue hiccup) we still clear the cookie — losing the cookie
+ * already removes all admin authority in-app.
+ *
+ * **Accepted risk (conscious decision):** if the server-side `signOut()` is not
+ * performed (handle didn't populate `adminSupabase`, or the call fails), the
+ * admin **access token** stays valid at GoTrue until its natural expiry
+ * (≤ 1 h). The exposure is deliberately minimal: access-token-only (NO refresh
+ * token is ever stored), the cookie is httpOnly + secure + SameSite=Strict, and
+ * there is a single admin account. We accept this ≤ 1 h leak window rather than
+ * add token-revocation infrastructure. See docs/wip/admin-elevation-progress.md.
+ *
+ * Responses:
+ * - 200: cookie cleared
+ * - 401: not authenticated
+ */
+
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { ADMIN_ELEVATION_COOKIE } from '$lib/server/adminElevation';
+
+export const POST: RequestHandler = async ({ locals, cookies }) => {
+	// Must be authenticated (401 otherwise). A bare user check is sufficient here
+	// — revoking elevation needs no role/profile, and avoids an unnecessary DB
+	// round-trip. CSRF is enforced globally in hooks.server.ts.
+	if (!locals.user) {
+		throw error(401, 'Non autorisé - Authentification requise');
+	}
+
+	// Best-effort server-side invalidation of the admin session. The admin client
+	// (set by adminElevationHandle) authenticates with `Authorization: Bearer
+	// <admin access token>`, so `signOut()` issues GoTrue's logout against that
+	// session and revokes it server-side — closing the access-token leak window
+	// instead of leaving it valid until natural expiry. Wrapped in try/catch and
+	// intentionally ignored on failure: clearing the cookie below is what
+	// actually removes admin authority in-app, so revoke must never fail on this.
+	if (locals.adminElevation?.active && locals.adminSupabase) {
+		try {
+			await locals.adminSupabase.auth.signOut();
+		} catch {
+			// Ignore — see "Accepted risk" in the module doc: worst case the token
+			// stays valid at GoTrue for the remainder of its ≤ 1 h lifetime.
+		}
+	}
+
+	// Path must match how the cookie was set so the browser actually drops it.
+	// SameSite=Strict mirrors the cookie's `set` options.
+	cookies.delete(ADMIN_ELEVATION_COOKIE, { path: '/', sameSite: 'strict' });
+
+	return json({ success: true });
+};

--- a/src/routes/api/admin/elevate/revoke/__tests__/revoke.test.ts
+++ b/src/routes/api/admin/elevate/revoke/__tests__/revoke.test.ts
@@ -1,0 +1,111 @@
+/**
+ * POST /api/admin/elevate/revoke — API Unit Tests
+ * ===============================================
+ *
+ * Clears the admin elevation cookie ("quitter le mode admin"). Returns 200 for
+ * any authenticated caller; clearing an already-absent cookie is idempotent.
+ *
+ * @module api/admin/elevate/revoke.test
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockSupabase, createMockLocals } from '$tests/helpers';
+
+const TEACHER_ID = '550e8400-e29b-41d4-a716-446655440001';
+
+function makeEvent(locals: any) {
+	const cookieDelete = vi.fn();
+	return {
+		event: {
+			locals,
+			cookies: { delete: cookieDelete, get: vi.fn(), set: vi.fn() },
+			url: new URL('http://localhost/api/admin/elevate/revoke')
+		} as any,
+		cookieDelete
+	};
+}
+
+describe('POST /api/admin/elevate/revoke', () => {
+	beforeEach(() => import.meta.hot?.invalidate());
+
+	it('clears the ubu-admin-elevation cookie and returns 200', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(TEACHER_ID, supabase, 'teacher') as any;
+		locals.user = { id: TEACHER_ID };
+		locals.profile = { id: TEACHER_ID, role: 'teacher' };
+
+		const { event, cookieDelete } = makeEvent(locals);
+		const response = await POST(event);
+
+		expect(response.status).toBe(200);
+		expect(cookieDelete).toHaveBeenCalledTimes(1);
+		const [name, options] = cookieDelete.mock.calls[0];
+		expect(name).toBe('ubu-admin-elevation');
+		// SameSite=Strict mirrors the cookie's `set` options so the browser drops it.
+		expect(options).toMatchObject({ path: '/', sameSite: 'strict' });
+	});
+
+	it('best-effort signs out the admin session server-side when currently elevated', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(TEACHER_ID, supabase, 'teacher') as any;
+		locals.user = { id: TEACHER_ID };
+		locals.profile = { id: TEACHER_ID, role: 'teacher' };
+		// Simulate an active elevation with an admin-context client.
+		const signOut = vi.fn().mockResolvedValue({ error: null });
+		locals.adminElevation = {
+			active: true,
+			adminUserId: '550e8400-e29b-41d4-a716-446655440002',
+			expiresAt: Date.now() + 3600_000
+		};
+		locals.adminSupabase = { auth: { signOut } };
+
+		const { event, cookieDelete } = makeEvent(locals);
+		const response = await POST(event);
+
+		expect(response.status).toBe(200);
+		// Server-side invalidation attempted, then cookie cleared.
+		expect(signOut).toHaveBeenCalledTimes(1);
+		expect(cookieDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it('still clears the cookie (200) when the best-effort signOut throws', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(TEACHER_ID, supabase, 'teacher') as any;
+		locals.user = { id: TEACHER_ID };
+		locals.profile = { id: TEACHER_ID, role: 'teacher' };
+		const signOut = vi.fn().mockRejectedValue(new Error('GoTrue unreachable'));
+		locals.adminElevation = {
+			active: true,
+			adminUserId: '550e8400-e29b-41d4-a716-446655440002',
+			expiresAt: Date.now() + 3600_000
+		};
+		locals.adminSupabase = { auth: { signOut } };
+
+		const { event, cookieDelete } = makeEvent(locals);
+		const response = await POST(event);
+
+		// signOut failure must NOT break revoke — cookie still cleared.
+		expect(response.status).toBe(200);
+		expect(signOut).toHaveBeenCalledTimes(1);
+		expect(cookieDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects an unauthenticated caller with 401', async () => {
+		const { POST } = await import('../+server');
+		const supabase = createMockSupabase();
+		const locals = createMockLocals(undefined, supabase) as any;
+
+		const { event } = makeEvent(locals);
+		try {
+			await POST(event);
+			expect.fail('Should have thrown 401');
+		} catch (err: any) {
+			expect(err.status).toBe(401);
+		}
+	});
+});

--- a/tests/integration/admin-elevation.test.ts
+++ b/tests/integration/admin-elevation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Admin Elevation (Pattern 2) — Integration Tests (needs a running DB)
+ * ===================================================================
+ *
+ * Run `pnpm db:start` first; the orchestrator runs this, not the implementing
+ * agent. Verifies the CORE invariant of server-side admin elevation:
+ *
+ *   `createAdminClient(adminAccessToken)` issues queries that RLS evaluates
+ *   with `auth.uid() = <admin>` — i.e. the request-scoped client really acts
+ *   AS the admin (audit + RLS preserved), without persisting any session.
+ *
+ * It also confirms the negative: a client built from a TEACHER's access token
+ * does NOT see admin-only data — the elevation cookie's power comes entirely
+ * from WHOSE token it carries (verified server-side via getUser + role check),
+ * never from the cookie's mere presence.
+ *
+ * NOTE: this exercises `createAdminClient` (the request-scoped admin client) and
+ * the token→identity binding. The full handle (createAdminElevationHandle) is
+ * covered by the unit suite; here we assert the RLS identity end-to-end.
+ *
+ * @module tests/integration/admin-elevation
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { cleanupAllTestData } from '../helpers/database/trigger-test-helpers';
+import { DEFAULT_TEST_PASSWORD } from '../helpers/database/supabase-client';
+import { TestData } from '../helpers/database/test-data-factory';
+import type { Database } from '$lib/types/database';
+import { createAdminClient } from '$lib/server/adminElevation';
+
+const SUPABASE_URL = process.env.SUPABASE_TEST_URL || 'http://localhost:54321';
+const ANON_KEY =
+	process.env.SUPABASE_TEST_ANON_KEY ||
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+/** Sign in via a throwaway client and return only the access token. */
+async function getAccessToken(email: string): Promise<string> {
+	const client = createClient<Database>(SUPABASE_URL, ANON_KEY, {
+		auth: { persistSession: false, autoRefreshToken: false }
+	});
+	const { data, error } = await client.auth.signInWithPassword({
+		email,
+		password: DEFAULT_TEST_PASSWORD
+	});
+	if (error || !data.session) {
+		throw new Error(`sign-in failed for ${email}: ${error?.message ?? 'no session'}`);
+	}
+	return data.session.access_token;
+}
+
+describe('Admin Elevation — createAdminClient acts as the admin under RLS', () => {
+	let adminEmail: string;
+	let adminId: string;
+	let teacherEmail: string;
+
+	beforeAll(async () => {
+		await cleanupAllTestData();
+
+		const admin = await TestData.profile().withRole('admin').create();
+		const teacher = await TestData.profile().withRole('teacher').create();
+		adminEmail = admin.email;
+		adminId = admin.id;
+		teacherEmail = teacher.email;
+	});
+
+	afterAll(async () => {
+		await cleanupAllTestData();
+	});
+
+	it('binds auth.uid() to the admin (createAdminClient sends the admin Bearer token)', async () => {
+		const adminToken = await getAccessToken(adminEmail);
+		const adminClient = createAdminClient(adminToken);
+
+		// getUser() on the request-scoped client must resolve to the admin.
+		const { data, error } = await adminClient.auth.getUser();
+		expect(error).toBeNull();
+		expect(data.user?.id).toBe(adminId);
+	});
+
+	it('an admin-token client reads admin-gated data that a teacher-token client cannot', async () => {
+		// error_logs has SELECT gated by is_admin(); seed one row via service role.
+		await TestData.errorLog().create();
+
+		const adminToken = await getAccessToken(adminEmail);
+		const teacherToken = await getAccessToken(teacherEmail);
+
+		const adminClient = createAdminClient(adminToken);
+		const teacherClient = createAdminClient(teacherToken);
+
+		const { data: adminRows } = await adminClient.from('error_logs').select('id').limit(5);
+		const { data: teacherRows } = await teacherClient.from('error_logs').select('id').limit(5);
+
+		// Admin sees the seeded row(s); the teacher-token client (NOT an admin) does not.
+		expect((adminRows ?? []).length).toBeGreaterThanOrEqual(1);
+		// The teacher must not gain admin-only visibility just by being wrapped
+		// in createAdminClient — power comes from the token's identity (RLS), not
+		// from the wrapper.
+		expect((teacherRows ?? []).length).toBe(0);
+	});
+
+	it('does not persist a session (request-scoped, no token leakage between clients)', async () => {
+		const adminToken = await getAccessToken(adminEmail);
+		const adminClient = createAdminClient(adminToken);
+		await adminClient.auth.getUser();
+
+		// A fresh anon client built the normal way has no admin session.
+		const anon = createClient<Database>(SUPABASE_URL, ANON_KEY, {
+			auth: { persistSession: false, autoRefreshToken: false }
+		});
+		const { data } = await anon.auth.getUser();
+		expect(data.user).toBeNull();
+	});
+});


### PR DESCRIPTION
## Quoi
**Fondation** de l'unification admin/teacher (spec : `docs/wip/admin-elevation-progress.md`). Le prof reste connecté ; pour agir en admin il fournit les identifiants du compte admin → cookie httpOnly d'**access token admin** (sans refresh) → `locals.adminSupabase` (RLS admin) sur les chemins `/dashboard/admin` + `/api/admin`. Le token prof n'acquiert jamais les pouvoirs admin.

⚠️ **Infra dormante** : rien ne consomme encore `requireAdmin` (le câblage des ~90 routes admin = **Phase 3**, l'UI modale/bandeau/confirmation tapée = **Phase 4**, en PRs suivantes). Cette PR n'a **aucun effet visible** en prod — elle pose les briques.

## Contenu
- `src/lib/server/adminElevation.ts` : encode/decode cookie, `createAdminClient` (Bearer), client éphémère sans cookie store, `createAdminElevationHandle` (scopé chemins admin).
- `requireAdmin(locals)` (`middleware/auth.ts`) : OK si élévation active OU `role==='admin'` ; sinon 403.
- `POST /api/admin/elevate` (+ `/revoke`) : vérif creds admin via client éphémère (ne touche pas la session prof), pose/efface le cookie.
- Handle inséré dans la `sequence` (après `userProfileHandle`, avant `csrfHandle`). `Locals` étendus.

## Vérifications
- **30 tests unitaires** verts · **`check:incremental` 0 erreur** (1699 fichiers).
- **`security-auditor` : safe to proceed**, 0 critical, escalade de privilège **fermée**. Durcissements appliqués : buckets rate-limit dédiés, `SameSite=Strict`, revoke qui invalide côté serveur (best-effort), handle scopé (perf/DoS), UUID masqué dans les logs.
- ⚠️ Test d'intégration (`tests/integration/admin-elevation.test.ts`, RLS identity-binding) **écrit mais non exécuté** : `db:start` local a échoué (timeout health-check edge-runtime → Docker/ressources, pas le code). À jouer quand l'env est sain.

## Contraintes respectées
Safari/WebKit TDZ (tout en `$lib/server/*`, aucun import lourd dans le root layout) · `sb-*` cookies intacts · rôle depuis la DB · Zod · pas de `any`.