### PR TITLE
feat(auth): wire requireAdmin into admin routes (elevation Phase 3)

### DIFF
--- a/src/routes/(protected)/dashboard/admin/+layout.server.ts
+++ b/src/routes/(protected)/dashboard/admin/+layout.server.ts
@@ -1,0 +1,21 @@
+/**
+ * Admin section guard
+ * ===================
+ *
+ * Section-level gate for `/dashboard/admin/*`: students never get in. It does
+ * NOT require admin, because the section is mixed — most pages are admin-only
+ * (they self-gate with `requireAdmin`, which a non-elevated teacher fails), but
+ * a few (`friendships`, `users`) legitimately allow the teacher too. So the
+ * layout only enforces the least-restrictive common denominator (teacher OR
+ * admin); each page refines from there.
+ *
+ * @module routes/(protected)/dashboard/admin/+layout.server
+ */
+
+import { requireRoles } from '$lib/server/middleware/auth';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+	return {};
+};

--- a/src/routes/(protected)/dashboard/admin/backup/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/backup/+page.server.ts
@@ -7,23 +7,18 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getBackupStats } from '$lib/server/admin/exercise-backup';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	// Authorization check
-	if (!locals.profile) {
-		throw error(401, 'Non authentifie');
-	}
-
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Acces reserve aux administrateurs');
-	}
+	// Authorization check (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	try {
-		const stats = await getBackupStats(locals.supabase);
+		const stats = await getBackupStats(supabase);
 
 		return {
 			stats,
-			adminEmail: locals.profile.email ?? 'admin'
+			adminEmail: locals.profile?.email ?? 'admin'
 		};
 	} catch (err) {
 		console.error('Error loading backup stats:', err);

--- a/src/routes/(protected)/dashboard/admin/bug-reports/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/bug-reports/+page.server.ts
@@ -5,28 +5,14 @@
  * Only accessible to admins.
  */
 
-import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import type { BugReportWithAuthor } from '$lib/types/bug-reports';
 import { signBugReportScreenshots } from '$lib/server/bug-report-screenshots';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
-	// Check authentication
-	const { user } = await locals.safeGetSession();
-	if (!user) {
-		throw redirect(302, '/auth');
-	}
-
-	// Check if user is admin
-	const { data: profile } = await locals.supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Forbidden - Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Parse filters from query params
 	const status = url.searchParams.get('status') || undefined;
@@ -34,7 +20,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const severity = url.searchParams.get('severity') || undefined;
 
 	// Fetch all bug reports with author info
-	let query = locals.supabase
+	let query = supabase
 		.from('bug_reports')
 		.select(
 			`
@@ -67,12 +53,12 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 
 	// Get stats
-	const { data: allReports } = await locals.supabase
+	const { data: allReports } = await supabase
 		.from('bug_reports')
 		.select('status, severity, created_at');
 
 	// Replace stored screenshot_url with fresh signed URLs (private bucket)
-	await signBugReportScreenshots(locals.supabase, (reports ?? []) as BugReportWithAuthor[]);
+	await signBugReportScreenshots(supabase, (reports ?? []) as BugReportWithAuthor[]);
 
 	const today = new Date();
 	today.setHours(0, 0, 0, 0);

--- a/src/routes/(protected)/dashboard/admin/classes/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/classes/+page.server.ts
@@ -1,17 +1,10 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile, supabase } = locals;
-
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	// Verify admin role
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Fetch all schools
 	const { data: schools, error: schoolsError } = await supabase
@@ -81,12 +74,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions: Actions = {
-	create: async ({ request, locals: { safeGetSession, supabase } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+	create: async ({ request, locals }) => {
+		// Admin gate (admin login OR step-up elevation)
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const name = formData.get('name') as string;
@@ -166,12 +156,9 @@ export const actions: Actions = {
 		return { success: true };
 	},
 
-	update: async ({ request, locals: { safeGetSession, supabase } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+	update: async ({ request, locals }) => {
+		// Admin gate (admin login OR step-up elevation)
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
@@ -239,12 +226,9 @@ export const actions: Actions = {
 		return { success: true };
 	},
 
-	deactivate: async ({ request, locals: { safeGetSession, supabase } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+	deactivate: async ({ request, locals }) => {
+		// Admin gate (admin login OR step-up elevation)
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
@@ -266,12 +250,9 @@ export const actions: Actions = {
 		return { success: true };
 	},
 
-	activate: async ({ request, locals: { safeGetSession, supabase } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+	activate: async ({ request, locals }) => {
+		// Admin gate (admin login OR step-up elevation)
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const id = formData.get('id') as string;

--- a/src/routes/(protected)/dashboard/admin/cron/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/cron/+page.server.ts
@@ -3,9 +3,10 @@
  * Loads initial job data for the CRON monitoring page
  */
 
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import type { CronJobRun, CronJobsStats } from '$lib/server/validation/cron';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 // Type for background_job_runs table (not in generated types)
 interface BackgroundJobRunRow {
@@ -20,28 +21,14 @@ interface BackgroundJobRunRow {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	// Check authentication
-	const { user } = await locals.safeGetSession();
-	if (!user) {
-		throw redirect(302, '/auth');
-	}
-
-	// Check if user is admin
-	const { data: profile } = await locals.supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Forbidden - Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Calculate 7-day period start
 	const periodStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
 	// Fetch recent jobs (last 7 days, most recent first)
-	const { data: jobsData, error: jobsError } = await locals.supabase
+	const { data: jobsData, error: jobsError } = await supabase
 		.from('background_job_runs')
 		.select(
 			'id, job_name, status, started_at, completed_at, execution_time_ms, error_message, metadata'

--- a/src/routes/(protected)/dashboard/admin/debug/avatar/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/debug/avatar/+page.server.ts
@@ -18,16 +18,16 @@
  */
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile } = locals;
+	// Admin gate (admin login OR step-up elevation)
+	await requireAdmin(locals);
 
+	// Diagnostic data describes the CURRENT session (real admin or elevated teacher).
+	const { user, profile } = locals;
 	if (!user) {
 		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
 	}
 
 	return {

--- a/src/routes/(protected)/dashboard/admin/debug/database/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/debug/database/+page.server.ts
@@ -20,8 +20,8 @@
  * PRIVACY:
  * - Email addresses are redacted (first 3 chars + ***@domain.com)
  */
-import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 /**
  * Redact email address for privacy
@@ -35,15 +35,8 @@ function redactEmail(email: string | null): string {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile, supabase } = locals;
-
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Fetch all counts in a single query using database function
 	const { data: stats } = await supabase.rpc('get_database_stats');

--- a/src/routes/(protected)/dashboard/admin/debug/rls/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/debug/rls/+page.server.ts
@@ -15,8 +15,8 @@
  * PRIVACY:
  * - Uses test queries without exposing real user data
  */
-import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 interface PolicyTest {
 	table: string;
@@ -28,15 +28,9 @@ interface PolicyTest {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile, supabase } = locals;
-
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation). The returned client is the
+	// admin-context client, so these RLS tests run as the admin user.
+	const { supabase } = await requireAdmin(locals);
 
 	const tests: PolicyTest[] = [];
 

--- a/src/routes/(protected)/dashboard/admin/debug/session/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/debug/session/+page.server.ts
@@ -19,6 +19,7 @@
  */
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 /**
  * Redact sensitive token data
@@ -42,14 +43,14 @@ function redactEmail(email: string | null): string {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
+	// Admin gate (admin login OR step-up elevation).
+	await requireAdmin(locals);
+
+	// This page debugs the ACTUAL current session, so it intentionally uses the
+	// caller's own client (locals.supabase) and session, not the admin-context one.
 	const { user, profile, supabase } = locals;
-
-	if (!user) {
+	if (!user || !profile) {
 		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
 	}
 
 	// For this debug page only, we need to inspect the session object

--- a/src/routes/(protected)/dashboard/admin/docs/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/docs/+page.server.ts
@@ -1,27 +1,13 @@
 import type { PageServerLoad } from './$types';
-import { error } from '@sveltejs/kit';
-import { requireAuth } from '$lib/server/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { scanDocumentation } from '$lib/server/docs-scanner';
 import { parseMarkdown } from '$lib/server/markdown-parser';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 
-export const load: PageServerLoad = async ({ locals: { safeGetSession, supabase }, url }) => {
-	const { user } = await safeGetSession();
-	requireAuth(user);
-
-	if (!user) throw error(401, 'Unauthorized');
-
-	// Only admins can access docs
-	const { data: profile } = await supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (profile?.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+export const load: PageServerLoad = async ({ locals, url }) => {
+	// Admin gate (admin login OR step-up elevation)
+	await requireAdmin(locals);
 
 	// Scan all documentation
 	const categories = await scanDocumentation();

--- a/src/routes/(protected)/dashboard/admin/docs/[...path]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/docs/[...path]/+page.server.ts
@@ -1,25 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import { requireAuth } from '$lib/server/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { scanDocumentation, getDocumentContent } from '$lib/server/docs-scanner';
 import { parseMarkdown } from '$lib/server/markdown-parser';
 
-export const load: PageServerLoad = async ({ locals: { safeGetSession, supabase }, params }) => {
-	const { user } = await safeGetSession();
-	requireAuth(user);
-
-	if (!user) throw error(401, 'Unauthorized');
-
-	// Only admins can access docs
-	const { data: profile } = await supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (profile?.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+export const load: PageServerLoad = async ({ locals, params }) => {
+	// Admin gate (admin login OR step-up elevation)
+	await requireAdmin(locals);
 
 	// Parse path: /features/questions/README -> category: features, docPath: questions/README.md
 	// Filter out empty segments (from trailing slashes)

--- a/src/routes/(protected)/dashboard/admin/errors/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/errors/+page.server.ts
@@ -3,27 +3,13 @@
  * Load error logs and statistics for admin dashboard
  */
 
-import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getErrorStats, getErrorOccurrences } from '$lib/server/errorMonitoring';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
-	// Check authentication
-	const { user } = await locals.safeGetSession();
-	if (!user) {
-		throw redirect(302, '/auth');
-	}
-
-	// Check if user is admin
-	const { data: profile } = await locals.supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Forbidden - Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Parse filters from query params
 	const filters: Record<string, string | boolean | number> = {};
@@ -43,10 +29,10 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	filters.offset = 0;
 
 	// Load error statistics (last 24 hours)
-	const statsResult = await getErrorStats(locals.supabase, 24);
+	const statsResult = await getErrorStats(supabase, 24);
 
 	// Load error occurrences (deduplicated errors)
-	const occurrencesResult = await getErrorOccurrences(locals.supabase, filters);
+	const occurrencesResult = await getErrorOccurrences(supabase, filters);
 
 	return {
 		stats: statsResult.success ? statsResult.data : null,

--- a/src/routes/(protected)/dashboard/admin/errors/[id]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/errors/[id]/+page.server.ts
@@ -2,32 +2,19 @@
  * Error Detail Page - Server Load & Actions
  */
 
-import { error, redirect, fail } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { getErrorLog, resolveError } from '$lib/server/errorMonitoring';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const { id } = params;
 
-	// Check authentication
-	const { user } = await locals.safeGetSession();
-	if (!user) {
-		throw redirect(302, '/auth');
-	}
-
-	// Check if user is admin
-	const { data: profile } = await locals.supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Forbidden - Admin access required');
-	}
+	// Admin gate (admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Load error log
-	const result = await getErrorLog(locals.supabase, id);
+	const result = await getErrorLog(supabase, id);
 
 	if (!result.success || !result.data) {
 		throw error(404, 'Error not found');
@@ -45,26 +32,14 @@ export const actions: Actions = {
 	resolve: async ({ params, request, locals }) => {
 		const { id } = params;
 
-		const { user } = await locals.safeGetSession();
-		if (!user) {
-			return fail(401, { error: 'Unauthorized' });
-		}
-
-		// Check if user is admin
-		const { data: profile } = await locals.supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Forbidden - Admin access required' });
-		}
+		// Admin gate (admin login OR step-up elevation)
+		const { supabase, adminUserId } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const notes = formData.get('notes') as string;
 
-		const result = await resolveError(locals.supabase, id, user.id, notes);
+		// adminUserId is the acting admin recorded as the resolver (audit).
+		const result = await resolveError(supabase, id, adminUserId, notes);
 
 		if (!result.success) {
 			return fail(500, { error: result.error || 'Failed to resolve error' });

--- a/src/routes/(protected)/dashboard/admin/import-students/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/import-students/+page.server.ts
@@ -1,17 +1,11 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { validateFormData, importStudentsFormSchema } from '$lib/server/validation';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile, supabase } = locals;
-
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Fetch all schools for the school selector
 	const { data: schools, error: schoolsError } = await supabase
@@ -70,22 +64,8 @@ export const actions: Actions = {
 	 * Import students from CSV data
 	 */
 	import: async ({ request, locals }) => {
-		const { user, supabase } = locals;
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
-
-		// Check admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (profile?.role !== 'admin') {
-			return fail(403, { message: 'Admin access required' });
-		}
+		// Admin only (real admin login OR step-up elevation)
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 

--- a/src/routes/(protected)/dashboard/admin/migration/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/migration/+page.server.ts
@@ -13,11 +13,12 @@
  * - Admin-only access (role check)
  */
 
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { promises as fs } from 'fs';
 import path from 'path';
 import type { MigrationManifest, ManifestStructure, TreeNode } from '$lib/types/migration';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 /**
  * Get the latest export folder from data/migration-output/
@@ -38,17 +39,8 @@ async function getLatestExportFolder(): Promise<string> {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	// Authentication check
-	const { user } = await locals.safeGetSession();
-	if (!user) {
-		throw redirect(303, '/auth/login');
-	}
-
-	// Authorization check - admin only
-	const { profile } = locals;
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Acces reserve aux administrateurs');
-	}
+	// Authorization check - admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Read manifest.json from the latest export directory
 	const latestExport = await getLatestExportFolder();
@@ -61,8 +53,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		// Query migration_tracking for review statuses
 		// Only count Phase 4 (manual validation via UI) — not Phase 1 (auto-import)
 		const statusMap = new Map<number, 'validated' | 'failed'>();
-		if (locals.supabase) {
-			const { data: trackingData } = await locals.supabase
+		if (supabase) {
+			const { data: trackingData } = await supabase
 				.from('migration_tracking')
 				.select('old_question_index, migration_status')
 				.eq('phase', 4)

--- a/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/+page.server.ts
@@ -11,6 +11,7 @@ import { error } from '@sveltejs/kit';
 import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import type { GradeCode } from '$lib/types/grades';
 import type { MigrationStatus } from '$lib/types/migration';
 import type {
@@ -126,6 +127,9 @@ export interface QuestionEntry {
 }
 
 export const load: PageServerLoad = async ({ params, locals }) => {
+	// Authorization check - admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
+
 	const { theme, domain, subdomain } = params;
 
 	// Decode URL-encoded params
@@ -193,9 +197,9 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		const reviewStatusMap: Record<number, { status: MigrationStatus; reason?: string }> = {};
 		const questionEditsMap: Record<number, { editId: string; editedJson: unknown }> = {};
 
-		if (locals.supabase && globalIndices.length > 0) {
+		if (supabase && globalIndices.length > 0) {
 			// Load tracking data for review status
-			const { data: trackingData } = await locals.supabase
+			const { data: trackingData } = await supabase
 				.from('migration_tracking')
 				.select('old_question_index, migration_status, conversion_errors, conversion_notes')
 				.in('old_question_index', globalIndices);
@@ -216,7 +220,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 			// Load edits from migration_edits table
 			// We need to join with migration_tracking to get the old_question_index
-			const { data: editsData } = await locals.supabase
+			const { data: editsData } = await supabase
 				.from('migration_edits')
 				.select(
 					`

--- a/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/[globalIndex]/edit/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/migration/[theme]/[domain]/[subdomain]/[globalIndex]/edit/+page.server.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 import type { PageServerLoad } from './$types';
 import type { QuestionTemplate } from '$lib/questions/types';
 import type { QuestionEntry } from '../../+page.server';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 /**
  * Get the latest export folder from data/migration-output/
@@ -34,12 +35,8 @@ async function getLatestExportFolder(): Promise<string> {
 }
 
 export const load: PageServerLoad = async ({ params, locals }) => {
-	const { profile, supabase } = locals;
-
-	// Check admin role
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Accès refusé');
-	}
+	// Check admin (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	const { theme, domain, subdomain, globalIndex: globalIndexParam } = params;
 

--- a/src/routes/(protected)/dashboard/admin/notifications/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/notifications/+page.server.ts
@@ -1,10 +1,11 @@
-import { redirect, fail } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import {
 	getCreatedNotifications,
 	createNotification,
 	deleteNotification
 } from '$lib/server/notifications';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import type { CreateNotificationData } from '$lib/types/notification';
 import {
 	createNotificationSchema,
@@ -15,23 +16,9 @@ import {
 	checkNotificationDeleteRateLimit
 } from '$lib/server/rateLimiter';
 
-export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession } }) => {
-	const { user } = await safeGetSession();
-
-	if (!user) {
-		throw redirect(303, '/auth/login');
-	}
-
-	// Get user profile to check role
-	const { data: profile, error: profileError } = await supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (profileError || !profile || profile.role !== 'admin') {
-		throw redirect(303, '/dashboard');
-	}
+export const load: PageServerLoad = async ({ locals }) => {
+	// Admin only (real admin login OR step-up elevation)
+	const { supabase, adminUserId } = await requireAdmin(locals);
 
 	// Get all classes
 	const { data: classes } = await supabase
@@ -48,7 +35,7 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 		.order('lastname');
 
 	// Get admin's created notifications with stats
-	const notificationStats = await getCreatedNotifications(supabase, user.id);
+	const notificationStats = await getCreatedNotifications(supabase, adminUserId);
 
 	return {
 		classes: classes || [],
@@ -58,28 +45,14 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 };
 
 export const actions: Actions = {
-	create: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non authentifié' });
-		}
-
-		// Check admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Permission refusée' });
-		}
+	create: async ({ request, locals }) => {
+		// Admin only (real admin login OR step-up elevation)
+		const { supabase, adminUserId } = await requireAdmin(locals);
 
 		// ====================================================================
 		// SECURITY: Rate Limiting
 		// ====================================================================
-		const rateLimitResult = await checkNotificationCreateRateLimit(user.id, 'admin');
+		const rateLimitResult = await checkNotificationCreateRateLimit(adminUserId, 'admin');
 		if (!rateLimitResult.allowed) {
 			return fail(429, { error: rateLimitResult.message });
 		}
@@ -157,7 +130,7 @@ export const actions: Actions = {
 		// 'all' doesn't need additional data
 
 		// Create notification
-		const result = await createNotification(supabase, notificationData, user.id);
+		const result = await createNotification(supabase, notificationData, adminUserId);
 
 		if (!result.success) {
 			return fail(500, { error: result.error || 'Erreur lors de la création' });
@@ -166,17 +139,14 @@ export const actions: Actions = {
 		return { success: true };
 	},
 
-	delete: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non authentifié' });
-		}
+	delete: async ({ request, locals }) => {
+		// Admin only (real admin login OR step-up elevation)
+		const { supabase, adminUserId } = await requireAdmin(locals);
 
 		// ====================================================================
 		// SECURITY: Rate Limiting
 		// ====================================================================
-		const rateLimitResult = await checkNotificationDeleteRateLimit(user.id, 'admin');
+		const rateLimitResult = await checkNotificationDeleteRateLimit(adminUserId, 'admin');
 		if (!rateLimitResult.allowed) {
 			return fail(429, { error: rateLimitResult.message });
 		}
@@ -194,7 +164,7 @@ export const actions: Actions = {
 
 		const { notificationId } = validation.data;
 
-		const result = await deleteNotification(supabase, notificationId, user.id);
+		const result = await deleteNotification(supabase, notificationId, adminUserId);
 
 		if (!result.success) {
 			return fail(500, { error: result.error || 'Erreur lors de la suppression' });

--- a/src/routes/(protected)/dashboard/admin/questions/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/questions/+page.server.ts
@@ -25,17 +25,11 @@
 
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
-	const { user, profile, supabase } = locals;
-
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	/**
 	 * Parse query parameters for filters

--- a/src/routes/(protected)/dashboard/admin/questions/[id]/edit/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/questions/[id]/edit/+page.server.ts
@@ -16,14 +16,11 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { validateUuidParam } from '$lib/server/validation/params';
 import { mapDbTemplateToForm } from '$lib/questions/types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
-	const { profile, supabase } = locals;
-
-	// Check admin role
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Accès refusé');
-	}
+	// Check admin (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	const id = validateUuidParam(params.id);
 

--- a/src/routes/(protected)/dashboard/admin/schools/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/schools/+page.server.ts
@@ -2,19 +2,11 @@ import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { schoolUpsertSchema } from '$lib/server/validation/schools';
 import { uuidSchema } from '$lib/server/validation/common';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user, profile, supabase } = locals;
-
-	// Get authenticated user from session
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	// Verify admin role
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// Admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Fetch all schools
 	const { data: schools, error: schoolsError } = await supabase
@@ -34,11 +26,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 export const actions: Actions = {
 	create: async ({ request, locals }) => {
-		const { user, supabase } = locals;
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const parsed = schoolUpsertSchema.safeParse({
@@ -66,11 +54,7 @@ export const actions: Actions = {
 	},
 
 	update: async ({ request, locals }) => {
-		const { user, supabase } = locals;
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 
@@ -109,11 +93,7 @@ export const actions: Actions = {
 	},
 
 	delete: async ({ request, locals }) => {
-		const { user, supabase } = locals;
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
@@ -145,11 +125,7 @@ export const actions: Actions = {
 	},
 
 	bulk_create: async ({ request, locals }) => {
-		const { user, supabase } = locals;
-
-		if (!user) {
-			return fail(401, { message: 'Unauthorized' });
-		}
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const schoolsJson = formData.get('schools') as string;

--- a/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.server.ts
@@ -1,7 +1,8 @@
-import { error, fail, redirect } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { validateTimetable, type SchoolTimetable } from '$lib/utils/timetable';
 import { validateUuidParam } from '$lib/server/validation/params';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import {
 	createSchoolYearSchema,
 	updateSchoolYearSchema,
@@ -19,25 +20,11 @@ import {
 /**
  * Load school data with academic years, periods, holidays, and timetable
  */
-export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
-	const { user } = await safeGetSession();
-
-	if (!user) {
-		throw redirect(303, '/auth/login');
-	}
+export const load: PageServerLoad = async ({ params, locals }) => {
+	// Admin only (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	const schoolId = validateUuidParam(params.schoolId, 'schoolId');
-
-	// Get user profile to check if admin
-	const { data: profile } = await supabase
-		.from('profiles')
-		.select('role')
-		.eq('id', user.id)
-		.single();
-
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Only admins can manage school organisation');
-	}
 
 	// Fetch school data
 	const { data: school, error: schoolError } = await supabase
@@ -114,23 +101,8 @@ export const actions: Actions = {
 	/**
 	 * Create a new school year
 	 */
-	createYear: async ({ request, params, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent créer des années scolaires' });
-		}
+	createYear: async ({ request, params, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = createSchoolYearSchema.safeParse({
@@ -161,23 +133,8 @@ export const actions: Actions = {
 	/**
 	 * Update an existing school year
 	 */
-	updateYear: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent modifier des années scolaires' });
-		}
+	updateYear: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = updateSchoolYearSchema.safeParse({
@@ -216,23 +173,8 @@ export const actions: Actions = {
 	/**
 	 * Delete a school year
 	 */
-	deleteYear: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent supprimer des années scolaires' });
-		}
+	deleteYear: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = deleteSchoolYearSchema.safeParse({
@@ -259,23 +201,8 @@ export const actions: Actions = {
 	/**
 	 * Set active school year (deactivates all others for this school)
 	 */
-	setActiveYear: async ({ request, params, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: "Seuls les admins peuvent définir l'année active" });
-		}
+	setActiveYear: async ({ request, params, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = setActiveYearSchema.safeParse({
@@ -319,23 +246,8 @@ export const actions: Actions = {
 	/**
 	 * Create a new academic period
 	 */
-	createPeriod: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent créer des périodes académiques' });
-		}
+	createPeriod: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = createAcademicPeriodSchema.safeParse({
@@ -368,23 +280,8 @@ export const actions: Actions = {
 	/**
 	 * Update an existing academic period
 	 */
-	updatePeriod: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent modifier des périodes académiques' });
-		}
+	updatePeriod: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const periodOrderRaw = formData.get('period_order');
@@ -431,23 +328,8 @@ export const actions: Actions = {
 	/**
 	 * Delete an academic period
 	 */
-	deletePeriod: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent supprimer des périodes académiques' });
-		}
+	deletePeriod: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = deleteAcademicPeriodSchema.safeParse({
@@ -478,23 +360,8 @@ export const actions: Actions = {
 	/**
 	 * Create a new school holiday
 	 */
-	createHoliday: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent créer des vacances scolaires' });
-		}
+	createHoliday: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = createSchoolHolidaySchema.safeParse({
@@ -524,23 +391,8 @@ export const actions: Actions = {
 	/**
 	 * Update an existing school holiday
 	 */
-	updateHoliday: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent modifier des vacances scolaires' });
-		}
+	updateHoliday: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = updateSchoolHolidaySchema.safeParse({
@@ -580,23 +432,8 @@ export const actions: Actions = {
 	/**
 	 * Delete a school holiday
 	 */
-	deleteHoliday: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent supprimer des vacances scolaires' });
-		}
+	deleteHoliday: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = deleteSchoolHolidaySchema.safeParse({
@@ -627,23 +464,8 @@ export const actions: Actions = {
 	/**
 	 * Duplicate a school year with its periods and holidays
 	 */
-	duplicateYear: async ({ request, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { error: 'Non autorisé' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { error: 'Seuls les admins peuvent dupliquer des années scolaires' });
-		}
+	duplicateYear: async ({ request, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const validation = duplicateSchoolYearSchema.safeParse({
@@ -775,23 +597,8 @@ export const actions: Actions = {
 	 * Update school timetable
 	 * Validates periods and saves to database
 	 */
-	updateTimetable: async ({ request, params, locals: { supabase, safeGetSession } }) => {
-		const { user } = await safeGetSession();
-
-		if (!user) {
-			return fail(401, { message: 'Not authenticated' });
-		}
-
-		// Verify admin role
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('role')
-			.eq('id', user.id)
-			.single();
-
-		if (!profile || profile.role !== 'admin') {
-			return fail(403, { message: 'Only admins can update timetables' });
-		}
+	updateTimetable: async ({ request, params, locals }) => {
+		const { supabase } = await requireAdmin(locals);
 
 		const formData = await request.formData();
 		const timetableJson = formData.get('timetable') as string;

--- a/src/routes/(protected)/dashboard/admin/vip-cards/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/vip-cards/+page.server.ts
@@ -1,16 +1,13 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { profile } = locals;
-
-	// Check admin role
-	if (!profile || profile.role !== 'admin') {
-		throw redirect(303, '/dashboard');
-	}
+	// Check admin (real admin login OR step-up elevation)
+	const { supabase } = await requireAdmin(locals);
 
 	// Fetch all VIP card templates
-	const { data: templates, error: templatesError } = await locals.supabase
+	const { data: templates, error: templatesError } = await supabase
 		.from('vip_card_templates')
 		.select('*')
 		.order('rarity', { ascending: true })
@@ -22,7 +19,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	}
 
 	// Fetch all VIP card configs
-	const { data: configs, error: configsError } = await locals.supabase
+	const { data: configs, error: configsError } = await supabase
 		.from('vip_card_config')
 		.select('*')
 		.order('is_active', { ascending: false })

--- a/src/routes/api/admin/add-to-class/+server.ts
+++ b/src/routes/api/admin/add-to-class/+server.ts
@@ -1,10 +1,12 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { addToClassSchema } from '$lib/server/validation/admin';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// ✅ SECURITY: Validate input with Zod
 	const body = await request.json();
@@ -17,7 +19,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const { userId, classId } = validation.data;
 
 	// Check if already in class
-	const { data: existing } = await locals.supabase
+	const { data: existing } = await supabase
 		.from('class_members')
 		.select('id')
 		.eq('student_id', userId)
@@ -29,7 +31,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	// Add to class_members table
-	const { error: insertError } = await locals.supabase
+	const { error: insertError } = await supabase
 		.from('class_members')
 		.insert({ student_id: userId, class_id: classId });
 
@@ -39,7 +41,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	// Fetch the updated profile with all classes
-	const { data: updatedProfile, error: fetchError } = await locals.supabase
+	const { data: updatedProfile, error: fetchError } = await supabase
 		.from('profiles')
 		.select('*, schools(name), class_members(class_id)')
 		.eq('id', userId)

--- a/src/routes/api/admin/anti-fraud/run/+server.ts
+++ b/src/routes/api/admin/anti-fraud/run/+server.ts
@@ -10,12 +10,14 @@
  */
 
 import { error, json, type RequestHandler } from '@sveltejs/kit';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { runAntiFraudJob } from '$lib/server/anti-fraud';
 import { runJobOptionsSchema } from '$lib/server/validation/anti-fraud';
 
 export const POST: RequestHandler = async ({ locals, request }) => {
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// Body optionnel : si absent ou vide, on accepte.
 	let bodyJson: unknown = {};
@@ -33,6 +35,6 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		throw error(400, parsed.error.issues[0].message);
 	}
 
-	const report = await runAntiFraudJob(locals.supabase, parsed.data);
+	const report = await runAntiFraudJob(supabase, parsed.data);
 	return json(report);
 };

--- a/src/routes/api/admin/class-students/+server.ts
+++ b/src/routes/api/admin/class-students/+server.ts
@@ -1,7 +1,7 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { classStudentsQuerySchema } from '$lib/server/validation/admin';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 /**
  * GET /api/admin/class-students
@@ -31,7 +31,9 @@ import { requireRole } from '$lib/server/middleware/auth';
  *   });
  */
 export const GET: RequestHandler = async ({ url, locals }) => {
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// ✅ SECURITY: Validate query parameters with Zod
 	const validation = classStudentsQuerySchema.safeParse({
@@ -52,7 +54,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	try {
 		// Query class_members table and join with profiles
 		// Filter for students only (role = 'student')
-		const { data: members, error: queryError } = await locals.supabase
+		const { data: members, error: queryError } = await supabase
 			.from('class_members')
 			.select(
 				`

--- a/src/routes/api/admin/cron/jobs/+server.ts
+++ b/src/routes/api/admin/cron/jobs/+server.ts
@@ -14,7 +14,7 @@
 
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { cronJobsQuerySchema, type CronJobsResponse } from '$lib/server/validation/cron';
 
 // Period to milliseconds mapping
@@ -25,8 +25,9 @@ const PERIOD_MS: Record<string, number> = {
 };
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	// Verify admin access
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// Parse and validate query params (Zod handles defaults and transforms)
 	const queryParams = Object.fromEntries(url.searchParams.entries());
@@ -43,7 +44,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 	try {
 		// Build query for job runs
-		let query = locals.supabase
+		let query = supabase
 			.from('background_job_runs')
 			.select(
 				'id, job_name, status, started_at, completed_at, execution_time_ms, error_message, metadata',
@@ -70,7 +71,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		}
 
 		// Fetch stats for the period (separate query for aggregates)
-		const statsQuery = locals.supabase
+		const statsQuery = supabase
 			.from('background_job_runs')
 			.select('status, execution_time_ms')
 			.gte('started_at', periodStart);

--- a/src/routes/api/admin/cron/trigger/+server.ts
+++ b/src/routes/api/admin/cron/trigger/+server.ts
@@ -12,7 +12,7 @@
 
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { getEnv } from '$lib/server/env';
 import { cronTriggerBodySchema, type CronTriggerResponse } from '$lib/server/validation/cron';
 import { createServiceRoleClient } from '$lib/server/serviceRoleClient';
@@ -26,8 +26,9 @@ const RATE_LIMIT_MINUTES = 1;
 const RATE_LIMIT_MS = RATE_LIMIT_MINUTES * 60 * 1000;
 
 export const POST: RequestHandler = async ({ request, locals, url }) => {
-	// Verify admin access
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. This handler triggers jobs
+	// via fetch/service-role (no admin-context DB ops), so we only gate access.
+	await requireAdmin(locals);
 
 	// Parse and validate request body
 	let body: unknown;

--- a/src/routes/api/admin/exercises/backup-stats/+server.ts
+++ b/src/routes/api/admin/exercises/backup-stats/+server.ts
@@ -10,6 +10,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { getBackupStats } from '$lib/server/admin/exercise-backup';
 
 /**
@@ -26,18 +27,12 @@ import { getBackupStats } from '$lib/server/admin/exercise-backup';
  * }
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Non authentifie');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Acces reserve aux administrateurs');
-	}
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
-		const stats = await getBackupStats(locals.supabase);
+		const stats = await getBackupStats(supabase);
 		return json(stats);
 	} catch (err) {
 		console.error('Error fetching backup stats:', err);

--- a/src/routes/api/admin/exercises/backup/+server.ts
+++ b/src/routes/api/admin/exercises/backup/+server.ts
@@ -12,6 +12,7 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import {
 	exportBackupJSON,
 	exportBackupSQL,
@@ -52,17 +53,11 @@ const restoreBodySchema = z.object({
  *   - SQL format: Plain text SQL dump
  */
 export const GET: RequestHandler = async ({ url, locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Non authentifie');
-	}
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Acces reserve aux administrateurs');
-	}
-
-	// 3. Parse query parameters
+	// Parse query parameters
 	const params = {
 		format: url.searchParams.get('format') ?? 'json'
 	};
@@ -75,10 +70,13 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	const { format } = queryValidation.data;
 
 	try {
-		const adminEmail = locals.profile.email ?? 'admin@unknown';
+		// Cosmetic label embedded in the dump (not a security/audit field). Under
+		// step-up elevation `locals.profile` is the elevating user, so this may not
+		// be the admin's address; falls back to a placeholder when absent.
+		const adminEmail = locals.profile?.email ?? 'admin@unknown';
 
 		if (format === 'sql') {
-			const sqlDump = await exportBackupSQL(locals.supabase, adminEmail);
+			const sqlDump = await exportBackupSQL(supabase, adminEmail);
 			const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 
 			return new Response(sqlDump, {
@@ -90,7 +88,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		}
 
 		// JSON format (default)
-		const backup = await exportBackupJSON(locals.supabase, adminEmail);
+		const backup = await exportBackupJSON(supabase, adminEmail);
 		const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 
 		return new Response(JSON.stringify(backup, null, 2), {
@@ -125,17 +123,11 @@ export const GET: RequestHandler = async ({ url, locals }) => {
  * Response: RestoreResult
  */
 export const POST: RequestHandler = async ({ request, locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Non authentifie');
-	}
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged writes run via the
+	// returned admin-context client so RLS + ownership attribute them to the admin.
+	const { supabase, adminUserId } = await requireAdmin(locals);
 
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Acces reserve aux administrateurs');
-	}
-
-	// 3. Check content length (size limit)
+	// Check content length (size limit)
 	const contentLength = request.headers.get('content-length');
 	if (contentLength) {
 		const size = parseInt(contentLength, 10);
@@ -161,13 +153,14 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const { backup, options } = bodyValidation.data;
 
 	try {
-		// Add admin_id to options for orphan reassignment
+		// Add admin_id to options for orphan reassignment.
+		// Acting-admin identity → use adminUserId (correct under step-up elevation).
 		const restoreOptions = {
 			...options,
-			admin_id: options.reassign_orphans_to_admin ? locals.profile.id : undefined
+			admin_id: options.reassign_orphans_to_admin ? adminUserId : undefined
 		};
 
-		const result = await restoreFromBackup(locals.supabase, backup, restoreOptions);
+		const result = await restoreFromBackup(supabase, backup, restoreOptions);
 
 		// Return result with appropriate status
 		if (!result.success) {

--- a/src/routes/api/admin/health-stats/+server.ts
+++ b/src/routes/api/admin/health-stats/+server.ts
@@ -24,7 +24,7 @@ import {
 	getCachedHealthStats,
 	setCachedHealthStats
 } from '$lib/server/healthStats';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 // Cache configuration
 const CACHE_KEY = 'admin:health-stats';
@@ -45,12 +45,13 @@ const CACHE_TTL_SECONDS = 300; // 5 minutes
  * }
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// ✅ SECURITY: Verify user is admin
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads/writes run via
+	// the returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
 		// Step 1: Try to get from cache first
-		const cached = await getCachedHealthStats(locals.supabase, CACHE_KEY);
+		const cached = await getCachedHealthStats(supabase, CACHE_KEY);
 
 		if (cached) {
 			// Cache hit - return cached data with metadata
@@ -65,11 +66,11 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 		// Step 2: Cache miss - fetch fresh stats from database
 		// This queries multiple views and aggregates data (expensive operation)
-		const stats = await fetchHealthStats(locals.supabase);
+		const stats = await fetchHealthStats(supabase);
 
 		// Step 3: Store in cache for next request
 		// This is a fire-and-forget operation - we don't wait for it
-		setCachedHealthStats(locals.supabase, CACHE_KEY, stats, CACHE_TTL_SECONDS).catch((err) => {
+		setCachedHealthStats(supabase, CACHE_KEY, stats, CACHE_TTL_SECONDS).catch((err) => {
 			// Log but don't fail the request if cache write fails
 			console.error('Failed to cache health stats:', err);
 		});

--- a/src/routes/api/admin/remove-from-class/+server.ts
+++ b/src/routes/api/admin/remove-from-class/+server.ts
@@ -1,10 +1,12 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { removeFromClassSchema } from '$lib/server/validation/admin';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// ✅ SECURITY: Validate input with Zod
 	const body = await request.json();
@@ -17,7 +19,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const { userId, classId } = validation.data;
 
 	// Remove from class_members table
-	const { error: deleteError } = await locals.supabase
+	const { error: deleteError } = await supabase
 		.from('class_members')
 		.delete()
 		.eq('student_id', userId)
@@ -29,7 +31,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	// Fetch the updated profile with all classes
-	const { data: updatedProfile, error: fetchError } = await locals.supabase
+	const { data: updatedProfile, error: fetchError } = await supabase
 		.from('profiles')
 		.select('*, schools(name), class_members(class_id)')
 		.eq('id', userId)

--- a/src/routes/api/admin/schools/[schoolId]/config/+server.ts
+++ b/src/routes/api/admin/schools/[schoolId]/config/+server.ts
@@ -9,6 +9,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { updateSchoolConfigSchema } from '$lib/server/validation/school-config';
 import { DEFAULT_TIMEZONE } from '$lib/utils/timezones';
 import { DEFAULT_WEEK_CONFIG } from '$lib/utils/week-config';
@@ -19,17 +20,9 @@ import type { SchoolTimetable } from '$lib/utils/timetable';
  * Admin only
  */
 export const PUT: RequestHandler = async ({ params, request, locals }) => {
-	const { user, profile, supabase } = locals;
-
-	// Authentication check
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	// Authorization check - admin only
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged writes run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	const { schoolId } = params;
 
@@ -124,17 +117,9 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
  * Admin only
  */
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const { user, profile, supabase } = locals;
-
-	// Authentication check
-	if (!user) {
-		throw error(401, 'Unauthorized');
-	}
-
-	// Authorization check - admin only
-	if (!profile || profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged reads run via the
+	// returned admin-context client so RLS attributes them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	const { schoolId } = params;
 

--- a/src/routes/api/admin/search-users/+server.ts
+++ b/src/routes/api/admin/search-users/+server.ts
@@ -1,10 +1,12 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { searchUsersSchema } from '$lib/server/validation/admin';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	await requireRole(locals, 'admin');
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged search runs via the
+	// returned admin-context client so RLS attributes it to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	// ✅ SECURITY: Validate query parameters with Zod
 	const validation = searchUsersSchema.safeParse({
@@ -26,7 +28,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	// Use RPC function for accent-insensitive search (e.g., "zoe" finds "Zoé")
-	const { data: users, error: searchError } = await locals.supabase.rpc('search_users_unaccent', {
+	const { data: users, error: searchError } = await supabase.rpc('search_users_unaccent', {
 		search_term: searchTerm,
 		result_limit: limit
 	});

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -13,6 +13,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { updateUserFieldsSchema } from '$lib/server/validation/admin';
 import type { Database } from '$lib/types/database';
 
@@ -53,17 +54,9 @@ type ExtendedProfile = Profile & {
  *   - 500: Server error
  */
 export const PATCH: RequestHandler = async ({ request, locals, params }) => {
-	// ✅ SECURITY: Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// ✅ SECURITY: Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 	const userId = params.id;
 
 	// Validate UUID format for userId

--- a/src/routes/api/admin/vip-cards/configs/+server.ts
+++ b/src/routes/api/admin/vip-cards/configs/+server.ts
@@ -11,6 +11,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { createConfigSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardConfig } from '$lib/types/vip-card-admin';
 import { configToResponse } from '$lib/types/vip-card-admin';
@@ -42,17 +43,9 @@ import { configToResponse } from '$lib/types/vip-card-admin';
  *   - 500: Server error
  */
 export const POST: RequestHandler = async ({ request, locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
 		// 3. Input validation
@@ -115,17 +108,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
  *   - 500: Server error
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
 		// 3. Fetch all configs (active first, then by creation date)

--- a/src/routes/api/admin/vip-cards/configs/[id]/+server.ts
+++ b/src/routes/api/admin/vip-cards/configs/[id]/+server.ts
@@ -11,6 +11,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { updateConfigSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardConfig } from '$lib/types/vip-card-admin';
 import { configToResponse } from '$lib/types/vip-card-admin';
@@ -34,17 +35,9 @@ import { configToResponse } from '$lib/types/vip-card-admin';
  *   - 500: Server error
  */
 export const PATCH: RequestHandler = async ({ request, locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 	const configId = parseInt(params.id, 10);
 
 	if (isNaN(configId)) {
@@ -137,17 +130,8 @@ export const PATCH: RequestHandler = async ({ request, locals, params }) => {
  *   - 500: Server error
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login.
+	const { supabase } = await requireAdmin(locals);
 	const configId = parseInt(params.id, 10);
 
 	if (isNaN(configId)) {

--- a/src/routes/api/admin/vip-cards/configs/[id]/activate/+server.ts
+++ b/src/routes/api/admin/vip-cards/configs/[id]/activate/+server.ts
@@ -10,6 +10,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import type { VipCardConfig } from '$lib/types/vip-card-admin';
 import { configToResponse } from '$lib/types/vip-card-admin';
 
@@ -31,17 +32,9 @@ import { configToResponse } from '$lib/types/vip-card-admin';
  *   - 500: Server error
  */
 export const PATCH: RequestHandler = async ({ locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 	const configId = parseInt(params.id, 10);
 
 	if (isNaN(configId)) {

--- a/src/routes/api/admin/vip-cards/templates/+server.ts
+++ b/src/routes/api/admin/vip-cards/templates/+server.ts
@@ -11,6 +11,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { createTemplateSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardTemplate } from '$lib/types/vip-card-admin';
 import { templateToResponse } from '$lib/types/vip-card-admin';
@@ -40,17 +41,9 @@ import { templateToResponse } from '$lib/types/vip-card-admin';
  *   - 500: Server error
  */
 export const POST: RequestHandler = async ({ request, locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
 		// 3. Input validation
@@ -133,17 +126,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
  *   - 500: Server error
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login.
+	const { supabase } = await requireAdmin(locals);
 
 	try {
 		// 3. Fetch all templates (ordered by sort_order, then name)

--- a/src/routes/api/admin/vip-cards/templates/[id]/+server.ts
+++ b/src/routes/api/admin/vip-cards/templates/[id]/+server.ts
@@ -11,6 +11,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import { updateTemplateSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardTemplate } from '$lib/types/vip-card-admin';
 import { templateToResponse } from '$lib/types/vip-card-admin';
@@ -33,17 +34,9 @@ import { validateSlugParam } from '$lib/server/validation/params';
  *   - 500: Server error
  */
 export const PATCH: RequestHandler = async ({ request, locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops run via the
+	// returned admin-context client so RLS + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 	const templateId = validateSlugParam(params.id, 'templateId');
 
 	try {
@@ -133,17 +126,8 @@ export const PATCH: RequestHandler = async ({ request, locals, params }) => {
  *   - 500: Server error
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login.
+	const { supabase } = await requireAdmin(locals);
 	const templateId = validateSlugParam(params.id, 'templateId');
 
 	try {

--- a/src/routes/api/admin/vip-cards/templates/[id]/image/+server.ts
+++ b/src/routes/api/admin/vip-cards/templates/[id]/image/+server.ts
@@ -11,6 +11,7 @@
 import { error, json } from '@sveltejs/kit';
 import sharp from 'sharp';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import type { UploadImageResponse } from '$lib/types/vip-card-admin';
 import { validateSlugParam } from '$lib/server/validation/params';
 
@@ -33,17 +34,10 @@ const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
  *   - 500: Server error
  */
 export const POST: RequestHandler = async ({ request, locals, params }) => {
-	// 1. Authentication check
-	if (!locals.profile) {
-		throw error(401, 'Authentication required');
-	}
-
-	// 2. Authorization check (admin only)
-	if (locals.profile.role !== 'admin') {
-		throw error(403, 'Admin access required');
-	}
-
-	const supabase = locals.supabase;
+	// ✅ SECURITY: admin elevation OR real admin login. Privileged ops (storage
+	// upload + image_path update) run via the returned admin-context client so RLS
+	// + audit attribute them to the admin.
+	const { supabase } = await requireAdmin(locals);
 	const templateId = validateSlugParam(params.id, 'templateId');
 
 	try {


### PR DESCRIPTION
## Quoi
**Phase 3** de l'élévation admin (suite de #29). Câble `requireAdmin` dans les routes **admin-only** : leurs ops privilégiées tournent sous le **client admin** pour les DEUX voies (login admin réel OU élévation step-up).

- **18 endpoints** `/api/admin/*` (+ `users/[id]`) → `requireAdmin`.
- **22 pages** `dashboard/admin/*` (loads + actions) → `requireAdmin`.
- **Nouveau garde de section** `dashboard/admin/+layout.server.ts` (`requireRoles(['teacher','admin'])` — la section est **mixte**).

## Laissés intacts (NON admin-only — autorisent le prof)
`marketplace/admin/{activity,analytics,stats,trades}`, `dashboard/admin/{friendships,users}`, `api/admin/{search-users/pending, users/[id]/status, pending-users}`.

## Sécurité
- **`security-auditor` : SAFE TO MERGE**, 0 critical/high. Aucune op privilégiée laissée sur `locals.supabase` ; aucune route prof convertie par erreur ; attribution acteur via `adminUserId`.
- **Amélioration nette** : avant, un élève authentifié pouvait afficher les pages admin sans `+page.server.ts` ; le nouveau garde les bloque.
- L'accès admin réel est **inchangé** ; la voie élevée est fonctionnelle mais **dormante** jusqu'à l'UI (Phase 4).

## Vérifs
`check:incremental` 0 erreur (1700 fichiers) · test endpoint `config` 29/29 · service-role (cron/anti-fraud/backup) et Zod intacts.

## Suivi (non bloquant, LOW)
Quelques pages admin sans `+page.server.ts` (`message-templates`, `questions/create`…) s'appuient sur le garde + RLS + endpoints hors `/api/admin` — à confirmer admin-only vs teacher-allowed en Phase 4.

⚠️ Comportement : les form `actions` font désormais `throw error(403)` (au lieu de `fail(403)`) — Phase 4 attrapera le 403 → modale d'élévation.