### PR TITLE
feat(auth): admin elevation UI (Phase 4) — needs manual flow test

### DIFF
--- a/src/lib/config/dashboard-nav.ts
+++ b/src/lib/config/dashboard-nav.ts
@@ -31,6 +31,7 @@ import {
 	Target,
 	ClipboardList,
 	Brain,
+	ShieldCheck,
 	User as UserIcon,
 	LogOut
 } from '@lucide/svelte';
@@ -132,6 +133,10 @@ export function getNavLinks(
 			{ href: '/dashboard/teacher/moderation', label: 'Modération', icon: ShieldAlert },
 			{ href: '/dashboard/friends', label: 'Amis', icon: Users },
 			{ href: '/dashboard/chat', label: 'Chat', icon: MessageCircle },
+			// Entry point to the admin section. Visible to teachers (who step up via
+			// the elevation screen) and admins; never to students. The route itself
+			// is guarded by /dashboard/admin/+layout.server.ts.
+			{ href: '/dashboard/admin', label: 'Administration', icon: ShieldCheck },
 			...footerLinks
 		];
 	}
@@ -139,6 +144,7 @@ export function getNavLinks(
 	if (role === 'admin') {
 		return [
 			...common,
+			{ href: '/dashboard/admin', label: 'Administration', icon: ShieldCheck },
 			{ href: '/dashboard/admin/schools', label: 'Schools', icon: School },
 			{ href: '/dashboard/admin/users', label: 'Users', icon: Users },
 			{ href: '/dashboard/admin/classes', label: 'Classes', icon: GraduationCap },

--- a/src/lib/server/validation/admin-elevation.ts
+++ b/src/lib/server/validation/admin-elevation.ts
@@ -13,14 +13,13 @@ import { z } from 'zod';
 /**
  * Body schema for POST /api/admin/elevate.
  *
- * - `email`: the admin account's email (validated, length-capped).
- * - `password`: the admin account's password (non-empty, length-capped to
- *   prevent oversized-payload abuse). We deliberately do NOT enforce a
- *   minimum-length policy here — the credential is checked against Supabase
- *   auth, not created — so a `.min(1)` is the correct guard.
+ * Mono-admin model: the caller submits ONLY the password — the server resolves
+ * the single admin account's email itself. `password` is non-empty and
+ * length-capped (oversized-payload guard); we deliberately do NOT enforce a
+ * minimum-length policy — the credential is checked against Supabase auth, not
+ * created — so `.min(1)` is the correct guard.
  */
 export const adminElevateSchema = z.object({
-	email: z.string().trim().email('Email invalide').max(254, 'Email trop long'),
 	password: z.string().min(1, 'Mot de passe requis').max(200, 'Mot de passe trop long')
 });
 

--- a/src/routes/(protected)/dashboard/admin/+layout.server.ts
+++ b/src/routes/(protected)/dashboard/admin/+layout.server.ts
@@ -2,20 +2,63 @@
  * Admin section guard
  * ===================
  *
- * Section-level gate for `/dashboard/admin/*`: students never get in. It does
- * NOT require admin, because the section is mixed — most pages are admin-only
- * (they self-gate with `requireAdmin`, which a non-elevated teacher fails), but
- * a few (`friendships`, `users`) legitimately allow the teacher too. So the
- * layout only enforces the least-restrictive common denominator (teacher OR
- * admin); each page refines from there.
+ * Section-level gate for `/dashboard/admin/*`. With server-side admin elevation
+ * (Pattern 2) the rule is explicit:
+ *
+ *   - unauthenticated            → /auth/login
+ *   - active admin elevation     → allowed (parallel admin state)
+ *   - real admin account         → allowed (a true admin never needs to elevate)
+ *   - teacher (not elevated)     → redirected to the elevation screen, carrying
+ *                                  the requested path so they land back here once
+ *                                  elevated
+ *   - anyone else (students, …)  → 403
+ *
+ * Most child pages additionally self-gate with `requireAdmin`; a non-elevated
+ * teacher fails those, but a handful (`friendships`, `users`) legitimately allow
+ * the teacher too — so the redirect here is the floor, not a hard admin wall.
+ *
+ * SECURITY: the returned `adminElevation` is intentionally minimal — only
+ * `{ active, expiresAt }`. The admin user id and the elevation token are NEVER
+ * sent to the client.
  *
  * @module routes/(protected)/dashboard/admin/+layout.server
  */
 
-import { requireRoles } from '$lib/server/middleware/auth';
+import { error, redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ locals }) => {
-	await requireRoles(locals, ['teacher', 'admin']);
-	return {};
+// Pages under /dashboard/admin that legitimately allow the (single) teacher, not
+// just admins — they self-gate at teacher+admin. A non-elevated teacher must NOT
+// be bounced to the elevation screen for these. Keep in sync with the Phase 3
+// teacher-allowed exclusions (api/admin counterparts: users, pending approvals).
+const TEACHER_ALLOWED_PREFIXES = ['/dashboard/admin/friendships', '/dashboard/admin/users'];
+
+export const load: LayoutServerLoad = async ({ locals, url }) => {
+	if (!locals.user) {
+		throw redirect(303, '/auth/login');
+	}
+
+	if (locals.adminElevation?.active || locals.profile?.role === 'admin') {
+		// Active elevation or a real admin login → full admin-section access.
+	} else if (locals.profile?.role === 'teacher') {
+		const teacherAllowed = TEACHER_ALLOWED_PREFIXES.some(
+			(p) => url.pathname === p || url.pathname.startsWith(`${p}/`)
+		);
+		if (!teacherAllowed) {
+			// Admin-only page → send the teacher to the step-up screen, preserving
+			// the destination so they land back here once elevated.
+			throw redirect(303, `/dashboard/elevate?redirect=${encodeURIComponent(url.pathname)}`);
+		}
+		// Teacher-allowed page (friendships/users) → let the teacher through.
+	} else {
+		// Students and any other role have no business here.
+		throw error(403, "Accès réservé à l'administration");
+	}
+
+	// Expose ONLY the minimal, non-sensitive elevation state to the client.
+	return {
+		adminElevation: locals.adminElevation
+			? { active: locals.adminElevation.active, expiresAt: locals.adminElevation.expiresAt }
+			: null
+	};
 };

--- a/src/routes/(protected)/dashboard/admin/+layout.svelte
+++ b/src/routes/(protected)/dashboard/admin/+layout.svelte
@@ -1,0 +1,112 @@
+<!--
+	Admin section layout
+	====================
+
+	Wraps every `/dashboard/admin/*` page. When the caller is here through an
+	active admin ELEVATION (a teacher stepped up), it shows a sticky amber banner
+	with a live mm:ss countdown to the elevation expiry and a "Quitter le mode
+	admin" button. A real admin login has no elevation → no banner (they are
+	simply admins, not in a temporary elevated mode).
+
+	Countdown approach: `expiresAt` is a Unix epoch in ms (from the server). We
+	keep a reactive `now` ($state) refreshed by a 1s interval started in an
+	$effect (with cleanup). `remaining`/`countdown` are $derived from it, so the
+	mm:ss display ticks without manual DOM work. At 0 the cookie has expired
+	server-side; the next navigation will bounce the teacher back to the
+	elevation screen.
+-->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { goto, invalidateAll } from '$app/navigation';
+	import { LogOut, ShieldCheck } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { toaster } from '$lib/stores/toaster.svelte';
+	import type { LayoutData } from './$types';
+
+	let { data, children }: { data: LayoutData; children: Snippet } = $props();
+
+	// Reactive clock — refreshed every second by the interval below. Drives the
+	// countdown without touching the DOM by hand.
+	let now = $state(Date.now());
+
+	// Whether we are in an elevated (step-up) session that warrants the banner.
+	let elevated = $derived(data.adminElevation?.active === true);
+
+	// Milliseconds left before the elevation expires (clamped at 0).
+	let remainingMs = $derived(
+		data.adminElevation?.expiresAt ? Math.max(0, data.adminElevation.expiresAt - now) : 0
+	);
+
+	// mm:ss formatting of the remaining time.
+	let countdown = $derived.by(() => {
+		const totalSeconds = Math.floor(remainingMs / 1000);
+		const minutes = Math.floor(totalSeconds / 60);
+		const seconds = totalSeconds % 60;
+		return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+	});
+
+	// Tick the clock while an elevated banner is shown; clean up on teardown.
+	$effect(() => {
+		if (!elevated) return;
+		const id = setInterval(() => {
+			now = Date.now();
+		}, 1000);
+		return () => clearInterval(id);
+	});
+
+	let revoking = $state(false);
+
+	async function handleRevoke() {
+		if (revoking) return;
+		revoking = true;
+		try {
+			const response = await fetch('/api/admin/elevate/revoke', { method: 'POST' });
+			if (!response.ok) {
+				toaster.error('Impossible de quitter le mode administration. Réessayez.');
+				return;
+			}
+			// Re-run server loads so the dropped cookie is reflected, then leave the
+			// admin section (we can no longer access it without re-elevating).
+			await invalidateAll();
+			await goto('/dashboard');
+		} catch {
+			toaster.error('Erreur réseau. Réessayez.');
+		} finally {
+			revoking = false;
+		}
+	}
+</script>
+
+{#if elevated}
+	<div
+		class="sticky top-0 z-40 border-b border-amber-300 bg-amber-100 text-amber-900 shadow-sm dark:border-amber-700 dark:bg-amber-950/80 dark:text-amber-100"
+		role="status"
+		aria-live="polite"
+	>
+		<div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-2 px-4 py-2">
+			<div class="flex items-center gap-2">
+				<ShieldCheck class="h-5 w-5 shrink-0" />
+				<span class="font-semibold">Mode administration</span>
+				<span class="text-sm text-amber-700 dark:text-amber-200/80">
+					· expire dans
+					<span class="font-mono tabular-nums" aria-label="Temps restant {countdown}">
+						{countdown}
+					</span>
+				</span>
+			</div>
+			<Button
+				variant="outline"
+				size="sm"
+				onclick={handleRevoke}
+				disabled={revoking}
+				class="border-amber-400 bg-amber-50 text-amber-900 hover:bg-amber-200 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/70"
+			>
+				<LogOut class="mr-1 h-4 w-4" />
+				{revoking ? 'Sortie…' : 'Quitter le mode admin'}
+			</Button>
+		</div>
+	</div>
+{/if}
+
+{@render children()}

--- a/src/routes/(protected)/dashboard/admin/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/+page.svelte
@@ -1,0 +1,22 @@
+<!--
+	Admin section landing page
+	==========================
+
+	Index for `/dashboard/admin` — the target of the « Administration » nav entry
+	and the default post-elevation redirect. Without it the route resolves only to
+	the layout and 404s. Access is enforced upstream by `+layout.server.ts`
+	(active elevation or a real admin login); the admin-mode banner and the section
+	navigation come from the layout. Kept intentionally minimal — a richer
+	overview (health stats) can be added later.
+-->
+
+<svelte:head>
+	<title>Administration — UbuMaths</title>
+</svelte:head>
+
+<section class="mx-auto max-w-3xl p-6">
+	<h1 class="text-2xl font-bold tracking-tight">Administration</h1>
+	<p class="mt-2 text-muted-foreground">
+		Sélectionnez une section dans le menu pour gérer le site et la base de données.
+	</p>
+</section>

--- a/src/routes/(protected)/dashboard/elevate/+page.server.ts
+++ b/src/routes/(protected)/dashboard/elevate/+page.server.ts
@@ -1,0 +1,42 @@
+/**
+ * Admin elevation page — server load
+ * ==================================
+ *
+ * Resolves a SAFE post-elevation redirect target from the `?redirect=` query
+ * param. The parent `(protected)` layout already guarantees the caller is an
+ * authenticated teacher/admin, so this load only sanitises the redirect to
+ * prevent an open-redirect: the target MUST be an internal path under
+ * `/dashboard/admin`. Anything else (absolute URL, protocol-relative `//evil`,
+ * a path outside the admin section, or a missing param) falls back to the admin
+ * home. The validated path is returned to the page and used by `goto()` after a
+ * successful elevation.
+ *
+ * @module routes/(protected)/dashboard/elevate/+page.server
+ */
+
+import type { PageServerLoad } from './$types';
+
+/** Default landing once elevated. */
+const DEFAULT_REDIRECT = '/dashboard/admin';
+
+/**
+ * Validate an internal redirect target. Accepts only same-origin paths that
+ * live under `/dashboard/admin` (the elevation-gated section). Rejects absolute
+ * URLs and protocol-relative paths (`//host`) which could leak the user
+ * off-site.
+ */
+function safeRedirect(raw: string | null): string {
+	if (!raw) return DEFAULT_REDIRECT;
+	// Must be a root-relative path, but NOT protocol-relative ("//evil.com").
+	if (!raw.startsWith('/') || raw.startsWith('//')) return DEFAULT_REDIRECT;
+	// Must stay inside the admin section: exactly /dashboard/admin or a subpath.
+	if (raw !== '/dashboard/admin' && !raw.startsWith('/dashboard/admin/')) {
+		return DEFAULT_REDIRECT;
+	}
+	return raw;
+}
+
+export const load: PageServerLoad = async ({ url }) => {
+	const redirect = safeRedirect(url.searchParams.get('redirect'));
+	return { redirect };
+};

--- a/src/routes/(protected)/dashboard/elevate/+page.svelte
+++ b/src/routes/(protected)/dashboard/elevate/+page.svelte
@@ -7,8 +7,11 @@
 	success the server sets an httpOnly elevation cookie and the parallel admin
 	state becomes active — the teacher session is never modified.
 
+	Mono-admin model: only the admin PASSWORD is asked — the server resolves the
+	single admin account's email itself.
+
 	Flow:
-	  submit → POST /api/admin/elevate { email, password }
+	  submit → POST /api/admin/elevate { password }
 	    200 → invalidateAll() (re-runs layout loads so adminElevation is live)
 	         → goto(data.redirect) (server-validated, open-redirect-safe target)
 	    error → toaster with the server message; the form stays so the user can
@@ -28,7 +31,6 @@
 	let { data }: { data: PageData } = $props();
 
 	// Form state
-	let email = $state('');
 	let password = $state('');
 	let submitting = $state(false);
 
@@ -41,7 +43,7 @@
 			const response = await fetch('/api/admin/elevate', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ email, password })
+				body: JSON.stringify({ password })
 			});
 
 			if (response.ok) {
@@ -89,28 +91,14 @@
 			</div>
 			<Card.Title class="text-2xl">Accès administration</Card.Title>
 			<Card.Description>
-				Connexion admin requise. Saisissez les identifiants du compte administrateur pour accéder à
-				cet espace.
+				Saisissez le mot de passe du compte administrateur pour accéder à cet espace.
 			</Card.Description>
 		</Card.Header>
 
 		<Card.Content>
 			<form class="space-y-4" onsubmit={handleSubmit}>
 				<div class="space-y-2">
-					<Label for="admin-email">Adresse e-mail administrateur</Label>
-					<Input
-						id="admin-email"
-						type="email"
-						autocomplete="email"
-						bind:value={email}
-						placeholder="admin@exemple.fr"
-						required
-						disabled={submitting}
-					/>
-				</div>
-
-				<div class="space-y-2">
-					<Label for="admin-password">Mot de passe</Label>
+					<Label for="admin-password">Mot de passe administrateur</Label>
 					<Input
 						id="admin-password"
 						type="password"

--- a/src/routes/(protected)/dashboard/elevate/+page.svelte
+++ b/src/routes/(protected)/dashboard/elevate/+page.svelte
@@ -1,0 +1,130 @@
+<!--
+	Admin elevation page
+	====================
+
+	Step-up screen (Pattern 2). The teacher is already logged in as themselves;
+	to act as admin they prove they hold the ADMIN account's credentials. On
+	success the server sets an httpOnly elevation cookie and the parallel admin
+	state becomes active — the teacher session is never modified.
+
+	Flow:
+	  submit → POST /api/admin/elevate { email, password }
+	    200 → invalidateAll() (re-runs layout loads so adminElevation is live)
+	         → goto(data.redirect) (server-validated, open-redirect-safe target)
+	    error → toaster with the server message; the form stays so the user can
+	            retry. The submit button is disabled while the request is in flight.
+-->
+
+<script lang="ts">
+	import { goto, invalidateAll } from '$app/navigation';
+	import { ShieldCheck } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import * as Card from '$lib/components/ui/card';
+	import { toaster } from '$lib/stores/toaster.svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	// Form state
+	let email = $state('');
+	let password = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (submitting) return;
+
+		submitting = true;
+		try {
+			const response = await fetch('/api/admin/elevate', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email, password })
+			});
+
+			if (response.ok) {
+				// Re-run server loads so locals.adminElevation is reflected in page
+				// data (the admin layout guard now lets us through), then land on the
+				// validated target.
+				await invalidateAll();
+				await goto(data.redirect);
+				return;
+			}
+
+			// SvelteKit error() responses carry { message }; fall back to a generic
+			// French message if the body is not the expected shape.
+			let message = 'Échec de la connexion administration. Veuillez réessayer.';
+			try {
+				const body = (await response.json()) as { message?: unknown };
+				if (typeof body.message === 'string' && body.message.length > 0) {
+					message = body.message;
+				}
+			} catch {
+				// Non-JSON body — keep the generic message.
+			}
+			toaster.error(message);
+		} catch {
+			toaster.error('Erreur réseau. Vérifiez votre connexion et réessayez.');
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Accès administration — UbuMaths</title>
+</svelte:head>
+
+<div class="flex min-h-[60vh] items-center justify-center p-4">
+	<Card.Root class="w-full max-w-md">
+		<Card.Header class="space-y-2 text-center">
+			<div class="flex justify-center">
+				<div
+					class="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40"
+				>
+					<ShieldCheck class="h-6 w-6 text-amber-600 dark:text-amber-400" />
+				</div>
+			</div>
+			<Card.Title class="text-2xl">Accès administration</Card.Title>
+			<Card.Description>
+				Connexion admin requise. Saisissez les identifiants du compte administrateur pour accéder à
+				cet espace.
+			</Card.Description>
+		</Card.Header>
+
+		<Card.Content>
+			<form class="space-y-4" onsubmit={handleSubmit}>
+				<div class="space-y-2">
+					<Label for="admin-email">Adresse e-mail administrateur</Label>
+					<Input
+						id="admin-email"
+						type="email"
+						autocomplete="email"
+						bind:value={email}
+						placeholder="admin@exemple.fr"
+						required
+						disabled={submitting}
+					/>
+				</div>
+
+				<div class="space-y-2">
+					<Label for="admin-password">Mot de passe</Label>
+					<Input
+						id="admin-password"
+						type="password"
+						autocomplete="current-password"
+						bind:value={password}
+						required
+						disabled={submitting}
+					/>
+				</div>
+
+				<Button type="submit" class="w-full" disabled={submitting}>
+					{submitting ? 'Connexion…' : 'Accéder à l’administration'}
+				</Button>
+			</form>
+		</Card.Content>
+	</Card.Root>
+</div>

--- a/src/routes/api/admin/elevate/+server.ts
+++ b/src/routes/api/admin/elevate/+server.ts
@@ -2,12 +2,14 @@
  * POST /api/admin/elevate
  * =======================
  *
- * Server-side admin elevation (Pattern 2 — "step-up"). An authenticated
- * teacher/admin POSTs the **admin account's** email + password. The server:
+ * Server-side admin elevation (Pattern 2 — "step-up"). Mono-admin model: an
+ * authenticated teacher/admin POSTs ONLY the **admin account's password** — the
+ * server resolves the single admin account's email itself. The server:
  *
  *   1. confirms the CALLER is a teacher/admin (requireRoles),
  *   2. validates the body (Zod) + rate-limits like the login route,
- *   3. verifies the admin credentials with an EPHEMERAL client
+ *   3. resolves the single admin account's email, then verifies the credentials
+ *      with an EPHEMERAL client
  *      (`signInWithPassword`) — this NEVER touches the caller's `sb-*` session
  *      because the ephemeral client persists nothing and writes no cookies,
  *   4. confirms the signed-in user's `profiles.role === 'admin'` (role from DB),
@@ -69,28 +71,45 @@ export const POST: RequestHandler = async ({ request, locals, cookies, getClient
 	if (!validation.success) {
 		throw error(400, validation.error.issues[0].message);
 	}
-	const { email, password } = validation.data;
+	const { password } = validation.data;
 
-	// 3. Rate limit. Same dual IP + email scheme as the login route, but on
-	//    DEDICATED buckets (ratelimit:elevate:*) so a fat-fingered admin password
-	//    can't burn the /auth/login budget and lock the admin out of the real
-	//    login page (also avoids a targeted-lockout vector against login).
+	// 3. Rate limit by IP first — a cheap guard on DEDICATED buckets
+	//    (ratelimit:elevate:*) so a fat-fingered admin password can't burn the
+	//    /auth/login budget or lock the admin out of the real login page.
 	const ip = getClientAddress();
 	const ipLimit = await checkElevationRateLimitByIP(ip);
 	if (!ipLimit.allowed) {
 		throw error(429, ipLimit.message ?? 'Trop de tentatives. Réessayez plus tard.');
 	}
-	const emailLimit = await checkElevationRateLimitByEmail(email);
+
+	// 4. Mono-admin model: the caller submits only the password. Resolve the
+	//    single admin account's email server-side. `.single()` enforces exactly
+	//    one admin row (0 or >1 → error). profiles is readable here via the broad
+	//    leaderboard SELECT policy; the email is used only to drive the
+	//    server-side sign-in below and is never returned to the client.
+	const { data: adminProfile, error: adminLookupError } = await locals.supabase
+		.from('profiles')
+		.select('email')
+		.eq('role', 'admin')
+		.single();
+	if (adminLookupError || !adminProfile?.email) {
+		logger.error('Could not resolve the admin account for elevation:', adminLookupError);
+		throw error(500, 'Compte administrateur introuvable');
+	}
+	const adminEmail = adminProfile.email;
+
+	// Brute-force protection on the admin account itself (dedicated email bucket).
+	const emailLimit = await checkElevationRateLimitByEmail(adminEmail);
 	if (!emailLimit.allowed) {
 		throw error(429, emailLimit.message ?? 'Trop de tentatives. Réessayez plus tard.');
 	}
 
-	// 4. Verify the ADMIN credentials with an ephemeral client. This client
+	// 5. Verify the ADMIN credentials with an ephemeral client. This client
 	//    persists no session and writes no cookies → the caller's sb-* session
 	//    is untouched.
 	const ephemeral = createEphemeralAuthClient();
 	const { data: signInData, error: signInError } = await ephemeral.auth.signInWithPassword({
-		email,
+		email: adminEmail,
 		password
 	});
 
@@ -105,7 +124,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies, getClient
 	const expiresAtSec =
 		signInData.session.expires_at ?? Math.floor(Date.now() / 1000) + MAX_ELEVATION_MAX_AGE;
 
-	// 5. Confirm the signed-in account is actually an admin (role from the DB).
+	// 6. Confirm the signed-in account is actually an admin (role from the DB).
 	//    We read the role through the EPHEMERAL client — which is now authed as
 	//    the candidate — so the check uses the candidate's own "view own profile"
 	//    RLS path and never depends on the caller's (teacher's) RLS visibility of
@@ -126,7 +145,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies, getClient
 		throw error(403, 'Compte non administrateur');
 	}
 
-	// 6. Mint the elevation cookie. Cap the TTL at the token lifetime (≤ 1h).
+	// 7. Mint the elevation cookie. Cap the TTL at the token lifetime (≤ 1h).
 	const expiresAtMs = expiresAtSec * 1000;
 	const maxAge = Math.min(
 		MAX_ELEVATION_MAX_AGE,

--- a/src/routes/api/admin/elevate/__tests__/elevate.test.ts
+++ b/src/routes/api/admin/elevate/__tests__/elevate.test.ts
@@ -3,20 +3,21 @@
  * ========================================
  *
  * Server-side admin elevation (Pattern 2). An authenticated teacher/admin POSTs
- * the **admin account's** email+password; the server verifies the credentials
+ * only the **admin account's password** (mono-admin); the server resolves the admin
+ * email, verifies the credentials
  * with an EPHEMERAL Supabase client (so the caller's own sb-* session cookies
  * are never touched), confirms the credentials belong to an admin, and on
  * success sets the short-lived httpOnly `ubu-admin-elevation` cookie.
  *
  * Cases:
- *   - 400 invalid body (bad email / missing password)
+ *   - 400 invalid body (missing password)
  *   - 401 bad credentials (signInWithPassword fails)
  *   - 403 credentials belong to a NON-admin account
  *   - 200 + cookie set on valid admin credentials
  *   - 401/403 when the CALLER is not an authenticated teacher/admin
  *
- * The ephemeral client is mocked at the @supabase/supabase-js boundary; the
- * role-confirmation query runs through the mock locals.supabase.
+ * The ephemeral client is mocked (sign-in + role confirmation); the admin-email
+ * lookup runs through the mock locals.supabase.
  *
  * @module api/admin/elevate.test
  */
@@ -108,6 +109,11 @@ function signInSuccess(userId: string, email: string) {
 	};
 }
 
+/** Mono-admin model: stub the single-admin email lookup on the caller client. */
+function mockAdminLookup(supabase: any) {
+	supabase._mockChain.single.mockResolvedValueOnce({ data: { email: ADMIN_EMAIL }, error: null });
+}
+
 describe('POST /api/admin/elevate', () => {
 	beforeEach(() => {
 		signInWithPassword.mockReset();
@@ -123,7 +129,7 @@ describe('POST /api/admin/elevate', () => {
 		const { POST } = await import('../+server');
 		const supabase = createMockSupabase();
 		const locals = createMockLocals(undefined, supabase) as any; // no user
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const request = createMockRequest({ password: ADMIN_PASSWORD });
 		const { event } = makeEvent(request, locals);
 
 		try {
@@ -141,7 +147,7 @@ describe('POST /api/admin/elevate', () => {
 		const locals = createMockLocals(TEST_IDS.teacher, supabase, 'student') as any;
 		locals.user = { id: TEST_IDS.teacher };
 		locals.profile = { id: TEST_IDS.teacher, role: 'student' };
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const request = createMockRequest({ password: ADMIN_PASSWORD });
 		const { event } = makeEvent(request, locals);
 
 		try {
@@ -157,11 +163,11 @@ describe('POST /api/admin/elevate', () => {
 	// Body validation
 	// -------------------------------------------------------------------------
 
-	it('returns 400 for a malformed body (bad email)', async () => {
+	it('returns 400 when the password is missing', async () => {
 		const { POST } = await import('../+server');
 		const supabase = createMockSupabase();
 		const locals = teacherCaller(supabase);
-		const request = createMockRequest({ email: 'not-an-email', password: ADMIN_PASSWORD });
+		const request = createMockRequest({});
 		const { event } = makeEvent(request, locals);
 
 		try {
@@ -197,12 +203,13 @@ describe('POST /api/admin/elevate', () => {
 		const supabase = createMockSupabase();
 		const locals = teacherCaller(supabase);
 
+		mockAdminLookup(supabase);
 		signInWithPassword.mockResolvedValueOnce({
 			data: { user: null, session: null },
 			error: { message: 'Invalid login credentials' }
 		});
 
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: 'wrong' });
+		const request = createMockRequest({ password: 'wrong' });
 		const { event } = makeEvent(request, locals);
 
 		try {
@@ -220,6 +227,7 @@ describe('POST /api/admin/elevate', () => {
 		const locals = teacherCaller(supabase);
 
 		// Credentials are valid but for a teacher account.
+		mockAdminLookup(supabase);
 		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.teacher, ADMIN_EMAIL));
 		// Role confirmation via the ephemeral (candidate) client → role 'teacher'.
 		ephemeralSingle.mockResolvedValueOnce({
@@ -227,7 +235,7 @@ describe('POST /api/admin/elevate', () => {
 			error: null
 		});
 
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const request = createMockRequest({ password: ADMIN_PASSWORD });
 		const { event, cookieSet } = makeEvent(request, locals);
 
 		try {
@@ -249,13 +257,14 @@ describe('POST /api/admin/elevate', () => {
 		const supabase = createMockSupabase();
 		const locals = teacherCaller(supabase);
 
+		mockAdminLookup(supabase);
 		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.admin, ADMIN_EMAIL));
 		ephemeralSingle.mockResolvedValueOnce({
 			data: { id: TEST_IDS.admin, role: 'admin' },
 			error: null
 		});
 
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const request = createMockRequest({ password: ADMIN_PASSWORD });
 		const { event, cookieSet } = makeEvent(request, locals);
 
 		const response = await POST(event);
@@ -283,13 +292,14 @@ describe('POST /api/admin/elevate', () => {
 		const supabase = createMockSupabase();
 		const locals = teacherCaller(supabase);
 
+		mockAdminLookup(supabase);
 		signInWithPassword.mockResolvedValueOnce(signInSuccess(TEST_IDS.admin, ADMIN_EMAIL));
 		ephemeralSingle.mockResolvedValueOnce({
 			data: { id: TEST_IDS.admin, role: 'admin' },
 			error: null
 		});
 
-		const request = createMockRequest({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+		const request = createMockRequest({ password: ADMIN_PASSWORD });
 		const { event, cookieSet } = makeEvent(request, locals);
 
 		await POST(event);


### PR DESCRIPTION
## Quoi
**Phase 4** : l'UI qui rend l'élévation admin **utilisable** (suite de #29/#30).
- **`/dashboard/elevate`** : formulaire identifiants admin → `POST /api/admin/elevate` → `invalidateAll` + `goto(redirect)`. **Garde anti-open-redirect** (uniquement `/dashboard/admin`).
- **Garde de section** (`dashboard/admin/+layout.server.ts`) : prof non-élevé → redirigé vers l'écran d'élévation (en gardant la destination) ; admin/élevé passent ; élèves 403. **Allowlist** pour garder `friendships`/`users` accessibles au prof.
- **Bandeau « mode admin »** (`dashboard/admin/+layout.svelte`) : ambre, **compte à rebours mm:ss** jusqu'à expiration + « Quitter le mode admin » (revoke).
- Index `/dashboard/admin` minimal (manquait → 404).
- Entrée **« Administration »** dans la nav prof.

Seuls `{ active, expiresAt }` exposés au client — **jamais** le token/adminUserId.

## Corrigé dans le build initial (2 bugs)
1. Le garde redirigeait TOUS les profs non-élevés → cassait l'accès prof à `friendships`/`users` (régression vs #30). → allowlist.
2. La page index admin passait un `data` mal typé à `AdminDashboard` → index minimal à la place.

## Vérifs faites
`check:incremental` **0 erreur** (1704) · test `dashboard-nav` 18/18 · garde open-redirect revu (rejette absolu/`//`/hors `/dashboard/admin`) · `svelte-autofixer` passé.

## ⚠️ À TESTER MANUELLEMENT avant merge (je ne peux pas lancer l'app/DB)
1. Prof non-élevé → `/dashboard/admin/*` redirige vers l'élévation ; entrée « Administration » visible.
2. Élévation OK (creds admin) → atterrit sur la destination, bandeau ambre + mm:ss qui tourne.
3. Échecs (mauvais mdp 401 / non-admin 403 / rate-limit 429) → message FR via toaster, formulaire reste.
4. « Quitter le mode admin » → revoke → `/dashboard` ; re-visiter `/dashboard/admin` re-demande l'élévation.
5. Login **admin réel** → accès admin sans bandeau.
6. `friendships`/`users` accessibles au prof **non-élevé** (allowlist).
7. Élève → `/dashboard/admin/*` → 403.
8. Open-redirect : `?redirect=//evil.com` / `https://…` / `/dashboard/teacher` → tous repliés sur `/dashboard/admin`.

## Suite
Phase 4b : **confirmation tapée** pour actions destructives (différée). Phase 5 : revue + rejouer le test d'intégration élévation (Docker local KO ce jour).