### PR TITLE
feat(auth): typed-confirmation for destructive admin actions (Phase 4b)

### DIFF
--- a/src/lib/components/admin/TypedConfirmDialog.svelte
+++ b/src/lib/components/admin/TypedConfirmDialog.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	/**
+	 * TypedConfirmDialog — reusable destructive-action gate.
+	 *
+	 * Wraps a destructive SvelteKit form action behind a typed confirmation:
+	 * the admin must retype an exact token (e.g. the school name) before the
+	 * submit button enables. The server MUST re-enforce this (the dialog is
+	 * only the friendly front door) via `assertTypedConfirmation`.
+	 *
+	 * The form posts `confirm` (the typed value) plus any extra fields passed
+	 * through the `hiddenFields` snippet (e.g. the row id).
+	 */
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import { toaster } from '$lib/stores/toaster.svelte';
+	import type { Snippet } from 'svelte';
+
+	// ==========================================================================
+	// Props
+	// ==========================================================================
+
+	interface Props {
+		/** Exact text the user must type to enable the destructive action. */
+		expected: string;
+		/** SvelteKit form action, e.g. '?/delete'. */
+		action: string;
+		/** Dialog title. */
+		title: string;
+		/** Optional explanatory text shown above the confirmation field. */
+		description?: string;
+		/** Label of the destructive submit button. */
+		confirmLabel?: string;
+		/** Success toast message (defaults to a generic deletion message). */
+		successMessage?: string;
+		/**
+		 * The destructive button that opens the dialog. Receives the trigger
+		 * `props` (click + ARIA wiring) to spread onto the button element.
+		 */
+		trigger: Snippet<[Record<string, unknown>]>;
+		/** Extra hidden inputs to submit with the form (e.g. the id). */
+		hiddenFields?: Snippet;
+	}
+
+	let {
+		expected,
+		action,
+		title,
+		description,
+		confirmLabel = 'Supprimer définitivement',
+		successMessage = 'Suppression effectuée',
+		trigger,
+		hiddenFields
+	}: Props = $props();
+
+	// ==========================================================================
+	// State
+	// ==========================================================================
+
+	let open = $state(false);
+	let typed = $state('');
+	let submitting = $state(false);
+
+	// ==========================================================================
+	// Derived
+	// ==========================================================================
+
+	// Enable the destructive action only on an exact (trimmed) match.
+	const matches = $derived(typed.trim() === expected.trim());
+
+	// ==========================================================================
+	// Handlers
+	// ==========================================================================
+
+	function onOpenChange(next: boolean) {
+		open = next;
+		// Always reset the typed token when the dialog closes.
+		if (!next) typed = '';
+	}
+</script>
+
+<Dialog.Root bind:open {onOpenChange}>
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			{@render trigger(props)}
+		{/snippet}
+	</Dialog.Trigger>
+
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>{title}</Dialog.Title>
+			{#if description}
+				<Dialog.Description>{description}</Dialog.Description>
+			{/if}
+		</Dialog.Header>
+
+		<form
+			method="POST"
+			{action}
+			use:enhance={() => {
+				submitting = true;
+				return async ({ result, update }) => {
+					submitting = false;
+					if (result.type === 'success') {
+						open = false;
+						typed = '';
+						toaster.success(successMessage);
+						await update();
+					} else if (result.type === 'failure') {
+						// Keep the dialog open so the admin can read the error and retry.
+						const message =
+							typeof result.data?.message === 'string'
+								? result.data.message
+								: 'La suppression a échoué';
+						toaster.error(message);
+					} else {
+						// redirect / error result types: let SvelteKit handle it.
+						await update();
+					}
+					await invalidateAll();
+				};
+			}}
+		>
+			{@render hiddenFields?.()}
+			<input type="hidden" name="confirm" value={typed} />
+
+			<div class="space-y-2 py-4">
+				<label for="typed-confirm" class="block text-sm font-medium text-foreground">
+					Tapez <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs">{expected}</code> pour confirmer
+				</label>
+				<Input
+					id="typed-confirm"
+					autocomplete="off"
+					bind:value={typed}
+					placeholder={expected}
+					disabled={submitting}
+				/>
+			</div>
+
+			<Dialog.Footer>
+				<Button
+					type="button"
+					variant="outline"
+					onclick={() => onOpenChange(false)}
+					disabled={submitting}
+				>
+					Annuler
+				</Button>
+				<Button type="submit" variant="destructive" disabled={!matches || submitting}>
+					{confirmLabel}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/server/__tests__/confirmAction.test.ts
+++ b/src/lib/server/__tests__/confirmAction.test.ts
@@ -1,0 +1,46 @@
+/**
+ * assertTypedConfirmation — unit tests
+ * @module lib/server/__tests__/confirmAction
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertTypedConfirmation } from '../confirmAction';
+
+describe('assertTypedConfirmation', () => {
+	it('passes on an exact match', () => {
+		expect(() => assertTypedConfirmation('Lycée Voltaire', 'Lycée Voltaire')).not.toThrow();
+	});
+
+	it('passes when only surrounding whitespace differs (both trimmed)', () => {
+		expect(() => assertTypedConfirmation('  Lycée Voltaire  ', 'Lycée Voltaire')).not.toThrow();
+	});
+
+	it('throws 400 on a value mismatch', () => {
+		try {
+			assertTypedConfirmation('Autre école', 'Lycée Voltaire');
+			expect.fail('should have thrown');
+		} catch (err: unknown) {
+			expect((err as { status: number }).status).toBe(400);
+		}
+	});
+
+	it('is case-sensitive', () => {
+		try {
+			assertTypedConfirmation('lycée voltaire', 'Lycée Voltaire');
+			expect.fail('should have thrown');
+		} catch (err: unknown) {
+			expect((err as { status: number }).status).toBe(400);
+		}
+	});
+
+	it('throws 400 when the value is missing or not a string', () => {
+		for (const bad of [undefined, null, 42, {}, []]) {
+			try {
+				assertTypedConfirmation(bad, 'X');
+				expect.fail(`should have thrown for ${String(bad)}`);
+			} catch (err: unknown) {
+				expect((err as { status: number }).status).toBe(400);
+			}
+		}
+	});
+});

--- a/src/lib/server/confirmAction.ts
+++ b/src/lib/server/confirmAction.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed-confirmation guard for destructive admin actions
+ * ======================================================
+ *
+ * Once a teacher is elevated (or is a real admin), destructive operations don't
+ * ask for the password again — instead they require a **typed confirmation**:
+ * the client must echo back an EXACT expected token, either the resource's own
+ * name (targeted op, e.g. delete a school → type the school name) or a fixed
+ * keyword (global op, e.g. run a destructive cron → type `LANCER-CRON`).
+ *
+ * Enforced SERVER-SIDE so it can't be bypassed by calling the endpoint directly
+ * (the UI dialog is only the friendly front door). Comparison is trimmed and
+ * exact (case-sensitive) — the user is shown precisely what to type.
+ *
+ * @module lib/server/confirmAction
+ */
+
+import { error } from '@sveltejs/kit';
+
+/**
+ * Throw 400 unless `provided` exactly matches `expected` (after trimming).
+ *
+ * @param provided - the `confirm` value sent by the client (body/formData)
+ * @param expected - the exact token the user must type (resource name or keyword)
+ * @throws `400` when missing, non-string, or not an exact match
+ *
+ * @example Targeted (type the resource name)
+ * ```ts
+ * assertTypedConfirmation(formData.get('confirm'), school.name);
+ * await supabase.from('schools').delete().eq('id', school.id);
+ * ```
+ * @example Global (type a keyword)
+ * ```ts
+ * assertTypedConfirmation(body.confirm, 'LANCER-CRON');
+ * ```
+ */
+export function assertTypedConfirmation(provided: unknown, expected: string): void {
+	if (typeof provided !== 'string' || provided.trim() !== expected.trim()) {
+		throw error(400, `Confirmation requise : tapez exactement « ${expected} » pour confirmer.`);
+	}
+}

--- a/src/routes/(protected)/dashboard/admin/schools/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/schools/+page.server.ts
@@ -3,6 +3,7 @@ import type { PageServerLoad, Actions } from './$types';
 import { schoolUpsertSchema } from '$lib/server/validation/schools';
 import { uuidSchema } from '$lib/server/validation/common';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	// Admin only (real admin login OR step-up elevation)
@@ -97,6 +98,18 @@ export const actions: Actions = {
 
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
+
+		// Typed confirmation (destructive): the admin must type the exact school name.
+		// Enforced server-side — the dialog is only the friendly front door.
+		const { data: school, error: schoolError } = await supabase
+			.from('schools')
+			.select('name')
+			.eq('id', id)
+			.single();
+		if (schoolError || !school) {
+			return fail(404, { message: 'École introuvable' });
+		}
+		assertTypedConfirmation(formData.get('confirm'), school.name);
 
 		// Check if school has any profiles associated
 		const { data: profiles, error: checkError } = await supabase

--- a/src/routes/(protected)/dashboard/admin/schools/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/schools/+page.svelte
@@ -6,6 +6,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import SchoolConfigModal from '$lib/components/admin/SchoolConfigModal.svelte';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -320,22 +321,27 @@
 								<Button variant="ghost" size="sm" onclick={() => openEditModal(school)}>
 									Modifier
 								</Button>
-								<form method="POST" action="?/delete" use:enhance class="inline">
-									<input type="hidden" name="id" value={school.id} />
-									<Button
-										type="submit"
-										variant="ghost"
-										size="sm"
-										class="text-destructive hover:text-destructive"
-										onclick={(e) => {
-											if (!confirm('Êtes-vous sûr de vouloir supprimer cette école ?')) {
-												e.preventDefault();
-											}
-										}}
-									>
-										Supprimer
-									</Button>
-								</form>
+								<TypedConfirmDialog
+									expected={school.name}
+									action="?/delete"
+									title="Supprimer l'école « {school.name} »"
+									description="Cette action est irréversible. L'école et sa configuration seront supprimées."
+									successMessage="École supprimée"
+								>
+									{#snippet trigger(props)}
+										<Button
+											{...props}
+											variant="ghost"
+											size="sm"
+											class="text-destructive hover:text-destructive"
+										>
+											Supprimer
+										</Button>
+									{/snippet}
+									{#snippet hiddenFields()}
+										<input type="hidden" name="id" value={school.id} />
+									{/snippet}
+								</TypedConfirmDialog>
 							</td>
 						</tr>
 					{:else}


### PR DESCRIPTION
## Quoi
**Phase 4b** : confirmation **tapée** pour les actions admin destructives. Une fois élevé, pas de re-mot-de-passe — il faut **taper un token exact**, vérifié **côté serveur** (non contournable par appel direct).

- `assertTypedConfirmation(provided, expected)` (`src/lib/server/confirmAction.ts`) + 5 tests unitaires.
- **`<TypedConfirmDialog>`** réutilisable (`src/lib/components/admin/`) : dialog shadcn dont le bouton destructif reste **désactivé tant que le texte tapé ≠ token exact** ; soumet l'action avec un champ `confirm`.
- **Exemplar câblé** : supprimer une école → il faut taper le **nom exact de l'école** (remplace le `window.confirm` natif).

`check:incremental` 0 erreur · 5/5 tests guard.

## ⚠️ Volontairement UN seul exemplar
Je livre **delete-école** d'abord pour que tu **valides l'UX du dialog** avant que je réplique le pattern (composant réutilisable) sur les autres ops.

## ⚠️ À tester manuellement (je ne peux pas lancer l'app)
1. « Supprimer » ouvre le dialog ; bouton désactivé jusqu'à taper le nom exact (espaces de bord ignorés).
2. École **avec des utilisateurs** → message d'erreur serveur en toast, dialog reste ouvert.
3. Suppression OK → dialog se ferme, toast succès, ligne disparaît.
4. Fermer le dialog (Annuler/Échap/overlay) réinitialise le champ.

## Reste à câbler (même composant, après validation UX)
vip `configs/[id]` + `templates/[id]` delete · `classes` delete · `schools/[schoolId]/organisation` deletes · `cron/trigger` (mot-clé) · `anti-fraud/run` (mot-clé) · `exercises/backup` restore (mot-clé).