### PR TITLE
ci: run quality CI on all PRs (required-checks compatibility)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,10 +9,9 @@ on:
       - '.github/dependabot.yml'
   pull_request:
     branches: [main, dev]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.github/dependabot.yml'
+    # No paths-ignore here: with required status checks on `main`, EVERY PR must
+    # run CI so those checks always report. Otherwise a doc-only PR would have
+    # "expected" required checks that never run → it could never be merged.
   workflow_dispatch: # Allow manual trigger
 
 # Cancel an in-progress run when a newer commit is pushed to the same ref —


### PR DESCRIPTION
Removes the `pull_request` `paths-ignore` so every PR runs CI. Required for the new branch protection on `main` (required status checks) — otherwise a doc-only PR would have "expected" checks that never run and could never merge. Push trigger keeps its paths-ignore (saves CI minutes on intermediate branch pushes). Workflow-only change.