### PR TITLE
feat(auth): typed-confirmation for remaining destructive admin ops (Phase 4b)

### DIFF
--- a/src/lib/components/admin/TypedConfirmDialog.svelte
+++ b/src/lib/components/admin/TypedConfirmDialog.svelte
@@ -2,13 +2,19 @@
 	/**
 	 * TypedConfirmDialog — reusable destructive-action gate.
 	 *
-	 * Wraps a destructive SvelteKit form action behind a typed confirmation:
-	 * the admin must retype an exact token (e.g. the school name) before the
-	 * submit button enables. The server MUST re-enforce this (the dialog is
-	 * only the friendly front door) via `assertTypedConfirmation`.
+	 * Wraps a destructive operation behind a typed confirmation: the admin must
+	 * retype an exact token (e.g. the school name) before the submit button
+	 * enables. The server MUST re-enforce this (the dialog is only the friendly
+	 * front door) via `assertTypedConfirmation`.
 	 *
-	 * The form posts `confirm` (the typed value) plus any extra fields passed
-	 * through the `hiddenFields` snippet (e.g. the row id).
+	 * Two mutually-exclusive modes:
+	 * - **Form-action mode** (`action` prop): posts `confirm` (the typed value)
+	 *   plus any extra fields from the `hiddenFields` snippet (e.g. the row id)
+	 *   to a SvelteKit form action via `use:enhance`.
+	 * - **Callback mode** (`onConfirm` prop): calls `onConfirm()` instead of
+	 *   submitting a form. The consumer is responsible for the fetch (and for
+	 *   sending the `confirm` token in the request body). On resolve → close +
+	 *   reset + success toast; on throw → keep open + error toast.
 	 */
 
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -26,8 +32,19 @@
 	interface Props {
 		/** Exact text the user must type to enable the destructive action. */
 		expected: string;
-		/** SvelteKit form action, e.g. '?/delete'. */
-		action: string;
+		/**
+		 * SvelteKit form action, e.g. '?/delete'. Mutually exclusive with
+		 * `onConfirm` — provide exactly one.
+		 */
+		action?: string;
+		/**
+		 * Callback-mode handler: invoked when the admin confirms. The consumer
+		 * owns the request (and must include the `confirm` token in its body).
+		 * Mutually exclusive with `action` — provide exactly one. On resolve the
+		 * dialog closes + resets + shows the success toast; on throw it stays
+		 * open + shows the error toast.
+		 */
+		onConfirm?: () => Promise<void> | void;
 		/** Dialog title. */
 		title: string;
 		/** Optional explanatory text shown above the confirmation field. */
@@ -48,6 +65,7 @@
 	let {
 		expected,
 		action,
+		onConfirm,
 		title,
 		description,
 		confirmLabel = 'Supprimer définitivement',
@@ -55,6 +73,9 @@
 		trigger,
 		hiddenFields
 	}: Props = $props();
+
+	// Callback mode is selected when `onConfirm` is provided and no `action`.
+	const callbackMode = $derived(onConfirm !== undefined && action === undefined);
 
 	// ==========================================================================
 	// State
@@ -80,6 +101,26 @@
 		// Always reset the typed token when the dialog closes.
 		if (!next) typed = '';
 	}
+
+	// Callback-mode submit: run the consumer's handler, then mirror the
+	// form-action mode's outcomes (close + reset + success toast on resolve,
+	// keep open + error toast on throw).
+	async function handleCallbackConfirm() {
+		if (!onConfirm || !matches || submitting) return;
+		submitting = true;
+		try {
+			await onConfirm();
+			open = false;
+			typed = '';
+			toaster.success(successMessage);
+		} catch (err) {
+			// Keep the dialog open so the admin can read the error and retry.
+			const message = err instanceof Error ? err.message : 'La suppression a échoué';
+			toaster.error(message);
+		} finally {
+			submitting = false;
+		}
+	}
 </script>
 
 <Dialog.Root bind:open {onOpenChange}>
@@ -97,62 +138,103 @@
 			{/if}
 		</Dialog.Header>
 
-		<form
-			method="POST"
-			{action}
-			use:enhance={() => {
-				submitting = true;
-				return async ({ result, update }) => {
-					submitting = false;
-					if (result.type === 'success') {
-						open = false;
-						typed = '';
-						toaster.success(successMessage);
-						await update();
-					} else if (result.type === 'failure') {
-						// Keep the dialog open so the admin can read the error and retry.
-						const message =
-							typeof result.data?.message === 'string'
-								? result.data.message
-								: 'La suppression a échoué';
-						toaster.error(message);
-					} else {
-						// redirect / error result types: let SvelteKit handle it.
-						await update();
-					}
-					await invalidateAll();
-				};
-			}}
-		>
-			{@render hiddenFields?.()}
-			<input type="hidden" name="confirm" value={typed} />
+		{#if callbackMode}
+			<div>
+				<div class="space-y-2 py-4">
+					<label for="typed-confirm" class="block text-sm font-medium text-foreground">
+						Tapez <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs">{expected}</code> pour
+						confirmer
+					</label>
+					<Input
+						id="typed-confirm"
+						autocomplete="off"
+						bind:value={typed}
+						placeholder={expected}
+						disabled={submitting}
+					/>
+				</div>
 
-			<div class="space-y-2 py-4">
-				<label for="typed-confirm" class="block text-sm font-medium text-foreground">
-					Tapez <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs">{expected}</code> pour confirmer
-				</label>
-				<Input
-					id="typed-confirm"
-					autocomplete="off"
-					bind:value={typed}
-					placeholder={expected}
-					disabled={submitting}
-				/>
+				<Dialog.Footer>
+					<Button
+						type="button"
+						variant="outline"
+						onclick={() => onOpenChange(false)}
+						disabled={submitting}
+					>
+						Annuler
+					</Button>
+					<Button
+						type="button"
+						variant="destructive"
+						onclick={handleCallbackConfirm}
+						disabled={!matches || submitting}
+					>
+						{confirmLabel}
+					</Button>
+				</Dialog.Footer>
 			</div>
+		{:else}
+			<form
+				method="POST"
+				{action}
+				use:enhance={() => {
+					submitting = true;
+					return async ({ result, update }) => {
+						submitting = false;
+						if (result.type === 'success') {
+							open = false;
+							typed = '';
+							toaster.success(successMessage);
+							await update();
+						} else if (result.type === 'failure') {
+							// Keep the dialog open so the admin can read the error and retry.
+							// Accept either fail() convention: { message } or { error }.
+							const failMessage =
+								typeof result.data?.message === 'string'
+									? result.data.message
+									: typeof result.data?.error === 'string'
+										? result.data.error
+										: 'La suppression a échoué';
+							toaster.error(failMessage);
+						} else {
+							// redirect / error result types: let SvelteKit handle it.
+							await update();
+						}
+						await invalidateAll();
+					};
+				}}
+			>
+				{@render hiddenFields?.()}
+				<input type="hidden" name="confirm" value={typed} />
 
-			<Dialog.Footer>
-				<Button
-					type="button"
-					variant="outline"
-					onclick={() => onOpenChange(false)}
-					disabled={submitting}
-				>
-					Annuler
-				</Button>
-				<Button type="submit" variant="destructive" disabled={!matches || submitting}>
-					{confirmLabel}
-				</Button>
-			</Dialog.Footer>
-		</form>
+				<div class="space-y-2 py-4">
+					<label for="typed-confirm" class="block text-sm font-medium text-foreground">
+						Tapez <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs">{expected}</code> pour
+						confirmer
+					</label>
+					<Input
+						id="typed-confirm"
+						autocomplete="off"
+						bind:value={typed}
+						placeholder={expected}
+						disabled={submitting}
+					/>
+				</div>
+
+				<Dialog.Footer>
+					<Button
+						type="button"
+						variant="outline"
+						onclick={() => onOpenChange(false)}
+						disabled={submitting}
+					>
+						Annuler
+					</Button>
+					<Button type="submit" variant="destructive" disabled={!matches || submitting}>
+						{confirmLabel}
+					</Button>
+				</Dialog.Footer>
+			</form>
+		{/if}
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/vip-cards/VipCardConfigList.svelte
+++ b/src/lib/components/vip-cards/VipCardConfigList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
 	import type { Database } from '$lib/types/database';
 
 	type VipCardConfig = Database['public']['Tables']['vip_card_config']['Row'];
@@ -7,15 +8,16 @@
 	interface Props {
 		configs: VipCardConfig[];
 		onActivate: (configId: string) => Promise<void>;
+		// Receives the config name so the caller can echo it as the typed-
+		// confirmation token. Throws on failure (the dialog reacts to it).
+		onDelete: (configId: string, configName: string) => Promise<void>;
 		onEdit: (config: VipCardConfig) => void;
-		onDelete: (configId: string) => Promise<void>;
 		onCreate: () => void;
 	}
 
 	let { configs, onActivate, onEdit, onDelete, onCreate }: Props = $props();
 
 	let activating = $state<string | null>(null);
-	let deleting = $state<string | null>(null);
 
 	async function handleActivate(configId: string) {
 		activating = configId;
@@ -23,17 +25,6 @@
 			await onActivate(configId);
 		} finally {
 			activating = null;
-		}
-	}
-
-	async function handleDelete(configId: string, configName: string) {
-		if (!confirm(`Supprimer la configuration "${configName}" ?`)) return;
-
-		deleting = configId;
-		try {
-			await onDelete(configId);
-		} finally {
-			deleting = null;
 		}
 	}
 
@@ -141,14 +132,19 @@
 
 							<Button size="sm" variant="outline" onclick={() => onEdit(config)}>Modifier</Button>
 
-							<Button
-								size="sm"
-								variant="destructive"
-								onclick={() => handleDelete(config.id, config.config_name)}
-								disabled={config.is_active || deleting === config.id}
+							<TypedConfirmDialog
+								expected={config.config_name}
+								onConfirm={() => onDelete(config.id, config.config_name)}
+								title="Supprimer la configuration « {config.config_name} »"
+								description="Cette action est irréversible. La configuration de probabilités sera définitivement supprimée."
+								successMessage="Configuration supprimée"
 							>
-								{deleting === config.id ? 'Suppression...' : 'Supprimer'}
-							</Button>
+								{#snippet trigger(props)}
+									<Button {...props} size="sm" variant="destructive" disabled={config.is_active}>
+										Supprimer
+									</Button>
+								{/snippet}
+							</TypedConfirmDialog>
 						</div>
 					</div>
 

--- a/src/lib/components/vip-cards/VipCardPreview.svelte
+++ b/src/lib/components/vip-cards/VipCardPreview.svelte
@@ -5,6 +5,7 @@
 	import type { VipCardAction } from '$lib/types/vip-card';
 	import { categoryIcon } from './utils';
 	import MySelect from '$lib/components/MySelect.svelte';
+	import type { Snippet } from 'svelte';
 	type ActionType = VipCardAction['type'];
 
 	// Typed action interface (Database stores as Json, but we know the structure)
@@ -40,6 +41,12 @@
 		onEdit?: () => void;
 		onDelete?: () => void;
 		onUploadImage?: () => void;
+		/**
+		 * Optional override for the delete affordance. When provided it replaces
+		 * the built-in delete button (e.g. to host a TypedConfirmDialog trigger).
+		 * Takes precedence over `onDelete`.
+		 */
+		deleteTrigger?: Snippet;
 	}
 
 	// Action display utilities
@@ -90,7 +97,8 @@
 		onInlineEdit,
 		onEdit,
 		onDelete,
-		onUploadImage
+		onUploadImage,
+		deleteTrigger
 	}: Props = $props();
 
 	const currentEnabled = $derived(isEnabled ?? card.is_enabled);
@@ -359,7 +367,11 @@
 			{/if}
 
 			<!-- Delete Button (Bottom Right) -->
-			{#if onDelete}
+			{#if deleteTrigger}
+				<div class="absolute right-2 bottom-2 z-10">
+					{@render deleteTrigger()}
+				</div>
+			{:else if onDelete}
 				<button
 					type="button"
 					class="absolute right-2 bottom-2 z-10 rounded-full bg-destructive p-2 text-destructive-foreground shadow-lg transition-all hover:scale-110 hover:bg-destructive/90 active:scale-95"

--- a/src/lib/server/validation/__tests__/cron.test.ts
+++ b/src/lib/server/validation/__tests__/cron.test.ts
@@ -88,11 +88,16 @@ describe('cronJobsQuerySchema', () => {
 });
 
 describe('cronTriggerBodySchema', () => {
-	it('should accept allowed job paths', () => {
+	it('should accept allowed job paths (with the confirm token)', () => {
 		for (const path of ALLOWED_JOB_PATHS) {
-			const result = cronTriggerBodySchema.parse({ job_path: path });
+			const result = cronTriggerBodySchema.parse({ job_path: path, confirm: 'LANCER' });
 			expect(result.job_path).toBe(path);
 		}
+	});
+
+	it('should require the confirm field (typed confirmation)', () => {
+		const result = cronTriggerBodySchema.safeParse({ job_path: ALLOWED_JOB_PATHS[0] });
+		expect(result.success).toBe(false);
 	});
 
 	it('should reject empty job_path', () => {

--- a/src/lib/server/validation/cron.ts
+++ b/src/lib/server/validation/cron.ts
@@ -67,6 +67,12 @@ const ALLOWED_JOB_PATHS = [
 ] as const;
 
 /**
+ * Typed-confirmation keyword the admin must echo to trigger a CRON job.
+ * Global destructive op → fixed keyword (not a resource name).
+ */
+export const CRON_TRIGGER_CONFIRM_KEYWORD = 'LANCER';
+
+/**
  * Request body for triggering a CRON job manually
  */
 export const cronTriggerBodySchema = z.object({
@@ -76,7 +82,9 @@ export const cronTriggerBodySchema = z.object({
 		.refine(
 			(path) => ALLOWED_JOB_PATHS.includes(path as (typeof ALLOWED_JOB_PATHS)[number]),
 			`Job path must be one of: ${ALLOWED_JOB_PATHS.join(', ')}`
-		)
+		),
+	// Typed-confirmation token; re-enforced server-side via assertTypedConfirmation.
+	confirm: z.string()
 });
 
 export type CronTriggerBody = z.infer<typeof cronTriggerBodySchema>;

--- a/src/routes/(protected)/dashboard/admin/backup/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/backup/+page.svelte
@@ -8,6 +8,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import * as Alert from '$lib/components/ui/alert';
 	import { toaster } from '$lib/stores/toaster.svelte';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
 	import {
 		Download,
 		Upload,
@@ -24,6 +25,10 @@
 	let { data } = $props();
 	// svelte-ignore state_referenced_locally
 	const initialData = data;
+
+	// Typed-confirmation keyword for the (destructive) restore; re-enforced
+	// server-side via assertTypedConfirmation.
+	const RESTORE_CONFIRM_KEYWORD = 'RESTAURER';
 
 	// Export state
 	let exportingJson = $state(false);
@@ -154,7 +159,11 @@
 		}
 	}
 
-	// Restore from backup
+	// Restore from backup. Invoked by the TypedConfirmDialog (callback mode);
+	// it echoes the 'RESTAURER' keyword in the body (re-enforced server-side).
+	// Throws on hard failure so the dialog stays open + toasts; resolves on a
+	// completed restore (the dialog closes + shows the success toast). Partial
+	// success (errors per record) still resolves and is surfaced via restoreResult.
 	async function restore() {
 		if (!importFile) return;
 
@@ -171,6 +180,7 @@
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
+					confirm: RESTORE_CONFIRM_KEYWORD,
 					backup,
 					options: {
 						conflict_strategy: conflictStrategy,
@@ -179,18 +189,23 @@
 				})
 			});
 
+			// Hard failure (e.g. 400 missing/invalid confirm, 413 too large, 500).
+			if (!response.ok && response.status !== 207) {
+				const errBody = await response.json().catch(() => ({}));
+				throw new Error(errBody.message || 'Erreur lors de la restauration');
+			}
+
 			const result: RestoreResult = await response.json();
 			restoreResult = result;
 
 			if (result.success) {
-				toaster.success('Restauration terminee avec succes');
 				await refreshStats();
 			} else {
+				// Completed with per-record errors: surface them, don't treat as a
+				// hard failure (the dialog still resolves/closes).
 				toaster.warning('Restauration terminee avec des erreurs');
+				await refreshStats();
 			}
-		} catch (err) {
-			console.error('Restore error:', err);
-			toaster.error('Erreur lors de la restauration');
 		} finally {
 			importing = false;
 		}
@@ -402,15 +417,26 @@
 					</p>
 				</div>
 
-				<Button onclick={restore} disabled={importing} class="w-full">
-					{#if importing}
-						<Loader2 class="mr-2 h-4 w-4 animate-spin" />
-						Restauration en cours...
-					{:else}
-						<Upload class="mr-2 h-4 w-4" />
-						Restaurer
-					{/if}
-				</Button>
+				<TypedConfirmDialog
+					expected={RESTORE_CONFIRM_KEYWORD}
+					onConfirm={restore}
+					title="Restaurer depuis le backup"
+					description="Cette operation va importer les exercices du fichier selon la strategie de conflit choisie. Selon la strategie « Remplacer », des donnees existantes peuvent etre ecrasees."
+					confirmLabel="Restaurer"
+					successMessage="Restauration terminee avec succes"
+				>
+					{#snippet trigger(props)}
+						<Button {...props} disabled={importing} class="w-full">
+							{#if importing}
+								<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+								Restauration en cours...
+							{:else}
+								<Upload class="mr-2 h-4 w-4" />
+								Restaurer
+							{/if}
+						</Button>
+					{/snippet}
+				</TypedConfirmDialog>
 			{/if}
 		</Card.Content>
 	</Card.Root>

--- a/src/routes/(protected)/dashboard/admin/cron/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/cron/+page.svelte
@@ -9,6 +9,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Switch from '$lib/components/ui/switch';
 	import { toaster } from '$lib/stores/toaster.svelte';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
 	import { MetricCard } from '$lib/components/admin/widgets';
 	import { cn } from '$lib/utils';
 	import {
@@ -43,10 +44,9 @@
 	let detailsModalOpen = $state(false);
 	let selectedJob = $state<CronJobRun | null>(null);
 
-	// Trigger confirmation state
-	let triggerDialogOpen = $state(false);
-	let jobToTrigger = $state<string | null>(null);
-	let triggering = $state(false);
+	// Typed-confirmation keyword for the (global, destructive) manual trigger.
+	// Re-enforced server-side via assertTypedConfirmation.
+	const TRIGGER_CONFIRM_KEYWORD = 'LANCER';
 
 	// Filter items
 	const jobNameItems = $derived([
@@ -203,45 +203,28 @@
 		detailsModalOpen = true;
 	}
 
-	function openTriggerDialog(jobName: string) {
-		const path = getJobPath(jobName);
-		if (!path) {
-			toaster.error('Ce job ne peut pas etre declenche manuellement');
+	// Triggers a job by path; sends the typed-confirmation keyword in the body.
+	// Throws on failure so the TypedConfirmDialog keeps itself open + toasts.
+	// On success it schedules a refresh and resolves (the dialog closes + toasts).
+	async function triggerJob(jobPath: string) {
+		const response = await fetch('/api/admin/cron/trigger', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ job_path: jobPath, confirm: TRIGGER_CONFIRM_KEYWORD })
+		});
+
+		const result = await response.json().catch(() => ({}));
+
+		if (response.ok && result.success) {
+			// Refresh after a short delay to see the new job run.
+			setTimeout(() => refresh(), 2000);
 			return;
 		}
-		jobToTrigger = path;
-		triggerDialogOpen = true;
-	}
 
-	async function confirmTrigger() {
-		if (!jobToTrigger) return;
-
-		triggering = true;
-		try {
-			const response = await fetch('/api/admin/cron/trigger', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ job_path: jobToTrigger })
-			});
-
-			const result = await response.json();
-
-			if (response.ok && result.success) {
-				toaster.success('Job declenche avec succes');
-				triggerDialogOpen = false;
-				// Refresh after a short delay to see the new job run
-				setTimeout(() => refresh(), 2000);
-			} else if (response.status === 429) {
-				toaster.warning(result.message || 'Rate limit atteint. Attendez avant de reessayer.');
-			} else {
-				toaster.error(result.message || 'Echec du declenchement du job');
-			}
-		} catch (err) {
-			toaster.error('Erreur lors du declenchement du job');
-			console.error('[CRON Trigger]', err);
-		} finally {
-			triggering = false;
+		if (response.status === 429) {
+			throw new Error(result.message || 'Rate limit atteint. Attendez avant de reessayer.');
 		}
+		throw new Error(result.message || 'Echec du declenchement du job');
 	}
 
 	// Auto-refresh effect
@@ -381,6 +364,7 @@
 				<div class="space-y-3">
 					{#each filteredJobs as job (job.id)}
 						{@const statusInfo = getStatusBadge(job.status)}
+						{@const jobPath = getJobPath(job.job_name)}
 						<div
 							class="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-accent/50"
 						>
@@ -415,14 +399,31 @@
 								<Button variant="outline" size="sm" onclick={() => openDetails(job)}>
 									Details
 								</Button>
-								<Button
-									variant="ghost"
-									size="sm"
-									onclick={() => openTriggerDialog(job.job_name)}
-									title="Relancer ce job"
-								>
-									<Play class="h-4 w-4" />
-								</Button>
+								{#if jobPath}
+									<TypedConfirmDialog
+										expected={TRIGGER_CONFIRM_KEYWORD}
+										onConfirm={() => triggerJob(jobPath)}
+										title="Declencher le job « {formatJobName(job.job_name)} »"
+										description="Le job sera execute immediatement. Vous ne pouvez declencher le meme job qu'une fois par minute."
+										confirmLabel="Declencher"
+										successMessage="Job declenche avec succes"
+									>
+										{#snippet trigger(props)}
+											<Button {...props} variant="ghost" size="sm" title="Relancer ce job">
+												<Play class="h-4 w-4" />
+											</Button>
+										{/snippet}
+									</TypedConfirmDialog>
+								{:else}
+									<Button
+										variant="ghost"
+										size="sm"
+										onclick={() => toaster.error('Ce job ne peut pas etre declenche manuellement')}
+										title="Relancer ce job"
+									>
+										<Play class="h-4 w-4" />
+									</Button>
+								{/if}
 							</div>
 						</div>
 					{/each}
@@ -507,53 +508,30 @@
 		<Dialog.Footer>
 			<Button variant="outline" onclick={() => (detailsModalOpen = false)}>Fermer</Button>
 			{#if selectedJob}
-				<Button
-					onclick={() => {
-						detailsModalOpen = false;
-						openTriggerDialog(selectedJob!.job_name);
-					}}
-				>
-					<Play class="mr-2 h-4 w-4" />
-					Relancer
-				</Button>
-			{/if}
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
-
-<!-- Trigger Confirmation Dialog -->
-<Dialog.Root bind:open={triggerDialogOpen}>
-	<Dialog.Content class="sm:max-w-[425px]">
-		<Dialog.Header>
-			<Dialog.Title>Confirmer le declenchement</Dialog.Title>
-			<Dialog.Description>
-				Voulez-vous vraiment declencher manuellement ce job CRON ?
-			</Dialog.Description>
-		</Dialog.Header>
-
-		<div class="py-4">
-			<div class="rounded-md bg-muted p-3">
-				<p class="font-mono text-sm">{jobToTrigger}</p>
-			</div>
-			<p class="mt-2 text-sm text-muted-foreground">
-				Le job sera execute immediatement. Vous ne pouvez declencher le meme job qu'une fois par
-				minute.
-			</p>
-		</div>
-
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (triggerDialogOpen = false)} disabled={triggering}>
-				Annuler
-			</Button>
-			<Button onclick={confirmTrigger} disabled={triggering}>
-				{#if triggering}
-					<RefreshCw class="mr-2 h-4 w-4 animate-spin" />
-					Execution...
+				{@const selectedJobPath = getJobPath(selectedJob.job_name)}
+				{#if selectedJobPath}
+					<TypedConfirmDialog
+						expected={TRIGGER_CONFIRM_KEYWORD}
+						onConfirm={() => triggerJob(selectedJobPath)}
+						title="Declencher le job « {formatJobName(selectedJob.job_name)} »"
+						description="Le job sera execute immediatement. Vous ne pouvez declencher le meme job qu'une fois par minute."
+						confirmLabel="Declencher"
+						successMessage="Job declenche avec succes"
+					>
+						{#snippet trigger(props)}
+							<Button {...props}>
+								<Play class="mr-2 h-4 w-4" />
+								Relancer
+							</Button>
+						{/snippet}
+					</TypedConfirmDialog>
 				{:else}
-					<Play class="mr-2 h-4 w-4" />
-					Declencher
+					<Button onclick={() => toaster.error('Ce job ne peut pas etre declenche manuellement')}>
+						<Play class="mr-2 h-4 w-4" />
+						Relancer
+					</Button>
 				{/if}
-			</Button>
+			{/if}
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.server.ts
@@ -3,6 +3,7 @@ import type { PageServerLoad, Actions } from './$types';
 import { validateTimetable, type SchoolTimetable } from '$lib/utils/timetable';
 import { validateUuidParam } from '$lib/server/validation/params';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 import {
 	createSchoolYearSchema,
 	updateSchoolYearSchema,
@@ -185,6 +186,18 @@ export const actions: Actions = {
 			return fail(400, { error: 'ID invalide' });
 		}
 
+		// Typed confirmation (destructive): fetch the year name so the admin must type it.
+		// Enforced server-side — the dialog is only the friendly front door.
+		const { data: year, error: yearError } = await supabase
+			.from('school_years')
+			.select('name')
+			.eq('id', validation.data.id)
+			.single();
+		if (yearError || !year) {
+			return fail(404, { error: 'Année scolaire introuvable' });
+		}
+		assertTypedConfirmation(formData.get('confirm'), year.name);
+
 		const { error: dbError } = await supabase
 			.from('school_years')
 			.delete()
@@ -340,6 +353,18 @@ export const actions: Actions = {
 			return fail(400, { error: 'ID invalide' });
 		}
 
+		// Typed confirmation (destructive): fetch the period name so the admin must type it.
+		// Enforced server-side — the dialog is only the friendly front door.
+		const { data: period, error: periodError } = await supabase
+			.from('academic_periods')
+			.select('name')
+			.eq('id', validation.data.id)
+			.single();
+		if (periodError || !period) {
+			return fail(404, { error: 'Période académique introuvable' });
+		}
+		assertTypedConfirmation(formData.get('confirm'), period.name);
+
 		const { error: dbError } = await supabase
 			.from('academic_periods')
 			.delete()
@@ -443,6 +468,18 @@ export const actions: Actions = {
 		if (!validation.success) {
 			return fail(400, { error: 'ID invalide' });
 		}
+
+		// Typed confirmation (destructive): fetch the holiday name so the admin must type it.
+		// Enforced server-side — the dialog is only the friendly front door.
+		const { data: holiday, error: holidayError } = await supabase
+			.from('school_holidays')
+			.select('name')
+			.eq('id', validation.data.id)
+			.single();
+		if (holidayError || !holiday) {
+			return fail(404, { error: 'Vacances scolaires introuvables' });
+		}
+		assertTypedConfirmation(formData.get('confirm'), holiday.name);
 
 		const { error: dbError } = await supabase
 			.from('school_holidays')

--- a/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/schools/[schoolId]/organisation/+page.svelte
@@ -26,6 +26,7 @@
 	} from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import MySelect from '$lib/components/MySelect.svelte';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
 
 	// Types for the new academic tables
 	type SchoolYear = {
@@ -106,7 +107,6 @@
 	let periodDialog: HTMLDialogElement;
 	let holidayDialog: HTMLDialogElement;
 	let duplicateDialog: HTMLDialogElement;
-	let deleteYearDialog: HTMLDialogElement;
 
 	// ========================================
 	// Derived State
@@ -299,16 +299,6 @@
 		yearDialog?.close();
 	}
 
-	function openDeleteYearDialog(year: SchoolYear) {
-		editingYear = year;
-		deleteYearDialog?.showModal();
-	}
-
-	function closeDeleteYearDialog() {
-		editingYear = null;
-		deleteYearDialog?.close();
-	}
-
 	function openDuplicateDialog() {
 		if (!data.activeYear) {
 			toaster.warning('Aucune année active à dupliquer');
@@ -393,7 +383,6 @@
 			closePeriodDialog();
 			closeHolidayDialog();
 			closeDuplicateDialog();
-			closeDeleteYearDialog();
 			invalidateAll().then(() => {});
 		} else if (form?.error) {
 			toaster.error(form.error);
@@ -631,6 +620,27 @@
 								<Copy class="h-4 w-4" />
 								Dupliquer
 							</Button>
+							<TypedConfirmDialog
+								expected={selectedYear.name}
+								action="?/deleteYear"
+								title="Supprimer l'année « {selectedYear.name} »"
+								description="Cette action est irréversible. L'année scolaire ainsi que toutes ses périodes et vacances seront définitivement supprimées."
+								successMessage="Année scolaire supprimée"
+							>
+								{#snippet trigger(props)}
+									<Button
+										{...props}
+										variant="outline"
+										class="gap-2 text-destructive hover:text-destructive"
+									>
+										<Trash2 class="h-4 w-4" />
+										Supprimer
+									</Button>
+								{/snippet}
+								{#snippet hiddenFields()}
+									<input type="hidden" name="id" value={selectedYear.id} />
+								{/snippet}
+							</TypedConfirmDialog>
 						{/if}
 					</div>
 				</div>
@@ -713,27 +723,27 @@
 												<Button variant="ghost" size="sm" onclick={() => openPeriodDialog(period)}>
 													<Pencil class="h-4 w-4" />
 												</Button>
-												<form
-													method="POST"
+												<TypedConfirmDialog
+													expected={period.name}
 													action="?/deletePeriod"
-													use:enhance
-													class="inline-block"
+													title="Supprimer la période « {period.name} »"
+													description="Cette action est irréversible. La période sera définitivement supprimée."
+													successMessage="Période supprimée"
 												>
-													<input type="hidden" name="id" value={period.id} />
-													<Button
-														type="submit"
-														variant="ghost"
-														size="sm"
-														class="text-destructive hover:text-destructive"
-														onclick={(e) => {
-															if (!confirm('Êtes-vous sûr de vouloir supprimer cette période ?')) {
-																e.preventDefault();
-															}
-														}}
-													>
-														<Trash2 class="h-4 w-4" />
-													</Button>
-												</form>
+													{#snippet trigger(props)}
+														<Button
+															{...props}
+															variant="ghost"
+															size="sm"
+															class="text-destructive hover:text-destructive"
+														>
+															<Trash2 class="h-4 w-4" />
+														</Button>
+													{/snippet}
+													{#snippet hiddenFields()}
+														<input type="hidden" name="id" value={period.id} />
+													{/snippet}
+												</TypedConfirmDialog>
 											</td>
 										</tr>
 									{/each}
@@ -809,27 +819,27 @@
 												>
 													<Pencil class="h-4 w-4" />
 												</Button>
-												<form
-													method="POST"
+												<TypedConfirmDialog
+													expected={holiday.name}
 													action="?/deleteHoliday"
-													use:enhance
-													class="inline-block"
+													title="Supprimer les vacances « {holiday.name} »"
+													description="Cette action est irréversible. Les vacances seront définitivement supprimées."
+													successMessage="Vacances supprimées"
 												>
-													<input type="hidden" name="id" value={holiday.id} />
-													<Button
-														type="submit"
-														variant="ghost"
-														size="sm"
-														class="text-destructive hover:text-destructive"
-														onclick={(e) => {
-															if (!confirm('Êtes-vous sûr de vouloir supprimer ces vacances ?')) {
-																e.preventDefault();
-															}
-														}}
-													>
-														<Trash2 class="h-4 w-4" />
-													</Button>
-												</form>
+													{#snippet trigger(props)}
+														<Button
+															{...props}
+															variant="ghost"
+															size="sm"
+															class="text-destructive hover:text-destructive"
+														>
+															<Trash2 class="h-4 w-4" />
+														</Button>
+													{/snippet}
+													{#snippet hiddenFields()}
+														<input type="hidden" name="id" value={holiday.id} />
+													{/snippet}
+												</TypedConfirmDialog>
 											</td>
 										</tr>
 									{/each}
@@ -1093,63 +1103,11 @@
 				</div>
 			</div>
 
-			<div class="mt-6 flex items-center justify-between">
-				{#if editingYear}
-					<Button
-						type="button"
-						variant="destructive"
-						onclick={() => {
-							if (editingYear) {
-								closeYearDialog();
-								openDeleteYearDialog(editingYear);
-							}
-						}}
-						class="gap-2"
-					>
-						<Trash2 class="h-4 w-4" />
-						Supprimer
-					</Button>
-				{:else}
-					<div></div>
-				{/if}
-
+			<div class="mt-6 flex items-center justify-end">
 				<div class="flex gap-2">
 					<Button type="button" variant="outline" onclick={closeYearDialog}>Annuler</Button>
 					<Button type="submit">Enregistrer</Button>
 				</div>
-			</div>
-		</form>
-	</div>
-</dialog>
-
-<!-- ========================================
-     Delete Year Confirmation Dialog
-     ======================================== -->
-<dialog
-	bind:this={deleteYearDialog}
-	class="rounded-lg border border-border bg-card p-0 shadow-xl backdrop:bg-black/50"
->
-	<div class="w-full max-w-md min-w-[400px]">
-		<div class="border-b border-border px-6 pt-6 pb-4">
-			<h2 class="text-lg font-semibold text-foreground">Confirmer la suppression</h2>
-		</div>
-
-		<div class="px-6 py-4">
-			<p class="text-sm text-muted-foreground">
-				Êtes-vous sûr de vouloir supprimer l'année scolaire <strong class="text-foreground"
-					>{editingYear?.name}</strong
-				> ? Cette action supprimera également toutes les périodes et vacances associées.
-			</p>
-		</div>
-
-		<form method="POST" action="?/deleteYear" use:enhance class="border-t border-border px-6 py-4">
-			{#if editingYear}
-				<input type="hidden" name="id" value={editingYear.id} />
-			{/if}
-
-			<div class="flex justify-end gap-2">
-				<Button type="button" variant="outline" onclick={closeDeleteYearDialog}>Annuler</Button>
-				<Button type="submit" variant="destructive">Supprimer</Button>
 			</div>
 		</form>
 	</div>
@@ -1281,44 +1239,7 @@
 					</div>
 				</div>
 
-				<div class="mt-6 flex items-center justify-between">
-					{#if editingAcademicPeriod}
-						<Button
-							type="button"
-							variant="destructive"
-							class="gap-2"
-							onclick={async () => {
-								if (!confirm('Êtes-vous sûr de vouloir supprimer cette période ?')) {
-									return;
-								}
-								const formData = new FormData();
-								formData.append('id', editingAcademicPeriod?.id ?? '');
-								try {
-									const response = await fetch('?/deletePeriod', {
-										method: 'POST',
-										body: formData,
-										headers: { 'x-sveltekit-action': 'true' }
-									});
-									if (response.ok) {
-										await invalidateAll();
-										toaster.success('Période supprimée');
-										closePeriodDialog();
-									} else {
-										toaster.error('Erreur lors de la suppression');
-									}
-								} catch (error) {
-									console.error('Error deleting period:', error);
-									toaster.error('Erreur lors de la suppression');
-								}
-							}}
-						>
-							<Trash2 class="h-4 w-4" />
-							Supprimer
-						</Button>
-					{:else}
-						<div></div>
-					{/if}
-
+				<div class="mt-6 flex items-center justify-end">
 					<div class="flex gap-2">
 						<Button type="button" variant="outline" onclick={closePeriodDialog}>Annuler</Button>
 						<Button type="submit">Enregistrer</Button>
@@ -1400,44 +1321,7 @@
 					</div>
 				</div>
 
-				<div class="mt-6 flex items-center justify-between">
-					{#if editingHoliday}
-						<Button
-							type="button"
-							variant="destructive"
-							class="gap-2"
-							onclick={async () => {
-								if (!confirm('Êtes-vous sûr de vouloir supprimer ces vacances ?')) {
-									return;
-								}
-								const formData = new FormData();
-								formData.append('id', editingHoliday?.id ?? '');
-								try {
-									const response = await fetch('?/deleteHoliday', {
-										method: 'POST',
-										body: formData,
-										headers: { 'x-sveltekit-action': 'true' }
-									});
-									if (response.ok) {
-										await invalidateAll();
-										toaster.success('Vacances supprimées');
-										closeHolidayDialog();
-									} else {
-										toaster.error('Erreur lors de la suppression');
-									}
-								} catch (error) {
-									console.error('Error deleting holiday:', error);
-									toaster.error('Erreur lors de la suppression');
-								}
-							}}
-						>
-							<Trash2 class="h-4 w-4" />
-							Supprimer
-						</Button>
-					{:else}
-						<div></div>
-					{/if}
-
+				<div class="mt-6 flex items-center justify-end">
 					<div class="flex gap-2">
 						<Button type="button" variant="outline" onclick={closeHolidayDialog}>Annuler</Button>
 						<Button type="submit">Enregistrer</Button>

--- a/src/routes/(protected)/dashboard/admin/vip-cards/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/vip-cards/+page.svelte
@@ -7,6 +7,8 @@
 	import VipCardImageUploader from '$lib/components/vip-cards/VipCardImageUploader.svelte';
 	import VipCardConfigList from '$lib/components/vip-cards/VipCardConfigList.svelte';
 	import VipCardConfigEditor from '$lib/components/vip-cards/VipCardConfigEditor.svelte';
+	import TypedConfirmDialog from '$lib/components/admin/TypedConfirmDialog.svelte';
+	import { Trash2 } from '@lucide/svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { rarityLabel } from '$lib/components/vip-cards/utils';
 	import type { Database } from '$lib/types/database';
@@ -64,7 +66,6 @@
 	let creatingCard = $state(false);
 	let editingCard = $state<VipCardTemplate | null>(null);
 	let uploadingImageCard = $state<VipCardTemplate | null>(null);
-	let deletingCard = $state<VipCardTemplate | null>(null);
 	let creatingConfig = $state(false);
 	let editingConfig = $state<VipCardConfig | null>(null);
 
@@ -211,35 +212,22 @@
 		}
 	}
 
-	function handleDeleteCard(cardId: string) {
-		const card = templates.find((t) => t.id === cardId);
-		if (card) {
-			deletingCard = card;
+	// Typed-confirmation delete: echo the card name in the body; the server
+	// re-enforces it via assertTypedConfirmation. Throws on failure so the
+	// dialog keeps itself open + toasts; success → toast + close handled by it.
+	async function deleteCard(cardId: string, cardName: string) {
+		const response = await fetch(`/api/admin/vip-cards/templates/${cardId}`, {
+			method: 'DELETE',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ confirm: cardName })
+		});
+
+		if (!response.ok) {
+			const error = await response.json();
+			throw new Error(error.message || 'Failed to delete');
 		}
-	}
 
-	async function confirmDeleteCard() {
-		if (!deletingCard) return;
-
-		const cardId = deletingCard.id;
-
-		try {
-			const response = await fetch(`/api/admin/vip-cards/templates/${cardId}`, {
-				method: 'DELETE'
-			});
-
-			if (!response.ok) {
-				const error = await response.json();
-				throw new Error(error.message || 'Failed to delete');
-			}
-
-			templates = templates.filter((t) => t.id !== cardId);
-			toaster.success('Carte supprimée');
-			deletingCard = null;
-		} catch (error) {
-			console.error('Delete error:', error);
-			toaster.error(error instanceof Error ? error.message : 'Échec de la suppression');
-		}
+		templates = templates.filter((t) => t.id !== cardId);
 	}
 
 	function handleImageUploaded(cardId: string, newImageUrl: string) {
@@ -348,23 +336,22 @@
 		}
 	}
 
-	async function handleDeleteConfig(configId: string) {
-		try {
-			const response = await fetch(`/api/admin/vip-cards/configs/${configId}`, {
-				method: 'DELETE'
-			});
+	async function handleDeleteConfig(configId: string, configName: string) {
+		// Typed-confirmation: echo the config name in the body; the server
+		// re-enforces it via assertTypedConfirmation. Errors propagate to the
+		// dialog (it keeps itself open + toasts on throw).
+		const response = await fetch(`/api/admin/vip-cards/configs/${configId}`, {
+			method: 'DELETE',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ confirm: configName })
+		});
 
-			if (!response.ok) {
-				const error = await response.json();
-				throw new Error(error.message || 'Failed to delete');
-			}
-
-			configs = configs.filter((c) => c.id !== configId);
-			toaster.success('Configuration supprimée');
-		} catch (error) {
-			console.error('Delete config error:', error);
-			toaster.error(error instanceof Error ? error.message : 'Échec de la suppression');
+		if (!response.ok) {
+			const error = await response.json();
+			throw new Error(error.message || 'Failed to delete');
 		}
+
+		configs = configs.filter((c) => c.id !== configId);
 	}
 </script>
 
@@ -411,9 +398,29 @@
 									onInlineEdit={(name, description, action, rarity) =>
 										handleInlineEdit(card.id, name, description, action, rarity)}
 									onEdit={() => (editingCard = card)}
-									onDelete={() => handleDeleteCard(card.id)}
 									onUploadImage={() => (uploadingImageCard = card)}
-								/>
+								>
+									{#snippet deleteTrigger()}
+										<TypedConfirmDialog
+											expected={card.name}
+											onConfirm={() => deleteCard(card.id, card.name)}
+											title="Supprimer la carte « {card.name} »"
+											description="Cette action est irréversible. Les cartes déjà attribuées aux élèves resteront, mais cette carte ne sera plus disponible pour de nouveaux tirages."
+											successMessage="Carte supprimée"
+										>
+											{#snippet trigger(props)}
+												<button
+													{...props}
+													type="button"
+													class="rounded-full bg-destructive p-2 text-destructive-foreground shadow-lg transition-all hover:scale-110 hover:bg-destructive/90 active:scale-95"
+													aria-label="Supprimer la carte"
+												>
+													<Trash2 class="h-4 w-4" />
+												</button>
+											{/snippet}
+										</TypedConfirmDialog>
+									{/snippet}
+								</VipCardPreview>
 							{/each}
 						</div>
 					</div>
@@ -499,63 +506,6 @@
 				onComplete={(newUrl) => handleImageUploaded(cardId, newUrl)}
 				onCancel={() => (uploadingImageCard = null)}
 			/>
-		</Dialog.Content>
-	</Dialog.Root>
-{/if}
-
-<!-- Delete Card Confirmation Modal -->
-{#if deletingCard}
-	<Dialog.Root
-		open={true}
-		onOpenChange={() => {
-			deletingCard = null;
-		}}
-	>
-		<Dialog.Content class="max-w-md">
-			<Dialog.Header>
-				<Dialog.Title>Confirmer la suppression</Dialog.Title>
-				<Dialog.Description>
-					Êtes-vous sûr de vouloir supprimer la carte <strong class="font-semibold text-foreground"
-						>"{deletingCard.name}"</strong
-					> ?
-				</Dialog.Description>
-			</Dialog.Header>
-
-			<div class="space-y-4">
-				<!-- Warning message -->
-				<div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
-					<p class="text-sm text-destructive">
-						⚠️ Cette action est <strong>irréversible</strong>. Toutes les cartes déjà attribuées aux
-						élèves resteront, mais cette carte ne sera plus disponible pour de nouveaux tirages.
-					</p>
-				</div>
-
-				<!-- Card preview -->
-				<div class="rounded-lg border bg-muted/20 p-4">
-					<div class="flex items-center gap-3">
-						{#if deletingCard.image_path}
-							<img
-								src={deletingCard.image_path}
-								alt={deletingCard.name}
-								class="h-16 w-16 rounded-md object-cover"
-							/>
-						{/if}
-						<div class="flex-1">
-							<p class="font-medium">{deletingCard.name}</p>
-							<p class="text-sm text-muted-foreground">{deletingCard.description}</p>
-							<p class="mt-1 text-xs text-muted-foreground">
-								{rarityLabel(deletingCard.rarity)} • ID: {deletingCard.id}
-							</p>
-						</div>
-					</div>
-				</div>
-
-				<!-- Action buttons -->
-				<div class="flex justify-end gap-2">
-					<Button variant="outline" onclick={() => (deletingCard = null)}>Annuler</Button>
-					<Button variant="destructive" onclick={confirmDeleteCard}>Supprimer</Button>
-				</div>
-			</div>
 		</Dialog.Content>
 	</Dialog.Root>
 {/if}

--- a/src/routes/api/admin/cron/trigger/+server.ts
+++ b/src/routes/api/admin/cron/trigger/+server.ts
@@ -13,8 +13,13 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 import { getEnv } from '$lib/server/env';
-import { cronTriggerBodySchema, type CronTriggerResponse } from '$lib/server/validation/cron';
+import {
+	cronTriggerBodySchema,
+	CRON_TRIGGER_CONFIRM_KEYWORD,
+	type CronTriggerResponse
+} from '$lib/server/validation/cron';
 import { createServiceRoleClient } from '$lib/server/serviceRoleClient';
 
 // Simple in-memory rate limit store
@@ -44,6 +49,9 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 	}
 
 	const { job_path } = validation.data;
+
+	// ✅ SECURITY: global destructive op → require the fixed keyword.
+	assertTypedConfirmation(validation.data.confirm, CRON_TRIGGER_CONFIRM_KEYWORD);
 
 	// Check rate limit
 	const lastTrigger = rateLimitStore.get(job_path);

--- a/src/routes/api/admin/exercises/backup/+server.ts
+++ b/src/routes/api/admin/exercises/backup/+server.ts
@@ -13,6 +13,7 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 import {
 	exportBackupJSON,
 	exportBackupSQL,
@@ -24,11 +25,19 @@ import { isBackupSizeValid, getMaxFileSizeDisplay } from '$lib/server/validation
 // VALIDATION SCHEMAS
 // ============================================================================
 
+/**
+ * Typed-confirmation keyword the admin must echo to restore a backup.
+ * Global destructive op → fixed keyword (not a resource name).
+ */
+const RESTORE_CONFIRM_KEYWORD = 'RESTAURER';
+
 const exportQuerySchema = z.object({
 	format: z.enum(['json', 'sql']).default('json')
 });
 
 const restoreBodySchema = z.object({
+	// Typed-confirmation token; re-enforced server-side via assertTypedConfirmation.
+	confirm: z.string(),
 	backup: z.unknown(),
 	options: z.object({
 		conflict_strategy: z.enum(['skip', 'replace']).default('skip'),
@@ -150,7 +159,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		throw error(400, bodyValidation.error.issues[0].message);
 	}
 
-	const { backup, options } = bodyValidation.data;
+	const { confirm, backup, options } = bodyValidation.data;
+
+	// ✅ SECURITY: global destructive op → require the fixed keyword.
+	assertTypedConfirmation(confirm, RESTORE_CONFIRM_KEYWORD);
 
 	try {
 		// Add admin_id to options for orphan reassignment.

--- a/src/routes/api/admin/vip-cards/configs/[id]/+server.ts
+++ b/src/routes/api/admin/vip-cards/configs/[id]/+server.ts
@@ -10,11 +10,18 @@
  */
 
 import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
 import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 import { updateConfigSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardConfig } from '$lib/types/vip-card-admin';
 import { configToResponse } from '$lib/types/vip-card-admin';
+
+/**
+ * Body for the typed-confirmation DELETE: the admin must echo the config name.
+ */
+const deleteConfirmSchema = z.object({ confirm: z.string() });
 
 /**
  * PATCH /api/admin/vip-cards/configs/[id]
@@ -129,13 +136,26 @@ export const PATCH: RequestHandler = async ({ request, locals, params }) => {
  *   - 404: Config not found
  *   - 500: Server error
  */
-export const DELETE: RequestHandler = async ({ locals, params }) => {
+export const DELETE: RequestHandler = async ({ request, locals, params }) => {
 	// ✅ SECURITY: admin elevation OR real admin login.
 	const { supabase } = await requireAdmin(locals);
 	const configId = parseInt(params.id, 10);
 
 	if (isNaN(configId)) {
 		throw error(400, 'Invalid config ID');
+	}
+
+	// Typed-confirmation gate: parse the body defensively (a missing/invalid
+	// body fails the schema → 400) and require the echoed config name below.
+	let confirmBody: unknown;
+	try {
+		confirmBody = await request.json();
+	} catch {
+		confirmBody = null;
+	}
+	const confirmParsed = deleteConfirmSchema.safeParse(confirmBody);
+	if (!confirmParsed.success) {
+		throw error(400, confirmParsed.error.issues[0].message);
 	}
 
 	try {
@@ -158,6 +178,9 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 		if (existing.is_active) {
 			throw error(400, 'Cannot delete active config. Deactivate it first.');
 		}
+
+		// ✅ SECURITY: require the admin to have typed the exact config name.
+		assertTypedConfirmation(confirmParsed.data.confirm, existing.config_name);
 
 		// 4. Delete config
 		const { error: deleteError } = await supabase

--- a/src/routes/api/admin/vip-cards/templates/[id]/+server.ts
+++ b/src/routes/api/admin/vip-cards/templates/[id]/+server.ts
@@ -10,12 +10,19 @@
  */
 
 import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
 import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/middleware/auth';
+import { assertTypedConfirmation } from '$lib/server/confirmAction';
 import { updateTemplateSchema } from '$lib/server/validation/vip-card-admin';
 import type { VipCardTemplate } from '$lib/types/vip-card-admin';
 import { templateToResponse } from '$lib/types/vip-card-admin';
 import { validateSlugParam } from '$lib/server/validation/params';
+
+/**
+ * Body for the typed-confirmation DELETE: the admin must echo the template name.
+ */
+const deleteConfirmSchema = z.object({ confirm: z.string() });
 
 /**
  * PATCH /api/admin/vip-cards/templates/[id]
@@ -125,16 +132,29 @@ export const PATCH: RequestHandler = async ({ request, locals, params }) => {
  *   - 409: Cannot delete template with existing instances
  *   - 500: Server error
  */
-export const DELETE: RequestHandler = async ({ locals, params }) => {
+export const DELETE: RequestHandler = async ({ request, locals, params }) => {
 	// ✅ SECURITY: admin elevation OR real admin login.
 	const { supabase } = await requireAdmin(locals);
 	const templateId = validateSlugParam(params.id, 'templateId');
+
+	// Typed-confirmation gate: parse the body defensively (a missing/invalid
+	// body fails the schema → 400) and require the echoed template name below.
+	let confirmBody: unknown;
+	try {
+		confirmBody = await request.json();
+	} catch {
+		confirmBody = null;
+	}
+	const confirmParsed = deleteConfirmSchema.safeParse(confirmBody);
+	if (!confirmParsed.success) {
+		throw error(400, confirmParsed.error.issues[0].message);
+	}
 
 	try {
 		// 3. Check if template exists
 		const { data: existing, error: checkError } = await supabase
 			.from('vip_card_templates')
-			.select('id')
+			.select('id, name')
 			.eq('id', templateId)
 			.maybeSingle();
 
@@ -146,6 +166,9 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 		if (!existing) {
 			throw error(404, `Template with ID "${templateId}" not found`);
 		}
+
+		// ✅ SECURITY: require the admin to have typed the exact template name.
+		assertTypedConfirmation(confirmParsed.data.confirm, existing.name);
 
 		// 4. Check if template has instances (prevent deletion if in use)
 		const { count, error: countError } = await supabase


### PR DESCRIPTION
## Quoi
Étend la **confirmation tapée** (Phase 4b) aux ops destructives admin restantes, en réutilisant `assertTypedConfirmation` + `TypedConfirmDialog` (à qui j'ai ajouté un **mode callback** pour les ops via fetch, en plus du mode form-action).

| Op | Token à taper | Type |
|---|---|---|
| VIP config DELETE | nom de la config | ressource |
| VIP template DELETE | nom du template | ressource |
| Backup **restore** | `RESTAURER` | mot-clé (écrase les données) |
| Org: delete année / période / congé | nom de la ressource | ressource |
| Cron: déclenchement manuel | `LANCER` | mot-clé |

Le dialog lit désormais les deux conventions `fail()` (`{ message }` | `{ error }`).

## Décisions (NON câblé)
- **Supprimer une classe** : pas de hard-delete (seulement `deactivate`/`activate` réversible) → laissé.
- **`anti-fraud/run`** : **aucune UI**, et joignable server-to-server via le `fetch(job_path)` de `cron/trigger` → exiger un mot-clé **400-erait** cette chaîne. **Reverté** (on ajoutera la confirmation si un bouton humain est créé un jour).

## Vérifié
`check:incremental` 0 erreur · tests schémas confirmAction/backup/vip/cron verts (test cron mis à jour pour le champ `confirm`). `vercel.json` crons = `[]` → aucune automation cassée.

## ⚠️ À spot-checker en prod (UI non testable par moi)
Les dialogs : VIP delete, backup restore, deletes organisation (année/période/congé), trigger cron. **Note UX** : le trigger cron exige `LANCER` pour *tout* job (même bénin) — dis-moi si c'est trop lourd, je l'enlève.