### PR TITLE
ci: fix eslint cache (content strategy) — Lint was still 12 min

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,17 +50,22 @@ jobs:
       # The key is unique per commit (always saves a fresh cache); restore-keys
       # fall back to the most recent compatible cache. eslint invalidates entries
       # itself when a file or the config changes, so this is correctness-safe.
+      # Key prefix is versioned (-content) so the new content-strategy cache
+      # starts clean and never restores a stale metadata-strategy cache.
       - name: Restore ESLint cache
         uses: actions/cache@v4
         with:
           path: .eslintcache
-          key: eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.*') }}-${{ github.sha }}
+          key: eslint-content-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.*') }}-${{ github.sha }}
           restore-keys: |
-            eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.*') }}-
-            eslint-${{ runner.os }}-
+            eslint-content-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.*') }}-
+            eslint-content-${{ runner.os }}-
 
+      # --cache-strategy content (NOT the default mtime): CI checkouts rewrite
+      # every file's mtime, so the default strategy treats all files as changed
+      # and the cache is useless. Hashing content is stable across checkouts.
       - name: Run ESLint
-        run: pnpm eslint . --cache
+        run: pnpm eslint . --cache --cache-strategy content
 
   typecheck:
     name: Type Check


### PR DESCRIPTION
## Pourquoi
Le cache eslint ajouté précédemment **ne servait à rien** : Lint restait à ~12 min et les caches sauvés faisaient ~0 Mo. Cause : eslint `--cache` utilise par défaut la stratégie **`metadata` (mtime)**, et chaque `git checkout` en CI **réécrit les mtimes** → eslint considère **tous** les fichiers comme modifiés → relinte tout.

## Fix
`--cache-strategy content` : eslint hashe le **contenu** des fichiers (stable entre checkouts) → seuls les fichiers réellement modifiés sont relintés. Clé de cache versionnée (`eslint-content-…`) pour repartir propre.

⚠️ Ce run-ci est encore à froid (nouvelle stratégie → cache neuf) ; le gain (~12 min → 1-2 min) apparaît dès la **PR suivante**, une fois qu'un push sur `main` aura sauvé le cache content.