### PR TITLE
fix(admin): annuaire (UAI/RNE) search works when elevated

### DIFF
--- a/src/routes/(protected)/dashboard/admin/schools/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/schools/+page.svelte
@@ -11,7 +11,7 @@
 
 	let { data }: { data: PageData } = $props();
 
-	// Mirrors the normalized payload from GET /api/annuaire/search.
+	// Mirrors the normalized payload from GET /api/admin/annuaire/search.
 	type AnnuaireSchool = {
 		uai: string;
 		name: string;
@@ -115,7 +115,7 @@
 		annuaireLoading = true;
 		annuaireOpen = true;
 		try {
-			const res = await fetch(`/api/annuaire/search?q=${encodeURIComponent(q)}`);
+			const res = await fetch(`/api/admin/annuaire/search?q=${encodeURIComponent(q)}`);
 			const results = res.ok ? ((await res.json()).schools ?? []) : [];
 			if (seq !== annuaireSeq) return; // superseded by a newer search
 			annuaireResults = results;

--- a/src/routes/api/admin/annuaire/search/+server.ts
+++ b/src/routes/api/admin/annuaire/search/+server.ts
@@ -1,6 +1,6 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { requireRole } from '$lib/server/middleware/auth';
+import { requireAdmin } from '$lib/server/middleware/auth';
 import {
 	annuaireSearchQuerySchema,
 	annuaireResponseSchema,
@@ -12,8 +12,10 @@ import {
  * (Opendatasoft v2.1). Lets an admin look up an establishment by name and
  * auto-fill its UAI/RNE and contact details from the official source.
  *
- * Admin-only. The dataset is public (no API key), but we proxy server-side to
- * avoid CORS, validate the response, and normalize the payload.
+ * Admin-only via `requireAdmin` (real admin OR an elevated teacher — the route
+ * lives under /api/admin so the elevation handle is in scope). The dataset is
+ * public (no API key), but we proxy server-side to avoid CORS, validate the
+ * response, and normalize the payload.
  */
 const ANNUAIRE_URL =
 	'https://data.education.gouv.fr/api/explore/v2.1/catalog/datasets/fr-en-annuaire-education/records';
@@ -29,7 +31,7 @@ const SELECT_FIELDS = [
 ].join(',');
 
 export const GET: RequestHandler = async ({ url, fetch, locals }) => {
-	await requireRole(locals, 'admin');
+	await requireAdmin(locals);
 
 	const parsed = annuaireSearchQuerySchema.safeParse({ q: url.searchParams.get('q') ?? '' });
 	if (!parsed.success) {


### PR DESCRIPTION
## Bug
« Rechercher dans l'Annuaire de l'Éducation nationale » ne retournait rien pour un **prof élevé**.

**Cause** : `/api/annuaire/search` utilisait `requireRole(locals,'admin')` (vérifie `role==='admin'` en dur) → un prof élevé (role `teacher`) prend un **403**, et le `catch` silencieux du frontend le transformait en « aucun résultat ». (L'API open data externe marche : 79 résultats pour « voltaire ».)

## Fix
Déplace `/api/annuaire/search` → **`/api/admin/annuaire/search`** (donc couvert par le handle d'élévation) + garde **`requireAdmin`** (vrai admin OU prof élevé). Met à jour l'unique appelant frontend. **Pas de relâchement de sécu** : toujours admin-only, mais conscient de l'élévation.

`check:incremental` 0 erreur. Même classe de bug que la sidebar (#36) : des gardes `role==='admin'` non migrées vers `requireAdmin`.