### PR TITLE
perf(build): skip gzip-size reporting in the prod build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -114,7 +114,11 @@ export default defineConfig(({ mode }) => {
 		 */
 		build: {
 			// Increase chunk size warning limit
-			chunkSizeWarningLimit: 1000
+			chunkSizeWarningLimit: 1000,
+			// Skip the "computing gzip size" pass over every output chunk. We already
+			// get bundle sizes from the ANALYZE=1 visualizer, and the Safari-TDZ chunk
+			// guard reads RAW bytes — so the gzip report is dead weight on the prod build.
+			reportCompressedSize: false
 		},
 
 		test: {


### PR DESCRIPTION
## Profil du build Vercel prod (déploiement #39, mesuré)
| Phase | Temps |
|---|---|
| Clone | ~5 s |
| Install (pnpm) | **1.8 s** (cache restauré) |
| **Bundling vite/rollup** (client 7479 + serveur 8670 modules) | **~3 min** ← l'essentiel |
| Total | **~3 m 13 s** |

Le cache de build Vercel est bien restauré, l'install est négligeable. **Le coût quasi-total est le bundling de ~16 k modules.**

## Ce changement
`reportCompressedSize: false` : supprime la passe « computing gzip size » sur chaque chunk (~87 chunks). Gain **petit** (quelques secondes), **gratuit, sans risque** : on a déjà le visualizer `ANALYZE=1` pour les tailles, et la garde Safari-TDZ lit les **octets bruts** (pas le gzip).

## Pour un vrai gros gain (pas dans cette PR)
Le levier réel = **réduire le bundle** (16 k modules = deps lourdes). Lazy-loader les libs hors chemin critique (MathLive, geometry-core, mathAST…) couperait le build **et** le poids runtime. C'est un chantier app-level (j'ouvre le `bundle-analyze` si tu veux le chiffrer). À ton appel.