### PR TITLE
fix(annuaire): search by name + commune, with pagination

### DIFF
--- a/src/lib/server/validation/schools.ts
+++ b/src/lib/server/validation/schools.ts
@@ -84,7 +84,9 @@ export type SchoolUpsert = z.infer<typeof schoolUpsertSchema>;
 
 /** Query for the Annuaire search proxy endpoint. */
 export const annuaireSearchQuerySchema = z.object({
-	q: z.string().trim().min(2).max(100)
+	q: z.string().trim().min(2).max(100),
+	// 1-based page; capped at 50 (×20 = 1000 results) as a sane upper bound.
+	page: z.coerce.number().int().min(1).max(50).default(1)
 });
 
 /** Raw record shape returned by the Opendatasoft `fr-en-annuaire-education` dataset. */

--- a/src/routes/(protected)/dashboard/admin/schools/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/schools/+page.svelte
@@ -53,6 +53,13 @@
 	let annuaireTimer: ReturnType<typeof setTimeout> | undefined;
 	// Monotonic token: drops responses from superseded (slower) requests.
 	let annuaireSeq = 0;
+	// Pagination of the Annuaire results.
+	let annuairePage = $state(1);
+	let annuaireTotal = $state(0);
+	let annuairePageSize = $state(20);
+	let annuaireTotalPages = $derived(
+		Math.min(50, Math.max(1, Math.ceil(annuaireTotal / annuairePageSize)))
+	);
 
 	function resetAnnuaire() {
 		clearTimeout(annuaireTimer);
@@ -60,6 +67,8 @@
 		annuaireResults = [];
 		annuaireOpen = false;
 		annuaireLoading = false;
+		annuairePage = 1;
+		annuaireTotal = 0;
 	}
 
 	function openCreateModal() {
@@ -105,25 +114,37 @@
 			annuaireOpen = false;
 			return;
 		}
-		annuaireTimer = setTimeout(searchAnnuaire, 300);
+		annuaireTimer = setTimeout(() => searchAnnuaire(1), 300);
 	}
 
-	async function searchAnnuaire() {
+	async function searchAnnuaire(page = 1) {
 		const q = annuaireQuery.trim();
 		if (q.length < 2) return;
 		const seq = ++annuaireSeq;
 		annuaireLoading = true;
 		annuaireOpen = true;
 		try {
-			const res = await fetch(`/api/admin/annuaire/search?q=${encodeURIComponent(q)}`);
-			const results = res.ok ? ((await res.json()).schools ?? []) : [];
+			const res = await fetch(`/api/admin/annuaire/search?q=${encodeURIComponent(q)}&page=${page}`);
+			const body = res.ok ? await res.json() : null;
 			if (seq !== annuaireSeq) return; // superseded by a newer search
-			annuaireResults = results;
+			annuaireResults = body?.schools ?? [];
+			annuaireTotal = body?.total ?? 0;
+			annuairePage = body?.page ?? page;
+			annuairePageSize = body?.pageSize ?? 20;
 		} catch {
-			if (seq === annuaireSeq) annuaireResults = [];
+			if (seq === annuaireSeq) {
+				annuaireResults = [];
+				annuaireTotal = 0;
+			}
 		} finally {
 			if (seq === annuaireSeq) annuaireLoading = false;
 		}
+	}
+
+	function goAnnuairePage(delta: number) {
+		const next = annuairePage + delta;
+		if (next < 1 || next > annuaireTotalPages) return;
+		searchAnnuaire(next);
 	}
 
 	function selectAnnuaireSchool(school: AnnuaireSchool) {
@@ -473,6 +494,31 @@
 															>
 														</button>
 													{/each}
+												{/if}
+												{#if annuaireTotal > annuairePageSize}
+													<div
+														class="sticky bottom-0 flex items-center justify-between border-t border-border bg-card px-2 py-1.5 text-xs text-muted-foreground"
+													>
+														<button
+															type="button"
+															class="rounded px-2 py-1 hover:bg-muted disabled:opacity-40"
+															disabled={annuairePage <= 1 || annuaireLoading}
+															onclick={() => goAnnuairePage(-1)}
+														>
+															‹ Précédent
+														</button>
+														<span
+															>Page {annuairePage} / {annuaireTotalPages} · {annuaireTotal} résultats</span
+														>
+														<button
+															type="button"
+															class="rounded px-2 py-1 hover:bg-muted disabled:opacity-40"
+															disabled={annuairePage >= annuaireTotalPages || annuaireLoading}
+															onclick={() => goAnnuairePage(1)}
+														>
+															Suivant ›
+														</button>
+													</div>
 												{/if}
 											</div>
 										{/if}

--- a/src/routes/api/admin/annuaire/search/+server.ts
+++ b/src/routes/api/admin/annuaire/search/+server.ts
@@ -9,8 +9,8 @@ import {
 
 /**
  * Proxy to the national "Annuaire de l'éducation nationale" open dataset
- * (Opendatasoft v2.1). Lets an admin look up an establishment by name and
- * auto-fill its UAI/RNE and contact details from the official source.
+ * (Opendatasoft v2.1). Lets an admin look up an establishment by name and/or
+ * commune (full-text, all fields) and auto-fill its UAI/RNE + contact details.
  *
  * Admin-only via `requireAdmin` (real admin OR an elevated teacher — the route
  * lives under /api/admin so the elevation handle is in scope). The dataset is
@@ -45,9 +45,14 @@ export const GET: RequestHandler = async ({ url, fetch, locals }) => {
 	}
 
 	const apiUrl = new URL(ANNUAIRE_URL);
-	apiUrl.searchParams.set('where', `search(nom_etablissement,"${term}")`);
+	// Record-level full-text search across ALL fields (accent-/case-insensitive) so
+	// the admin can disambiguate a common name by adding the city — e.g. "Blaise
+	// Pascal Segré" pinpoints the right one among the 57 "Blaise Pascal" schools.
+	apiUrl.searchParams.set('where', `search("${term}")`);
 	apiUrl.searchParams.set('select', SELECT_FIELDS);
-	apiUrl.searchParams.set('limit', '10');
+	// 20 (not 10): a precise name+city query returns a handful, but a name-only
+	// query for a common name needs headroom in the autocomplete list.
+	apiUrl.searchParams.set('limit', '20');
 
 	let res: Response;
 	try {

--- a/src/routes/api/admin/annuaire/search/+server.ts
+++ b/src/routes/api/admin/annuaire/search/+server.ts
@@ -33,7 +33,10 @@ const SELECT_FIELDS = [
 export const GET: RequestHandler = async ({ url, fetch, locals }) => {
 	await requireAdmin(locals);
 
-	const parsed = annuaireSearchQuerySchema.safeParse({ q: url.searchParams.get('q') ?? '' });
+	const parsed = annuaireSearchQuerySchema.safeParse({
+		q: url.searchParams.get('q') ?? '',
+		page: url.searchParams.get('page') ?? '1'
+	});
 	if (!parsed.success) {
 		throw error(400, parsed.error.issues[0].message);
 	}
@@ -50,9 +53,11 @@ export const GET: RequestHandler = async ({ url, fetch, locals }) => {
 	// Pascal Segré" pinpoints the right one among the 57 "Blaise Pascal" schools.
 	apiUrl.searchParams.set('where', `search("${term}")`);
 	apiUrl.searchParams.set('select', SELECT_FIELDS);
-	// 20 (not 10): a precise name+city query returns a handful, but a name-only
-	// query for a common name needs headroom in the autocomplete list.
-	apiUrl.searchParams.set('limit', '20');
+	// Paginated: PAGE_SIZE per page, offset = (page-1)*PAGE_SIZE. The client pages
+	// through with prev/next using the `total` returned below — no arbitrary cap.
+	const PAGE_SIZE = 20;
+	apiUrl.searchParams.set('limit', String(PAGE_SIZE));
+	apiUrl.searchParams.set('offset', String((parsed.data.page - 1) * PAGE_SIZE));
 
 	let res: Response;
 	try {
@@ -81,5 +86,10 @@ export const GET: RequestHandler = async ({ url, fetch, locals }) => {
 			academy: r.libelle_academie ?? ''
 		}));
 
-	return json({ schools });
+	return json({
+		schools,
+		total: validated.data.total_count,
+		page: parsed.data.page,
+		pageSize: PAGE_SIZE
+	});
 };


### PR DESCRIPTION
## Bug
Recherche Annuaire : certains établissements introuvables — un nom courant (57 « Blaise Pascal ») ne pouvait pas être filtré par ville, car la recherche ne portait que sur le **nom**.

## Fix 1 — recherche tous-champs (nom + commune)
`search(nom_etablissement, "…")` → **`search("…")`** (plein-texte sur tous les champs, insensible aux accents/casse). On peut désormais taper « Blaise Pascal Segré » pour cibler la bonne parmi les 57. Vérifié sur l'API live.

## Fix 2 — pagination (remplace le cap fixe)
- **Backend** : param `page` (1-based, max 50) → `limit` + `offset` ; renvoie `{ schools, total, page, pageSize }`.
- **Frontend** : footer collant dans le dropdown autocomplete — `‹ Précédent · Page X / Y · Z résultats · Suivant ›`, affiché si `total > 20`, boutons désactivés aux bornes / pendant le chargement. Taper relance en page 1.

## Vérifié
`check:incremental` 0 erreur · svelte-autofixer clean.
⚠️ UI à tester visuellement (pagination du dropdown).

## Hors périmètre (noté)
Établissements **AEFE / étranger** (ex. Lycée Voltaire Doha) : absents de l'annuaire officiel France-only, et UAI au format `NNNMNN` incompatible avec la contrainte `^[0-9]{7}[A-Z]$` → saisie manuelle / décision migration à part.