### PR TITLE
refactor!: drop class-cluster teacher_id, move ownership to roles (mono-teacher)

### DIFF
--- a/docs/wip/drop-class-teacher-id-progress.md
+++ b/docs/wip/drop-class-teacher-id-progress.md
@@ -1,0 +1,88 @@
+# WIP — Retrait de `teacher_id` du cluster « classe assignée à un prof » (mono-prof)
+
+> Branche : `refactor/mono-teacher-drop-class-teacher-id`
+> Démarré : 2026-06-19. Crash-recovery doc.
+
+## Objectif
+
+Finir le passage mono-prof : supprimer la dimension multi-prof portée par
+`teacher_id` sur le **cluster classes** (les classes ne sont plus « assignées à
+un prof »). Propriété désormais portée par le **rôle** (`is_teacher_or_admin()`),
+pas par `teacher_id = auth.uid()`. **Permissions effectives inchangées** (un seul
+prof possède déjà tout) → refactor, pas élargissement de droits.
+
+Décidé avec David (spec Phase 0 validée) : **Cluster 1 uniquement**.
+Recos suivies : retirer les params `p_teacher_id` des RPC de classes + inclure
+le housekeeping (drop RPC mortes + simplif `admin/classes`) dans cette PR.
+
+## Périmètre — 6 tables (colonne `teacher_id` retirée)
+
+`classes`, `class_chapters`, `class_journal_entries`, `class_schedules`,
+`game_timeslots`, `evaluation_tasks` — + 6 FK, + trigger/fonction
+`set_chapter_teacher_id`.
+
+**Hors périmètre (gardent `teacher_id` = tampon propriétaire)** :
+`google_classroom_courses`, `google_integrations`, `orphaned_documents`,
+`rag_documents`, `teacher_vip_card_overrides`.
+⚠️ Mais les **fonctions** qui _joignent_ `classes.teacher_id` (ex.
+`get_teacher_override_impact`) doivent être réécrites (le JOIN classes change),
+même si leur propre colonne `teacher_id` reste.
+
+## Modèle cible / règles de réécriture
+
+- Helper `is_class_teacher(class_id)` : `classes.teacher_id = auth.uid()` → `is_teacher_or_admin()`.
+- Helper `is_class_teacher_of(p_teacher_id)` : `c.teacher_id = p_teacher_id` (classe de l'élève) → check rôle de `p_teacher_id` (teacher/admin).
+- Policies des 6 tables : tout prédicat `teacher_id = auth.uid()` → `is_teacher_or_admin()`. Policies `admins_*`/`Admins can…` (via `is_admin()`) redondantes une fois le prof couvert → consolider/supprimer.
+- `is_admin()` = **admin uniquement** (le commentaire « admin or teacher » est FAUX). Ne pas s'y fier pour couvrir le prof.
+- RPC de classes (`get_teacher_classes_with_data`, `_with_students`, `_for_messaging`, `get_teacher_assignment_stats`) : retirer le param `p_teacher_id` + la colonne `teacher_id` du RETURNS + le filtre `WHERE c.teacher_id = …` (mono-prof → toutes les classes).
+- Fonctions `SECURITY DEFINER` diverses référant `c.teacher_id = auth.uid()` → `is_teacher_or_admin()`.
+- Dead RPCs supprimées : `get_student_teachers`, `get_teacher_students` (0 appelant, bug latent `classes.archived`).
+
+## Plan d'exécution (TDD)
+
+- [x] **Phase 1 — Tests** : `ClassBuilder` ne passe plus `teacher_id` (fait). Tests RLS des 6 tables → en cours.
+- [x] **Phase 2 — Migration SQL** : `20260620090000_drop_class_teacher_id_mono_teacher.sql`. **Applique proprement** (`db:reset` OK) + scan : 0 fonction référence encore une colonne supprimée.
+  - §1 helpers (`is_class_teacher`→role, `is_class_teacher_of`→role).
+  - §2 policies des 6 tables → `is_teacher_or_admin()`.
+  - §2b **29 policies externes** sur d'autres tables qui sous-requêtaient `classes.teacher_id` (trouvées par l'erreur de dépendance `db:reset`) → role-based ; 2 policies `rag_*` réécrites à la main (système OR docs du prof si inscrit).
+  - §2c **12 policies** sur chapter sub-tables + `evaluation_task_perimeter` (deps sur colonnes dénormalisées, trouvées via `pg_policies`).
+  - §3 RPC de classes : param `p_teacher_id` retiré, `teacher_id` retiré du RETURNS.
+  - §4 ~25 fonctions SECURITY DEFINER ; §4b **`award_weekly_reward` + `compute_daily_summary`** (ratées par l'agent, `teacher_id = auth.uid()` bare → role) trouvées par scan `pg_get_functiondef`.
+  - §5 drop trigger `set_chapter_teacher_id`. §6 drop 6 colonnes. §7 drop dead RPCs.
+  - ⚠️ **Régression évitée** : l'agent avait redéfini `get_allowed_recipients`/`validate_message_recipients` depuis le baseline (aurait cassé Option B : élève hors-classe ne pouvait plus écrire au prof). Blocs **retirés** ; les versions live (Option B 20260618093000) restent.
+- [~] **Phase 3 — App + types** : en cours.
+  - `database.ts` régénéré depuis le **LOCAL** (`supabase gen types --local`) — ⚠️ PAS `pnpm db:types` (qui pointe sur EU prod, pas encore migrée).
+  - RPC call sites corrigés : `students.ts` (×2), `api/messages/recipients`, `exercise-assignments` (param `p_teacher_id` retiré).
+  - `admin/classes` : suppr. fetch profs + embed `teacher:profiles!classes_teacher_id_fkey` + colonne UI « Enseignant » + bloc form ; `create` n'insère plus teacher_id. `svelte-autofixer` OK.
+  - Server ownership-checks réécrits role-based : `stats/teacher-class-auth.ts`, `kanban.isClassTeacher`, `chapters.createChapter`.
+  - **Tests d'infra réparés** (la suite passait par `classes.teacher_id → profiles ON DELETE CASCADE`, supprimé) : `insertTestClass`, `cleanupAllTestData` (+ purge explicite classes/eval), `createEvaluationTask`, `cleanupCompetenceTestData`, `game-leaderboards.createClass`, `ClassBuilder`, factory `class()`.
+  - **RESTE** : `journal.ts` (~5 sites + mapper `db.teacher_id`), `notifications.ts`, `vip-card-queries.ts`, `admin/notifications`, caches client (`student-cache`/`teacher-cache`) + tout ce que `check:incremental` remonte. **Diagnostiquer 6 échecs résiduels** de la suite complète.
+  - Suite intégration : 24→6 échecs (test-infra), les 3 fichiers ciblés repassent verts isolément.
+- [~] **Phase 4 — Revue** :
+  - `security-auditor` : **CLEAN** (0 Critical/High/Medium). RLS préservée, pas d'escalade, service-role non bypassé, frontières élève intactes. 2 notes Low (warnings admin-inclusive, filtre `status='active'` retiré dans qq fn VIP) → à documenter.
+  - `code-reviewer` : **MUST-FIX M1** — ~139 refs dans ~55 fichiers route/page interrogent encore les colonnes supprimées (`.eq('teacher_id', user.id)`, `.select('teacher_id')`→garde `x.teacher_id !== user.id`, embeds `classes!inner(teacher_id)`). `check:incremental` ne les voit PAS (strings supabase non typées) ; la suite intégration ne couvre pas ces routes → 500 en prod sinon. **Sweep en cours** (agents par groupe + `api/google/**` à la main, KEEP google_classroom_courses).
+  - Triage KEEP (ne PAS toucher) : `google_classroom_courses`, `google_integrations`, `rag_documents`, `orphaned_documents`, `teacher_vip_card_overrides`, params RPC `p_teacher_id` (award_achievement_manual, validate_riddle_attempt), `vip_activation_requests`.
+  - **Sweep FAIT** : 5 agents `backend-developer` (chapters API ×18, teacher/cours ×3, teacher misc ×13, api marketplace/worksheets/etc ×17, python/student/misc ×~14) + `api/google/**` à la main (mixte KEEP/DROP) + `gamification/rewards` (oublié des lots). **Sweep source = 0 réf DROP restante**, `check:incremental` = **0 erreur**. Agents ont aussi trouvé un bug préexistant (`exercises` utilise `created_by`, pas `teacher_id`).
+  - Student-facing (`student/+layout`, `student/cours`, `api/student/profile`) : embed `teacher:teacher_id` retiré → résolution du prof unique via `profiles.eq('role','teacher')`, shape identique.
+  - **Tests** : 9 tests unitaires serveur cassés par le sweep (5 cas obsolètes « autre prof → 403 » à supprimer ; 4 mocks à recâbler : kanban `isClassTeacher`→profiles.role, shared-coursework DELETE). Réparés par `test-automator` (en cours).
+  - **Tests réparés** (test-automator) : 5 cas obsolètes « autre prof → 403 » supprimés ; 4 mocks recâblés (kanban, shared-coursework DELETE). `pnpm test:server` complet = **31848 pass**, 1 seul échec **pré-existant** (`futureDateSchema > should accept today` — bug timezone UTC/local, hors-sujet ; session a passé minuit).
+  - Polish reviewer S2 : params `teacherId` inutilisés de `journal.ts` → `_teacherId` (`argsIgnorePattern: '^_'`), JSDoc corrigée.
+
+## État final (DoD)
+
+- `check:incremental` = **0 erreur** (46 warnings pré-existants).
+- Migration applique proprement (`db:reset`), 0 fonction référence une colonne supprimée.
+- **Sweep source = 0 réf DROP** (≈55 fichiers route/page).
+- Intégration verte sur DB propre (sauf 2 tests `admin-elevation` pré-existants = env local `PUBLIC_SUPABASE_URL` → prod).
+- `test:server` complet vert (sauf 1 test date pré-existant).
+- `security-auditor` CLEAN ; `code-reviewer` M1 (sweep) résolu.
+- **109 fichiers** (+4404/−1109).
+
+- [ ] **Phase 5 — PR** : branche → PR → CI verte. **STOP avant merge + `db:migrate` prod** (accord explicite de David requis ; release sous `maintenance:on` car destructif). ⚠️ eslint complet = CI-only (OOM local) : possible round-trip.
+- À documenter (notes Low de l'audit) : warnings admin-inclusive + filtre `status='active'` retiré (qq fn VIP) → `database-schema.md`.
+
+## Notes / pièges
+
+- Trigger mono-prof interdit ≥ 2 comptes `teacher` → chaque test ne crée qu'UN teacher ; `cleanupAllTestData()` entre les tests.
+- Membership élève via `class_members` (+ `is_class_student(class_id)`).
+- plpgsql ne valide pas le corps à la création → une fonction oubliée ne bloque pas la migration mais casse au runtime → la suite d'intégration est le filet.

--- a/src/lib/server/__tests__/journal.test.ts
+++ b/src/lib/server/__tests__/journal.test.ts
@@ -122,7 +122,6 @@ describe('createJournalEntry', () => {
 		expect(result.error).toBeNull();
 		expect(result.data).toBeDefined();
 		expect(result.data?.classId).toBe(mockClassId);
-		expect(result.data?.teacherId).toBe(mockTeacherId);
 		expect(result.data?.entryDate).toBe('2024-01-15');
 		expect(result.data?.lessonContent).toBe('Nous avons etudie les fractions');
 		expect(result.data?.homeworkContent).toBe('Exercices 1-5 page 42');
@@ -334,14 +333,12 @@ describe('deleteJournalEntry', () => {
 	it('should delete journal entry successfully', async () => {
 		const mockSupabase = createMockSupabase();
 
-		// First .eq() returns this for chaining, second .eq() resolves with data
-		mockSupabase._mockChain.eq
-			.mockReturnValueOnce(mockSupabase._mockChain) // First .eq() returns this
-			.mockResolvedValueOnce({
-				// Second .eq() resolves
-				data: null,
-				error: null
-			});
+		// Mono-teacher: deleteJournalEntry ends at a single .eq('id', ...) (no
+		// teacher_id ownership filter — RLS enforces it), which resolves here.
+		mockSupabase._mockChain.eq.mockResolvedValueOnce({
+			data: null,
+			error: null
+		});
 
 		const result = await journal.deleteJournalEntry(mockSupabase, mockEntryId, mockTeacherId);
 
@@ -352,7 +349,7 @@ describe('deleteJournalEntry', () => {
 	it('should handle delete error', async () => {
 		const mockSupabase = createMockSupabase();
 
-		mockSupabase._mockChain.eq.mockReturnValueOnce(mockSupabase._mockChain).mockResolvedValueOnce({
+		mockSupabase._mockChain.eq.mockResolvedValueOnce({
 			data: null,
 			error: { message: 'Delete failed', code: 'ERROR' }
 		});

--- a/src/lib/server/chapter-templates.ts
+++ b/src/lib/server/chapter-templates.ts
@@ -807,7 +807,6 @@ export async function instantiateTemplate(
 			.from('class_chapters')
 			.insert({
 				class_id: input.classId,
-				teacher_id: userId,
 				title: chapterTitle,
 				description: null,
 				is_visible: input.isVisible ?? false,

--- a/src/lib/server/chapters.ts
+++ b/src/lib/server/chapters.ts
@@ -79,7 +79,6 @@ function convertChapter(db: DbClassChapter): ClassChapter {
 	return {
 		id: db.id,
 		classId: db.class_id,
-		teacherId: db.teacher_id,
 		title: db.title,
 		description: db.description,
 		displayOrder: db.display_order,
@@ -198,7 +197,6 @@ export async function getTeacherChapters(
 			exercises:chapter_exercises(count)
 		`
 		)
-		.eq('teacher_id', teacherId)
 		.order('display_order', { ascending: true });
 
 	if (classId) {
@@ -237,10 +235,11 @@ export async function createChapter(
 	data: CreateChapterInput,
 	supabase: SupabaseClient<Database>
 ): Promise<OperationResult<ClassChapter>> {
-	// Get teacher_id from the class (required for DB type even though trigger sets it)
+	// Verify the class exists (chapter ownership is role-based via RLS now;
+	// class_chapters.teacher_id was dropped in the mono-teacher refactor).
 	const { data: classData, error: classError } = await supabase
 		.from('classes')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', data.classId)
 		.single();
 
@@ -267,7 +266,6 @@ export async function createChapter(
 		.from('class_chapters')
 		.insert({
 			class_id: data.classId,
-			teacher_id: classData.teacher_id,
 			title: data.title,
 			description: data.description ?? null,
 			display_order: displayOrder,

--- a/src/lib/server/exercise-assignments.ts
+++ b/src/lib/server/exercise-assignments.ts
@@ -1031,9 +1031,9 @@ export async function getAssignmentStats(
 	supabase: TypedSupabaseClient,
 	teacherId: string
 ): Promise<{ data: AssignmentStats | null; error: string | null }> {
-	const { data, error } = await callUnknownRpc(supabase, 'get_teacher_assignment_stats', {
-		p_teacher_id: teacherId
-	});
+	// Mono-teacher: the RPC scopes to the sole teacher via auth.uid().
+	void teacherId;
+	const { data, error } = await callUnknownRpc(supabase, 'get_teacher_assignment_stats', {});
 
 	if (error) {
 		console.error('Error fetching assignment stats:', error);

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -59,7 +59,6 @@ function convertJournalEntry(db: DbClassJournalEntry): ClassJournalEntry {
 	return {
 		id: db.id,
 		classId: db.class_id,
-		teacherId: db.teacher_id,
 		entryDate: db.entry_date,
 		lessonContent: db.lesson_content,
 		homeworkContent: db.homework_content,
@@ -78,25 +77,25 @@ function convertJournalEntry(db: DbClassJournalEntry): ClassJournalEntry {
  * Create a new journal entry
  *
  * @param supabase - Supabase client
- * @param teacherId - Teacher's user ID
+ * @param _teacherId - Unused (kept for API stability); ownership is role-based via RLS
  * @param input - Journal entry data
  * @returns Created journal entry
  */
 export async function createJournalEntry(
 	supabase: SupabaseClient<Database>,
-	teacherId: string,
+	_teacherId: string,
 	input: CreateJournalEntryInput
 ): Promise<OperationResult<ClassJournalEntry>> {
-	// Verify teacher owns the class
+	// Mono-teacher: the sole teacher/admin owns every class. RLS enforces write
+	// access on class_journal_entries; we just verify the class exists.
 	const { data: classData, error: classError } = await supabase
 		.from('classes')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', input.classId)
-		.eq('teacher_id', teacherId)
 		.single();
 
 	if (classError || !classData) {
-		console.error('[createJournalEntry] Teacher does not own class:', classError);
+		console.error('[createJournalEntry] Class not found:', classError);
 		return {
 			data: null,
 			error: new Error("Vous n'etes pas autorise a creer des entrees pour cette classe")
@@ -108,7 +107,6 @@ export async function createJournalEntry(
 		.from('class_journal_entries')
 		.insert({
 			class_id: input.classId,
-			teacher_id: teacherId,
 			entry_date: input.entryDate,
 			lesson_content: input.lessonContent ?? null,
 			homework_content: input.homeworkContent ?? null,
@@ -138,14 +136,14 @@ export async function createJournalEntry(
  *
  * @param supabase - Supabase client
  * @param entryId - Journal entry ID
- * @param teacherId - Teacher's user ID (for authorization)
+ * @param _teacherId - Unused (kept for API stability); ownership is role-based via RLS
  * @param input - Update data
  * @returns Updated journal entry
  */
 export async function updateJournalEntry(
 	supabase: SupabaseClient<Database>,
 	entryId: string,
-	teacherId: string,
+	_teacherId: string,
 	input: UpdateJournalEntryInput
 ): Promise<OperationResult<ClassJournalEntry>> {
 	// Build update object
@@ -162,7 +160,6 @@ export async function updateJournalEntry(
 		.from('class_journal_entries')
 		.update(updateData)
 		.eq('id', entryId)
-		.eq('teacher_id', teacherId)
 		.select()
 		.single();
 
@@ -193,19 +190,15 @@ export async function updateJournalEntry(
  *
  * @param supabase - Supabase client
  * @param entryId - Journal entry ID
- * @param teacherId - Teacher's user ID (for authorization)
+ * @param _teacherId - Unused (kept for API stability); ownership is role-based via RLS
  * @returns Success status
  */
 export async function deleteJournalEntry(
 	supabase: SupabaseClient<Database>,
 	entryId: string,
-	teacherId: string
+	_teacherId: string
 ): Promise<{ error: Error | null }> {
-	const { error } = await supabase
-		.from('class_journal_entries')
-		.delete()
-		.eq('id', entryId)
-		.eq('teacher_id', teacherId);
+	const { error } = await supabase.from('class_journal_entries').delete().eq('id', entryId);
 
 	if (error) {
 		console.error('[deleteJournalEntry] Error:', error);
@@ -319,14 +312,14 @@ export async function getJournalEntriesForWeek(
  * Get all journal entries for a teacher, optionally filtered by class
  *
  * @param supabase - Supabase client
- * @param teacherId - Teacher's user ID
+ * @param _teacherId - Unused (kept for API stability); ownership is role-based via RLS
  * @param classId - Optional class ID filter
  * @param limit - Max number of entries to return
  * @returns List of journal entries with class info
  */
 export async function getTeacherJournalEntries(
 	supabase: SupabaseClient<Database>,
-	teacherId: string,
+	_teacherId: string,
 	classId?: string,
 	limit: number = 50
 ): Promise<ListResult<JournalEntryWithClass>> {
@@ -338,7 +331,6 @@ export async function getTeacherJournalEntries(
 			class:classes!inner(name, level)
 		`
 		)
-		.eq('teacher_id', teacherId)
 		.order('entry_date', { ascending: false })
 		.limit(limit);
 

--- a/src/lib/server/kanban.ts
+++ b/src/lib/server/kanban.ts
@@ -489,19 +489,23 @@ export async function assertBoardAccess(
 }
 
 /**
- * Verify that `userId` is the teacher of `classId`. Returns true/false; the
+ * Verify that `userId` may manage `classId`'s board. Returns true/false; the
  * handler decides whether to throw 403 (when creating a class board) or
  * return a different code (e.g. 404 to mask existence).
+ *
+ * Mono-teacher: classes are no longer assigned to a teacher; the sole teacher
+ * (or admin) owns every class, so this is a role check.
  */
 export async function isClassTeacher(
 	supabase: AnySupabase,
 	classId: string,
 	userId: string
 ): Promise<boolean> {
+	void classId;
 	const { data, error: dbError } = await supabase
-		.from('classes')
-		.select('teacher_id')
-		.eq('id', classId)
+		.from('profiles')
+		.select('role')
+		.eq('id', userId)
 		.maybeSingle();
 
 	if (dbError) {
@@ -510,5 +514,6 @@ export async function isClassTeacher(
 	}
 
 	if (!data) return false;
-	return (data as { teacher_id: string }).teacher_id === userId;
+	const role = (data as { role: string }).role;
+	return role === 'teacher' || role === 'admin';
 }

--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -58,12 +58,9 @@ export async function createNotification(
 			}
 
 			if (data.target_type === 'class' && data.target_class_ids) {
-				// Verify teacher owns these classes (ownership lives on `classes.teacher_id`,
-				// not on `class_members` which only links students to classes)
-				const { data: teacherClasses } = await supabase
-					.from('classes')
-					.select('id')
-					.eq('teacher_id', createdBy);
+				// Mono-teacher: the sole teacher owns every class. Targets just have to
+				// reference existing classes.
+				const { data: teacherClasses } = await supabase.from('classes').select('id');
 
 				const teacherClassIds = teacherClasses?.map((c) => c.id) || [];
 				const invalidClasses = data.target_class_ids.filter((id) => !teacherClassIds.includes(id));
@@ -77,12 +74,9 @@ export async function createNotification(
 			}
 
 			if (data.target_type === 'users' && data.target_user_ids) {
-				// Verify teacher has access to these students: students enrolled in a class
-				// owned by this teacher (join class_members → classes.teacher_id)
-				const { data: teacherStudents } = await supabase
-					.from('class_members')
-					.select('student_id, classes!inner(teacher_id)')
-					.eq('classes.teacher_id', createdBy);
+				// Mono-teacher: every enrolled student is "ours". Targets just have to be
+				// students enrolled in some class.
+				const { data: teacherStudents } = await supabase.from('class_members').select('student_id');
 
 				const teacherStudentIds = teacherStudents?.map((cm) => cm.student_id) || [];
 				const invalidStudents = data.target_user_ids.filter(

--- a/src/lib/server/stats/teacher-class-auth.ts
+++ b/src/lib/server/stats/teacher-class-auth.ts
@@ -1,15 +1,17 @@
 /**
- * Garde d'autorisation : "prof propriétaire de la classe ou admin".
+ * Garde d'autorisation : "prof (unique) ou admin", pour une classe existante.
  *
- * Mutualise le check `classes.teacher_id = user.id` (ou admin) pour les
- * endpoints `/api/teacher/classes/[classId]/analytics/*`.
+ * Mono-prof : la classe n'est plus assignée à un prof (colonne `teacher_id`
+ * supprimée) ; le prof unique et l'admin possèdent toutes les classes. La garde
+ * de rôle suffit donc à l'autorisation. Utilisé par les endpoints
+ * `/api/teacher/classes/[classId]/analytics/*`.
  */
 
 import { error } from '@sveltejs/kit';
 import { requireRoles, type AuthResult } from '$lib/server/middleware/auth';
 
 export interface TeacherClassAuthResult extends AuthResult {
-	classRow: { id: string; teacher_id: string; name: string; grade: string | null };
+	classRow: { id: string; name: string; grade: string | null };
 }
 
 export async function requireTeacherOfClass(
@@ -20,18 +22,12 @@ export async function requireTeacherOfClass(
 
 	const { data: classRow, error: classErr } = await locals.supabase
 		.from('classes')
-		.select('id, teacher_id, name, grade')
+		.select('id, name, grade')
 		.eq('id', classId)
 		.maybeSingle();
 
 	if (classErr || !classRow) {
 		throw error(404, 'Classe introuvable');
-	}
-
-	const isOwner = classRow.teacher_id === user.id;
-	const isAdmin = profile.role === 'admin';
-	if (!isOwner && !isAdmin) {
-		throw error(403, 'Vous n’êtes pas le professeur de cette classe');
 	}
 
 	return { user, profile, classRow };

--- a/src/lib/server/students.ts
+++ b/src/lib/server/students.ts
@@ -63,7 +63,6 @@ export interface StudentFull extends Student {
  */
 export interface ClassWithStudents {
 	id: string;
-	teacher_id: string;
 	name: string;
 	description: string | null;
 	join_code: string;
@@ -78,7 +77,6 @@ export interface ClassWithStudents {
  */
 export interface ClassWithData {
 	id: string;
-	teacher_id: string;
 	name: string;
 	description: string | null;
 	join_code: string;
@@ -90,7 +88,6 @@ export interface ClassWithData {
 	schedules: Array<{
 		id: string;
 		class_id: string;
-		teacher_id: string;
 		day_of_week: number;
 		start_time: string;
 		end_time: string;
@@ -256,12 +253,10 @@ export async function getTeacherClassesWithStudents(
 	// Get teacher's test mode preference
 	const isTestMode = await getTeacherTestMode(userId, supabase);
 
-	// Call optimized RPC function
-	// Note: p_is_test_mode parameter exists in the database but types may be stale
+	// Call optimized RPC function (mono-teacher: scoped to the sole teacher via auth.uid())
 	const { data, error } = await supabase.rpc('get_teacher_classes_with_students', {
-		p_teacher_id: userId,
 		p_is_test_mode: isTestMode
-	} as unknown as { p_teacher_id: string });
+	});
 
 	if (error) {
 		console.error('[getTeacherClassesWithStudents] Error fetching classes:', error);
@@ -295,12 +290,10 @@ export async function getTeacherClassesWithCounts(
 	// Get teacher's test mode preference
 	const isTestMode = await getTeacherTestMode(userId, supabase);
 
-	// Call optimized RPC function
-	// Note: p_is_test_mode parameter exists in the database but types may be stale
+	// Call optimized RPC function (mono-teacher: scoped to the sole teacher via auth.uid())
 	const { data, error } = await supabase.rpc('get_teacher_classes_with_data', {
-		p_teacher_id: userId,
 		p_is_test_mode: isTestMode
-	} as unknown as { p_teacher_id: string });
+	});
 
 	if (error) {
 		console.error('[getTeacherClassesWithCounts] Error fetching classes:', error);

--- a/src/lib/server/vip-card-queries.ts
+++ b/src/lib/server/vip-card-queries.ts
@@ -253,11 +253,10 @@ export async function getPendingActivationRequests(
 	supabase: SupabaseClient<Database>,
 	teacherId: string
 ): Promise<VipCardActivationRequest[]> {
-	// Step 1: Get all class IDs where teacher teaches
-	const { data: teacherClasses, error: classesError } = await supabase
-		.from('classes')
-		.select('id')
-		.eq('teacher_id', teacherId);
+	// Step 1: Get all class IDs (mono-teacher: the sole teacher owns every class;
+	// RLS already scopes reads to the teacher/admin).
+	void teacherId;
+	const { data: teacherClasses, error: classesError } = await supabase.from('classes').select('id');
 
 	if (classesError) {
 		console.error('❌ [vip-card-queries] Error fetching teacher classes:', classesError);

--- a/src/lib/server/warnings.ts
+++ b/src/lib/server/warnings.ts
@@ -160,14 +160,14 @@ export async function getClassWarnings(options: {
 	teacherId: string;
 	supabase: SupabaseClient<Database>;
 }): Promise<ClassWarningsMap> {
-	const { classId, periodId, teacherId, supabase } = options;
+	const { classId, periodId, supabase } = options;
 
-	// Verify teacher owns the class (will fail if not via RLS)
+	// Mono-teacher: the sole teacher/admin owns every class; RLS enforces access.
+	// Just verify the class exists.
 	const { data: classCheck, error: classError } = await supabase
 		.from('classes')
 		.select('id')
 		.eq('id', classId)
-		.eq('teacher_id', teacherId)
 		.maybeSingle();
 
 	if (classError) {

--- a/src/lib/stores/teacherDashboardCache.svelte.ts
+++ b/src/lib/stores/teacherDashboardCache.svelte.ts
@@ -375,7 +375,6 @@ export class TeacherDashboardCache {
 			// Convert ClassInfo to ClassWithData format
 			classes.push({
 				id: cached.classInfo.id,
-				teacher_id: cached.classInfo.teacher_id,
 				name: cached.classInfo.name,
 				description: cached.classInfo.description,
 				join_code: cached.classInfo.join_code,

--- a/src/lib/types/chapters.ts
+++ b/src/lib/types/chapters.ts
@@ -135,7 +135,6 @@ export type ChapterColor =
 export interface ClassChapter {
 	id: string;
 	classId: string;
-	teacherId: string;
 	title: string;
 	description: string | null;
 	displayOrder: number;
@@ -339,7 +338,6 @@ export function dbChapterToApp(db: DbClassChapter): ClassChapter {
 	return {
 		id: db.id,
 		classId: db.class_id,
-		teacherId: db.teacher_id,
 		title: db.title,
 		description: db.description,
 		displayOrder: db.display_order,

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -1374,7 +1394,6 @@ export type Database = {
           icon: string | null
           id: string
           is_visible: boolean
-          teacher_id: string
           title: string
           updated_at: string
         }
@@ -1387,7 +1406,6 @@ export type Database = {
           icon?: string | null
           id?: string
           is_visible?: boolean
-          teacher_id: string
           title: string
           updated_at?: string
         }
@@ -1400,7 +1418,6 @@ export type Database = {
           icon?: string | null
           id?: string
           is_visible?: boolean
-          teacher_id?: string
           title?: string
           updated_at?: string
         }
@@ -1411,34 +1428,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "classes"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_chapters_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "class_chapters_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "class_chapters_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_chapters_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
         ]
       }
@@ -1519,7 +1508,6 @@ export type Database = {
           id: string
           is_published: boolean
           lesson_content: string | null
-          teacher_id: string
           updated_at: string
         }
         Insert: {
@@ -1531,7 +1519,6 @@ export type Database = {
           id?: string
           is_published?: boolean
           lesson_content?: string | null
-          teacher_id: string
           updated_at?: string
         }
         Update: {
@@ -1543,7 +1530,6 @@ export type Database = {
           id?: string
           is_published?: boolean
           lesson_content?: string | null
-          teacher_id?: string
           updated_at?: string
         }
         Relationships: [
@@ -1553,34 +1539,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "classes"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_journal_entries_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "class_journal_entries_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "class_journal_entries_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_journal_entries_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
         ]
       }
@@ -1656,7 +1614,6 @@ export type Database = {
           room: string | null
           start_time: string
           subject: string | null
-          teacher_id: string
           updated_at: string
         }
         Insert: {
@@ -1670,7 +1627,6 @@ export type Database = {
           room?: string | null
           start_time: string
           subject?: string | null
-          teacher_id: string
           updated_at?: string
         }
         Update: {
@@ -1684,7 +1640,6 @@ export type Database = {
           room?: string | null
           start_time?: string
           subject?: string | null
-          teacher_id?: string
           updated_at?: string
         }
         Relationships: [
@@ -1694,34 +1649,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "classes"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_schedules_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "class_schedules_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "class_schedules_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "class_schedules_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
         ]
       }
@@ -1736,7 +1663,6 @@ export type Database = {
           join_code: string
           name: string
           school_id: string | null
-          teacher_id: string
           tutor_config: Json | null
           updated_at: string
         }
@@ -1750,7 +1676,6 @@ export type Database = {
           join_code: string
           name: string
           school_id?: string | null
-          teacher_id: string
           tutor_config?: Json | null
           updated_at?: string
         }
@@ -1764,7 +1689,6 @@ export type Database = {
           join_code?: string
           name?: string
           school_id?: string | null
-          teacher_id?: string
           tutor_config?: Json | null
           updated_at?: string
         }
@@ -1782,34 +1706,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "schools"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "classes_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "classes_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "classes_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "classes_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
         ]
       }
@@ -2650,7 +2546,6 @@ export type Database = {
           name: string
           niveau_scolaire: string
           task_date: string | null
-          teacher_id: string
           updated_at: string
           worksheet_id: string | null
         }
@@ -2664,7 +2559,6 @@ export type Database = {
           name: string
           niveau_scolaire: string
           task_date?: string | null
-          teacher_id: string
           updated_at?: string
           worksheet_id?: string | null
         }
@@ -2678,7 +2572,6 @@ export type Database = {
           name?: string
           niveau_scolaire?: string
           task_date?: string | null
-          teacher_id?: string
           updated_at?: string
           worksheet_id?: string | null
         }
@@ -2703,34 +2596,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "exercises"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "evaluation_tasks_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "evaluation_tasks_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "evaluation_tasks_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "evaluation_tasks_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
           {
             foreignKeyName: "evaluation_tasks_worksheet_id_fkey"
@@ -4236,7 +4101,6 @@ export type Database = {
           is_active: boolean
           name: string
           starts_at: string
-          teacher_id: string
           updated_at: string
         }
         Insert: {
@@ -4249,7 +4113,6 @@ export type Database = {
           is_active?: boolean
           name: string
           starts_at: string
-          teacher_id: string
           updated_at?: string
         }
         Update: {
@@ -4262,7 +4125,6 @@ export type Database = {
           is_active?: boolean
           name?: string
           starts_at?: string
-          teacher_id?: string
           updated_at?: string
         }
         Relationships: [
@@ -4272,34 +4134,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "classes"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "game_timeslots_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "assessment_results"
-            referencedColumns: ["student_user_id"]
-          },
-          {
-            foreignKeyName: "game_timeslots_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "minesweeper_student_achievement_progress"
-            referencedColumns: ["student_id"]
-          },
-          {
-            foreignKeyName: "game_timeslots_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "game_timeslots_teacher_id_fkey"
-            columns: ["teacher_id"]
-            isOneToOne: false
-            referencedRelation: "riddle_progress"
-            referencedColumns: ["student_id"]
           },
         ]
       }
@@ -15627,12 +15461,6 @@ export type Database = {
           view_count: number
         }[]
       }
-      get_student_teachers: {
-        Args: { student_uuid: string }
-        Returns: {
-          teacher_id: string
-        }[]
-      }
       get_student_week_best: {
         Args: { p_school_id: string; p_student_id: string }
         Returns: {
@@ -15660,7 +15488,7 @@ export type Database = {
         }[]
       }
       get_teacher_assignment_stats: {
-        Args: { p_teacher_id: string }
+        Args: never
         Returns: {
           active_assignments: number
           class_assignments: number
@@ -15672,7 +15500,7 @@ export type Database = {
         }[]
       }
       get_teacher_classes_for_messaging: {
-        Args: { p_teacher_id: string }
+        Args: never
         Returns: {
           class_id: string
           class_name: string
@@ -15680,7 +15508,7 @@ export type Database = {
         }[]
       }
       get_teacher_classes_with_data: {
-        Args: { p_is_test_mode?: boolean; p_teacher_id: string }
+        Args: { p_is_test_mode?: boolean }
         Returns: {
           created_at: string
           description: string
@@ -15691,12 +15519,11 @@ export type Database = {
           name: string
           schedules: Json
           student_count: number
-          teacher_id: string
           updated_at: string
         }[]
       }
       get_teacher_classes_with_students: {
-        Args: { p_is_test_mode?: boolean; p_teacher_id: string }
+        Args: { p_is_test_mode?: boolean }
         Returns: {
           created_at: string
           description: string
@@ -15705,7 +15532,6 @@ export type Database = {
           join_code: string
           name: string
           students: Json
-          teacher_id: string
           updated_at: string
         }[]
       }
@@ -15753,12 +15579,6 @@ export type Database = {
           no_override_count: number
           rarity: string
           total_cards: number
-        }[]
-      }
-      get_teacher_students: {
-        Args: { teacher_uuid: string }
-        Returns: {
-          student_id: string
         }[]
       }
       get_template_statistics: {
@@ -16766,6 +16586,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       consent_status: ["pending", "granted", "expired"],
@@ -16817,3 +16640,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -316,7 +316,6 @@ export interface GameLeaderboard {
 export interface GameTimeslot {
 	id: string;
 	class_id: string;
-	teacher_id: string;
 	name: string;
 	challenge_ids: string[];
 	difficulty: number; // 1-5

--- a/src/lib/types/journal.ts
+++ b/src/lib/types/journal.ts
@@ -48,7 +48,6 @@ export type DbClassJournalEntryUpdate =
 export interface ClassJournalEntry {
 	id: string;
 	classId: string;
-	teacherId: string;
 	entryDate: string; // DATE format YYYY-MM-DD
 	lessonContent: string | null;
 	homeworkContent: string | null;

--- a/src/lib/types/teacher-cache.ts
+++ b/src/lib/types/teacher-cache.ts
@@ -47,7 +47,6 @@ export interface StudentRewards {
 export interface ClassSchedule {
 	id: string;
 	class_id: string;
-	teacher_id: string;
 	day_of_week: number;
 	period_number: number | null;
 	start_time: string;
@@ -64,7 +63,6 @@ export interface ClassSchedule {
  */
 export interface ClassInfo {
 	id: string;
-	teacher_id: string;
 	name: string;
 	description: string | null;
 	join_code: string;

--- a/src/routes/(protected)/dashboard/admin/classes/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/classes/+page.server.ts
@@ -17,26 +17,13 @@ export const load: PageServerLoad = async ({ locals }) => {
 		throw error(500, 'Failed to load schools');
 	}
 
-	// Fetch all teachers (for teacher assignment dropdown)
-	const { data: teachers, error: teachersError } = await supabase
-		.from('profiles')
-		.select('id, firstname, lastname, email, school_id')
-		.eq('role', 'teacher')
-		.order('lastname')
-		.order('firstname');
-
-	if (teachersError) {
-		console.error('Error fetching teachers:', teachersError);
-		throw error(500, 'Failed to load teachers');
-	}
-
-	// Fetch all classes with teacher and school info
+	// Mono-teacher: classes are no longer assigned to a teacher (teacher_id dropped).
+	// Fetch all classes with school info.
 	const { data: classes, error: classesError } = await supabase
 		.from('classes')
 		.select(
 			`
 			*,
-			teacher:profiles!classes_teacher_id_fkey(id, firstname, lastname, email),
 			school:schools(id, name)
 		`
 		)
@@ -68,7 +55,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	return {
 		schools: schools || [],
-		teachers: teachers || [],
 		classes: classesWithCounts || []
 	};
 };
@@ -89,21 +75,6 @@ export const actions: Actions = {
 		if (!name) {
 			return fail(400, { message: 'Name is required' });
 		}
-
-		// Single-teacher invariant: always assign the sole teacher (any client value ignored).
-		const { data: soleTeacher, error: teacherError } = await supabase
-			.from('profiles')
-			.select('id')
-			.eq('role', 'teacher')
-			.maybeSingle();
-
-		if (teacherError || !soleTeacher) {
-			console.error('Error resolving sole teacher:', teacherError);
-			return fail(400, {
-				message: 'Aucun professeur trouvé pour assigner la classe (configuration mono-professeur).'
-			});
-		}
-		const teacher_id = soleTeacher.id;
 
 		// Generate or use custom join code
 		let join_code = custom_join_code?.trim().toUpperCase();
@@ -141,7 +112,6 @@ export const actions: Actions = {
 		const { error: insertError } = await supabase.from('classes').insert({
 			name,
 			description: description || null,
-			teacher_id,
 			school_id: school_id || null,
 			grade: grade || null,
 			join_code,
@@ -173,7 +143,6 @@ export const actions: Actions = {
 		if (!id || !name) {
 			return fail(400, { message: 'ID and name are required' });
 		}
-		// Single-teacher invariant: teacher_id is never changed on update (stays the sole teacher).
 
 		// If join code changed, validate it's unique
 		const { data: currentClass, error: fetchError } = await supabase

--- a/src/routes/(protected)/dashboard/admin/classes/+page.svelte
+++ b/src/routes/(protected)/dashboard/admin/classes/+page.svelte
@@ -42,17 +42,6 @@
 			.filter((c) => !showActiveOnly || c.is_active)
 	);
 
-	// Get teacher display name
-	function getTeacherName(
-		teacher: { firstname?: string; lastname?: string; email?: string } | null
-	): string {
-		if (!teacher) return '—';
-		if (teacher.firstname && teacher.lastname) {
-			return `${teacher.firstname} ${teacher.lastname}`;
-		}
-		return teacher.email || '—';
-	}
-
 	// Items for MySelect components
 	let schoolFilterItems = $derived([
 		{ value: '', label: 'Toutes les écoles' },
@@ -211,11 +200,6 @@
 						<th
 							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase"
 						>
-							Enseignant
-						</th>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase"
-						>
 							Étudiants
 						</th>
 						<th
@@ -267,11 +251,6 @@
 											<Copy class="h-4 w-4" />
 										{/if}
 									</button>
-								</div>
-							</td>
-							<td class="px-6 py-4 whitespace-nowrap">
-								<div class="text-sm text-muted-foreground">
-									{getTeacherName(classItem.teacher)}
 								</div>
 							</td>
 							<td class="px-6 py-4 whitespace-nowrap">
@@ -489,14 +468,6 @@
 									placeholder="Aucune école"
 									triggerClass="h-9 w-full rounded-md border border-input bg-background px-3 text-sm inline-flex items-center justify-between"
 								/>
-							</div>
-
-							<!-- Teacher -->
-							<div>
-								<span class="mb-1 block text-sm font-medium text-foreground">Enseignant</span>
-								<p class="text-sm text-muted-foreground">
-									{data.teachers[0] ? getTeacherName(data.teachers[0]) : '—'} — assigné automatiquement
-								</p>
 							</div>
 
 							<!-- Grade -->

--- a/src/routes/(protected)/dashboard/admin/notifications/+page.server.ts
+++ b/src/routes/(protected)/dashboard/admin/notifications/+page.server.ts
@@ -23,7 +23,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	// Get all classes
 	const { data: classes } = await supabase
 		.from('classes')
-		.select('id, name, teacher_id')
+		.select('id, name')
 		.eq('is_active', true)
 		.order('name');
 

--- a/src/routes/(protected)/dashboard/student/+layout.server.ts
+++ b/src/routes/(protected)/dashboard/student/+layout.server.ts
@@ -45,7 +45,9 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	}
 
 	try {
-		// Fetch class memberships with class and teacher details
+		// Fetch class memberships with class details. Mono-teacher: classes are no
+		// longer linked to a teacher (teacher_id dropped), so the teacher is resolved
+		// once below — every class is taught by the sole teacher.
 		const { data: memberships, error: membershipError } = await supabase
 			.from('class_members')
 			.select(
@@ -55,11 +57,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 				classes:class_id (
 					id,
 					name,
-					is_active,
-					teacher:teacher_id (
-						id,
-						full_name
-					)
+					is_active
 				)
 			`
 			)
@@ -72,18 +70,24 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			// Non-critical - continue with empty classes
 		}
 
+		// Mono-teacher: resolve the sole teacher once for display attribution.
+		const { data: soleTeacher } = await supabase
+			.from('profiles')
+			.select('id, full_name')
+			.eq('role', 'teacher')
+			.maybeSingle();
+
 		// Transform to ClassMembership[]
 		const classes: ClassMembership[] = (memberships || [])
 			.filter((m) => m.classes)
 			.map((m) => {
-				// Handle case where classes or teacher might be arrays
+				// Handle case where classes might be an array
 				const classData = Array.isArray(m.classes) ? m.classes[0] : m.classes;
-				const teacher = Array.isArray(classData.teacher) ? classData.teacher[0] : classData.teacher;
 				return {
 					class_id: m.class_id,
 					class_name: classData.name,
-					teacher_name: teacher?.full_name || 'Unknown Teacher',
-					teacher_id: teacher?.id || '',
+					teacher_name: soleTeacher?.full_name || 'Unknown Teacher',
+					teacher_id: soleTeacher?.id || '',
 					joined_at: m.joined_at,
 					is_active: classData.is_active
 				};

--- a/src/routes/(protected)/dashboard/student/cours/+page.server.ts
+++ b/src/routes/(protected)/dashboard/student/cours/+page.server.ts
@@ -42,7 +42,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		throw error(500, 'Erreur lors du chargement des chapitres');
 	}
 
-	// Get student's class memberships with class details
+	// Get student's class memberships with class details.
+	// Mono-teacher: teacher_id was dropped from classes; resolve the sole teacher once below.
 	const { data: memberships, error: membershipError } = await locals.supabase
 		.from('class_members')
 		.select(
@@ -50,10 +51,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 			class_id,
 			classes:class_id (
 				id,
-				name,
-				teacher:teacher_id (
-					full_name
-				)
+				name
 			)
 		`
 		)
@@ -64,6 +62,13 @@ export const load: PageServerLoad = async ({ locals }) => {
 		console.error('[Student Cours] Error fetching memberships:', membershipError);
 	}
 
+	// Resolve the sole teacher once for display attribution.
+	const { data: soleTeacher } = await locals.supabase
+		.from('profiles')
+		.select('id, full_name')
+		.eq('role', 'teacher')
+		.maybeSingle();
+
 	// Build class info map and set of enrolled class IDs
 	const classMap = new Map<string, { className: string; teacherName: string }>();
 	const enrolledClassIds = new Set<string>();
@@ -71,10 +76,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 	for (const m of memberships || []) {
 		const classData = Array.isArray(m.classes) ? m.classes[0] : m.classes;
 		if (classData) {
-			const teacher = Array.isArray(classData.teacher) ? classData.teacher[0] : classData.teacher;
 			classMap.set(m.class_id, {
 				className: classData.name,
-				teacherName: teacher?.full_name || 'Professeur'
+				teacherName: soleTeacher?.full_name || 'Professeur'
 			});
 			enrolledClassIds.add(m.class_id);
 		}
@@ -86,7 +90,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		.map((row) => ({
 			id: row.id,
 			classId: row.class_id,
-			teacherId: row.teacher_id,
+			teacherId: soleTeacher?.id || '',
 			title: row.title,
 			description: row.description,
 			displayOrder: row.display_order,

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/+page.server.ts
@@ -27,13 +27,12 @@ function getWeekStart(date: Date = new Date()): string {
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	// Only teachers can view this page
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Get teacher's classes
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
 		.select('id, name, grade, is_active')
-		.eq('teacher_id', user.id)
 		.order('name');
 
 	if (classesError) {

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
@@ -33,7 +33,7 @@ const dateParamSchema = z
 
 export const load: PageServerLoad = async ({ locals, params }) => {
 	// Only teachers can view this page
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	const { classId, date } = params;
 
@@ -53,7 +53,6 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		.from('classes')
 		.select('id, name, grade')
 		.eq('id', classId)
-		.eq('teacher_id', user.id)
 		.single();
 
 	if (classError || !classData) {
@@ -78,7 +77,6 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		? {
 				id: existingEntry.id,
 				classId: existingEntry.class_id,
-				teacherId: existingEntry.teacher_id,
 				entryDate: existingEntry.entry_date,
 				lessonContent: existingEntry.lesson_content,
 				homeworkContent: existingEntry.homework_content,

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
@@ -208,11 +208,11 @@ export const load: PageServerLoad = async ({ locals }) => {
 		.eq('course_state', 'ACTIVE')
 		.order('name');
 
-	// Fetch which courses are already associated with classes (for filtering)
+	// Fetch which courses are already associated with classes (for filtering).
+	// Mono-teacher: the sole teacher owns every class; RLS scopes the read.
 	const { data: associatedCourseIds } = await supabase
 		.from('classes')
 		.select('google_classroom_course_id')
-		.eq('teacher_id', user.id)
 		.not('google_classroom_course_id', 'is', null);
 
 	// Single-teacher (Option B): students not enrolled in any active class.
@@ -276,10 +276,11 @@ export const actions: Actions = {
 			notes
 		} = validation.data;
 
-		// Verify teacher owns this class
+		// Mono-teacher: the sole teacher/admin owns every class; RLS enforces write
+		// access. Just verify the class exists.
 		const { data: classData, error: classError } = await supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', classId)
 			.single();
 
@@ -287,14 +288,9 @@ export const actions: Actions = {
 			return fail(404, { message: 'Class not found' });
 		}
 
-		if (classData.teacher_id !== user.id) {
-			return fail(403, { message: 'You do not own this class' });
-		}
-
 		// Insert schedule entry
 		const { error: insertError } = await supabase.from('class_schedules').insert({
 			class_id: classId,
-			teacher_id: user.id,
 			day_of_week: dayOfWeek,
 			period_number: periodNumber,
 			start_time: startTime,
@@ -351,19 +347,16 @@ export const actions: Actions = {
 			notes
 		} = validation.data;
 
-		// Verify teacher owns this schedule entry
+		// Mono-teacher: the sole teacher/admin owns every schedule entry; RLS enforces
+		// write access. Just verify the entry exists.
 		const { data: scheduleData, error: scheduleError } = await supabase
 			.from('class_schedules')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', id)
 			.single();
 
 		if (scheduleError || !scheduleData) {
 			return fail(404, { message: 'Schedule entry not found' });
-		}
-
-		if (scheduleData.teacher_id !== user.id) {
-			return fail(403, { message: 'You do not own this schedule entry' });
 		}
 
 		// Update schedule entry
@@ -416,19 +409,16 @@ export const actions: Actions = {
 
 		const { id } = validation.data;
 
-		// Verify teacher owns this schedule entry
+		// Mono-teacher: the sole teacher/admin owns every schedule entry; RLS enforces
+		// write access. Just verify the entry exists.
 		const { data: scheduleData, error: scheduleError } = await supabase
 			.from('class_schedules')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', id)
 			.single();
 
 		if (scheduleError || !scheduleData) {
 			return fail(404, { message: 'Schedule entry not found' });
-		}
-
-		if (scheduleData.teacher_id !== user.id) {
-			return fail(403, { message: 'You do not own this schedule entry' });
 		}
 
 		// Delete schedule entry
@@ -468,19 +458,16 @@ export const actions: Actions = {
 
 		const { classId, courseId } = validation.data;
 
-		// Verify teacher owns this class
+		// Mono-teacher: the sole teacher/admin owns every class; RLS enforces write
+		// access. Just verify the class exists.
 		const { data: classData, error: classError } = await locals.supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', classId)
 			.single();
 
 		if (classError || !classData) {
 			return fail(404, { message: 'Classe introuvable' });
-		}
-
-		if (classData.teacher_id !== user.id) {
-			return fail(403, { message: 'Vous ne possédez pas cette classe' });
 		}
 
 		// If courseId provided, verify teacher owns this course
@@ -500,12 +487,11 @@ export const actions: Actions = {
 			}
 		}
 
-		// Update the class
+		// Update the class (mono-teacher: RLS scopes write access to the teacher/admin)
 		const { error: updateError } = await locals.supabase
 			.from('classes')
 			.update({ google_classroom_course_id: courseId })
-			.eq('id', classId)
-			.eq('teacher_id', user.id);
+			.eq('id', classId);
 
 		if (updateError) {
 			console.error('Error updating class association:', updateError);

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
@@ -72,7 +72,6 @@
 		for (const classItem of data.classes) {
 			const classInfo = {
 				id: classItem.id,
-				teacher_id: classItem.teacher_id,
 				name: classItem.name,
 				description: classItem.description,
 				join_code: classItem.join_code,
@@ -291,7 +290,6 @@
 		const optimisticEntry: ClassSchedule = {
 			id: `temp-${entryKey}`, // Temporary ID
 			class_id: classId,
-			teacher_id: data.profile.id,
 			day_of_week: day,
 			start_time: period.start_time,
 			end_time: period.end_time,

--- a/src/routes/(protected)/dashboard/teacher/consent/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/consent/+page.server.ts
@@ -55,7 +55,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const { data: classes, error: classError } = await supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 

--- a/src/routes/(protected)/dashboard/teacher/contenu/templates/[templateId]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/contenu/templates/[templateId]/+page.server.ts
@@ -50,7 +50,6 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	const { data: classes } = await locals.supabase
 		.from('classes')
 		.select('id, name, grade, is_active')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 
@@ -224,14 +223,14 @@ export const actions: Actions = {
 			});
 		}
 
-		// Verify class ownership
+		// Verify class exists
 		const { data: classCheck } = await locals.supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', validation.data.classId)
 			.single();
 
-		if (!classCheck || classCheck.teacher_id !== user.id) {
+		if (!classCheck) {
 			return fail(403, { error: 'Accès refusé', action: 'instantiate' });
 		}
 

--- a/src/routes/(protected)/dashboard/teacher/cours/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cours/+page.server.ts
@@ -37,7 +37,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
 		.select('id, name, is_active')
-		.eq('teacher_id', user.id)
 		.order('name');
 
 	if (classesError) {

--- a/src/routes/(protected)/dashboard/teacher/cours/[classId]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cours/[classId]/+page.server.ts
@@ -32,12 +32,11 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
 	const { classId } = params;
 
-	// Verify teacher owns this class
+	// Verify class exists
 	const { data: classData, error: classError } = await locals.supabase
 		.from('classes')
 		.select('id, name, is_active')
 		.eq('id', classId)
-		.eq('teacher_id', user.id)
 		.single();
 
 	if (classError || !classData) {
@@ -106,15 +105,14 @@ export const actions: Actions = {
 	 * Create a new chapter
 	 */
 	create: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { classId } = params;
 
-		// Verify teacher owns this class
+		// Verify class exists
 		const { data: classData } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!classData) {
@@ -158,18 +156,17 @@ export const actions: Actions = {
 	 * Update an existing chapter
 	 */
 	update: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { classId } = params;
 
 		const formData = await request.formData();
 		const chapterId = formData.get('chapterId') as string;
 
-		// Verify teacher owns this chapter
+		// Verify chapter exists and belongs to this class
 		const { data: chapterData } = await locals.supabase
 			.from('class_chapters')
 			.select('id, class_id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapterData || chapterData.class_id !== classId) {
@@ -211,18 +208,17 @@ export const actions: Actions = {
 	 * Delete a chapter
 	 */
 	delete: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { classId } = params;
 
 		const formData = await request.formData();
 		const chapterId = formData.get('chapterId') as string;
 
-		// Verify teacher owns this chapter
+		// Verify chapter exists and belongs to this class
 		const { data: chapterData } = await locals.supabase
 			.from('class_chapters')
 			.select('id, class_id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapterData || chapterData.class_id !== classId) {
@@ -244,15 +240,14 @@ export const actions: Actions = {
 	 * Reorder chapters
 	 */
 	reorder: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { classId } = params;
 
-		// Verify teacher owns this class
+		// Verify class exists
 		const { data: classData } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!classData) {
@@ -300,19 +295,18 @@ export const actions: Actions = {
 	 * Toggle chapter visibility
 	 */
 	toggleVisibility: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { classId } = params;
 
 		const formData = await request.formData();
 		const chapterId = formData.get('chapterId') as string;
 		const isVisible = formData.get('isVisible') === 'true';
 
-		// Verify teacher owns this chapter
+		// Verify chapter exists and belongs to this class
 		const { data: chapterData } = await locals.supabase
 			.from('class_chapters')
 			.select('id, class_id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapterData || chapterData.class_id !== classId) {
@@ -337,12 +331,11 @@ export const actions: Actions = {
 		const { user } = await requireRole(locals, 'teacher');
 		const { classId } = params;
 
-		// Verify teacher owns this class
+		// Verify class exists
 		const { data: classData } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!classData) {

--- a/src/routes/(protected)/dashboard/teacher/cours/[classId]/[chapterId]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cours/[classId]/[chapterId]/+page.server.ts
@@ -47,12 +47,11 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	const { user } = await requireRole(locals, 'teacher');
 	const { classId, chapterId } = params;
 
-	// Verify teacher owns this chapter
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await locals.supabase
 		.from('class_chapters')
 		.select('*')
 		.eq('id', chapterId)
-		.eq('teacher_id', user.id)
 		.single();
 
 	if (chapterError || !chapter) {
@@ -190,7 +189,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	const { data: availableExercises } = await locals.supabase
 		.from('exercises')
 		.select('id, title, description')
-		.eq('teacher_id', user.id)
+		.eq('created_by', user.id)
 		.order('created_at', { ascending: false })
 		.limit(100);
 
@@ -227,7 +226,6 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		chapter: {
 			id: chapter.id,
 			classId: chapter.class_id,
-			teacherId: chapter.teacher_id,
 			title: chapter.title,
 			description: chapter.description,
 			displayOrder: chapter.display_order,
@@ -257,15 +255,14 @@ export const actions: Actions = {
 	// ============ CHECKLIST ACTIONS ============
 
 	addChecklistItem: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -293,20 +290,19 @@ export const actions: Actions = {
 	},
 
 	updateChecklistItem: async ({ request, locals, params: _params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const itemId = formData.get('itemId') as string;
 
-		// Verify ownership via chapter
+		// Verify item exists (RLS enforces ownership)
 		const { data: item } = await locals.supabase
 			.from('chapter_checklist_items')
-			.select('id, chapter:chapter_id!inner(teacher_id)')
+			.select('id')
 			.eq('id', itemId)
 			.single();
 
-		const chapterData = item?.chapter as unknown as { teacher_id: string } | null;
-		if (!item || chapterData?.teacher_id !== user.id) {
+		if (!item) {
 			return fail(403, { error: 'Acces refuse', action: 'updateChecklistItem' });
 		}
 
@@ -339,20 +335,19 @@ export const actions: Actions = {
 	},
 
 	deleteChecklistItem: async ({ request, locals }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const itemId = formData.get('itemId') as string;
 
-		// Verify ownership
+		// Verify item exists (RLS enforces ownership)
 		const { data: item } = await locals.supabase
 			.from('chapter_checklist_items')
-			.select('id, chapter:chapter_id!inner(teacher_id)')
+			.select('id')
 			.eq('id', itemId)
 			.single();
 
-		const chapterData = item?.chapter as unknown as { teacher_id: string } | null;
-		if (!item || chapterData?.teacher_id !== user.id) {
+		if (!item) {
 			return fail(403, { error: 'Acces refuse', action: 'deleteChecklistItem' });
 		}
 
@@ -368,15 +363,14 @@ export const actions: Actions = {
 	// ============ QUIZ ACTIONS ============
 
 	addQuizQuestion: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -404,20 +398,19 @@ export const actions: Actions = {
 	},
 
 	removeQuizQuestion: async ({ request, locals }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const quizQuestionId = formData.get('quizQuestionId') as string;
 
-		// Verify ownership
+		// Verify question exists (RLS enforces ownership)
 		const { data: question } = await locals.supabase
 			.from('chapter_quiz_questions')
-			.select('id, chapter:chapter_id!inner(teacher_id)')
+			.select('id')
 			.eq('id', quizQuestionId)
 			.single();
 
-		const chapterData = question?.chapter as unknown as { teacher_id: string } | null;
-		if (!question || chapterData?.teacher_id !== user.id) {
+		if (!question) {
 			return fail(403, { error: 'Acces refuse', action: 'removeQuizQuestion' });
 		}
 
@@ -433,15 +426,14 @@ export const actions: Actions = {
 	// ============ EXERCISE ACTIONS ============
 
 	linkExercise: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -465,20 +457,19 @@ export const actions: Actions = {
 	},
 
 	unlinkExercise: async ({ request, locals }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const chapterExerciseId = formData.get('chapterExerciseId') as string;
 
-		// Verify ownership
+		// Verify link exists (RLS enforces ownership)
 		const { data: link } = await locals.supabase
 			.from('chapter_exercises')
-			.select('id, chapter:chapter_id!inner(teacher_id)')
+			.select('id')
 			.eq('id', chapterExerciseId)
 			.single();
 
-		const chapterData = link?.chapter as unknown as { teacher_id: string } | null;
-		if (!link || chapterData?.teacher_id !== user.id) {
+		if (!link) {
 			return fail(403, { error: 'Acces refuse', action: 'unlinkExercise' });
 		}
 
@@ -494,15 +485,14 @@ export const actions: Actions = {
 	// ============ DOCUMENT ACTIONS ============
 
 	uploadDocument: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -588,15 +578,14 @@ export const actions: Actions = {
 	},
 
 	addGoogleDriveDocument: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -653,7 +642,7 @@ export const actions: Actions = {
 	},
 
 	deleteDocument: async ({ request, locals }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const documentId = formData.get('documentId') as string;
@@ -662,15 +651,14 @@ export const actions: Actions = {
 			return fail(400, { error: 'Document ID requis', action: 'deleteDocument' });
 		}
 
-		// Get document info and verify ownership
+		// Get document info and verify it exists (RLS enforces ownership)
 		const { data: document } = await locals.supabase
 			.from('chapter_documents')
-			.select('id, storage_path, source_type, chapter:chapter_id!inner(teacher_id)')
+			.select('id, storage_path, source_type')
 			.eq('id', documentId)
 			.single();
 
-		const chapterData = document?.chapter as unknown as { teacher_id: string } | null;
-		if (!document || chapterData?.teacher_id !== user.id) {
+		if (!document) {
 			return fail(403, { error: 'Acces refuse', action: 'deleteDocument' });
 		}
 
@@ -700,15 +688,14 @@ export const actions: Actions = {
 	// ============ TEMPLATE ACTIONS ============
 
 	migrateToVersion: async ({ request, locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {
@@ -738,15 +725,14 @@ export const actions: Actions = {
 	},
 
 	detachFromTemplate: async ({ locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { chapterId } = params;
 
-		// Verify ownership
+		// Verify chapter exists (RLS enforces ownership)
 		const { data: chapter } = await locals.supabase
 			.from('class_chapters')
 			.select('id')
 			.eq('id', chapterId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (!chapter) {

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/+page.server.ts
@@ -26,7 +26,7 @@ export interface EvaluationTaskListItem {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	const { data, error: err } = await locals.supabase
 		.from('evaluation_tasks')
@@ -46,7 +46,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 				perimeter:evaluation_task_perimeter (skill_id)
 			`
 		)
-		.eq('teacher_id', user.id)
 		.order('task_date', { ascending: false, nullsFirst: false })
 		.order('created_at', { ascending: false });
 

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/+page.server.ts
@@ -49,24 +49,22 @@ export interface TaskEditData {
 }
 
 export const load: PageServerLoad = async ({ locals, params }): Promise<TaskEditData> => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// 1. Charger la tâche
 	const { data: task, error: taskErr } = await locals.supabase
 		.from('evaluation_tasks')
-		.select('id, name, description, niveau_scolaire, class_id, task_date, teacher_id')
+		.select('id, name, description, niveau_scolaire, class_id, task_date')
 		.eq('id', params.id)
 		.maybeSingle();
 
 	if (taskErr) throw error(500, `Erreur de chargement : ${taskErr.message}`);
 	if (!task) throw error(404, 'Tâche introuvable');
-	if (task.teacher_id !== user.id) throw error(403, "Cette tâche n'est pas la vôtre");
 
 	// 2. Classes du prof pour le selecteur
 	const { data: classes } = await locals.supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 
@@ -159,7 +157,7 @@ const updateSchema = z.object({
 
 export const actions: Actions = {
 	update_meta: async ({ locals, request, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const formData = await request.formData();
 		const raw = {
 			name: formData.get('name'),
@@ -179,22 +177,21 @@ export const actions: Actions = {
 				class_id: parsed.data.class_id || null,
 				task_date: parsed.data.task_date || null
 			})
-			.eq('id', params.id)
-			.eq('teacher_id', user.id);
+			.eq('id', params.id);
 		if (updErr) return fail(500, { message: updErr.message });
 		return { success: true, message: 'Tâche mise à jour' };
 	},
 
 	save_perimeter: async ({ locals, request, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
-		// Vérifier la propriété de la tâche
+		await requireRole(locals, 'teacher');
+		// Vérifier l'existence de la tâche
 		const { data: task } = await locals.supabase
 			.from('evaluation_tasks')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', params.id)
 			.maybeSingle();
-		if (!task || task.teacher_id !== user.id) {
-			return fail(403, { message: 'Tâche non accessible' });
+		if (!task) {
+			return fail(404, { message: 'Tâche introuvable' });
 		}
 
 		const formData = await request.formData();
@@ -218,12 +215,11 @@ export const actions: Actions = {
 	},
 
 	delete: async ({ locals, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 		const { error: delErr } = await locals.supabase
 			.from('evaluation_tasks')
 			.delete()
-			.eq('id', params.id)
-			.eq('teacher_id', user.id);
+			.eq('id', params.id);
 		if (delErr) return fail(500, { message: delErr.message });
 		throw redirect(303, '/dashboard/teacher/evaluation-tasks');
 	}

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/saisie/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/[id]/saisie/+page.server.ts
@@ -45,14 +45,14 @@ export interface SaisieData {
 }
 
 export const load: PageServerLoad = async ({ locals, params }): Promise<SaisieData> => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// 1. Charger la tâche + vérifier propriété
 	const { data: task, error: taskErr } = await locals.supabase
 		.from('evaluation_tasks')
 		.select(
 			`
-				id, name, task_date, class_id, teacher_id,
+				id, name, task_date, class_id,
 				class:classes (id, name)
 			`
 		)
@@ -61,7 +61,6 @@ export const load: PageServerLoad = async ({ locals, params }): Promise<SaisieDa
 
 	if (taskErr) throw error(500, `Erreur tâche : ${taskErr.message}`);
 	if (!task) throw error(404, 'Tâche introuvable');
-	if (task.teacher_id !== user.id) throw error(403, "Cette tâche n'est pas la vôtre");
 
 	const cls = Array.isArray(task.class) ? task.class[0] : task.class;
 	if (!task.class_id) {
@@ -172,16 +171,16 @@ export const load: PageServerLoad = async ({ locals, params }): Promise<SaisieDa
 
 export const actions: Actions = {
 	save: async ({ locals, request, params }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
-		// Re-vérifier la propriété
+		// Re-vérifier l'existence
 		const { data: task } = await locals.supabase
 			.from('evaluation_tasks')
-			.select('id, teacher_id, class_id')
+			.select('id, class_id')
 			.eq('id', params.id)
 			.maybeSingle();
-		if (!task || task.teacher_id !== user.id) {
-			return fail(403, { message: 'Tâche non accessible' });
+		if (!task) {
+			return fail(404, { message: 'Tâche introuvable' });
 		}
 
 		// Récupérer le périmètre (skill_ids autorisés)

--- a/src/routes/(protected)/dashboard/teacher/evaluation-tasks/new/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/evaluation-tasks/new/+page.server.ts
@@ -27,13 +27,12 @@ export interface TeacherClassOption {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Charger les classes du prof pour le selecteur
 	const { data: classes, error: err } = await locals.supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 
@@ -46,7 +45,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 export const actions: Actions = {
 	default: async ({ locals, request }) => {
-		const { user } = await requireRole(locals, 'teacher');
+		await requireRole(locals, 'teacher');
 
 		const formData = await request.formData();
 		const raw = {
@@ -67,7 +66,6 @@ export const actions: Actions = {
 		const { data, error: insertError } = await locals.supabase
 			.from('evaluation_tasks')
 			.insert({
-				teacher_id: user.id,
 				name: parsed.data.name,
 				niveau_scolaire: parsed.data.niveau_scolaire,
 				class_id: parsed.data.class_id || null,

--- a/src/routes/(protected)/dashboard/teacher/gamification/buddies/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/gamification/buddies/+page.server.ts
@@ -34,14 +34,13 @@ export interface StudentBuddyInfo {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 	const supabase = locals.supabase;
 
 	// Get teacher's classes
 	const { data: classes, error: classesError } = await supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 

--- a/src/routes/(protected)/dashboard/teacher/gamification/marketplace/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/gamification/marketplace/+page.server.ts
@@ -32,7 +32,6 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const { data: teacherClasses, error: classesError } = await supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', userId)
 		.order('name');
 
 	if (classesError) {

--- a/src/routes/(protected)/dashboard/teacher/gamification/rewards/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/gamification/rewards/+page.server.ts
@@ -23,20 +23,15 @@ interface ActivationRequest {
 
 export const load: PageServerLoad = async ({ locals }) => {
 	// Require teacher/admin authentication
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 	const supabase = locals.supabase;
 
-	// Get all active students that this teacher teaches
+	// Mono-teacher: the sole teacher teaches every class, so all active members are
+	// this teacher's students (classes.teacher_id was dropped).
 	const { data: classMembers, error: classMembersError } = await supabase
 		.from('class_members')
-		.select(
-			`
-			student_id,
-			classes!inner(teacher_id)
-		`
-		)
-		.eq('status', 'active')
-		.eq('classes.teacher_id', user.id);
+		.select('student_id')
+		.eq('status', 'active');
 
 	if (classMembersError) {
 		console.error('[rewards] Error fetching class members:', classMembersError);

--- a/src/routes/(protected)/dashboard/teacher/message-templates/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/message-templates/+page.svelte
@@ -226,16 +226,9 @@
 	}
 
 	async function loadClasses() {
-		const {
-			data: { user }
-		} = await data.supabase.auth.getUser();
-
-		if (!user) return;
-
 		const { data: classesData } = await data.supabase
 			.from('classes')
 			.select('id, name')
-			.eq('teacher_id', user.id)
 			.order('name');
 
 		if (classesData) {

--- a/src/routes/(protected)/dashboard/teacher/notifications/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/notifications/+page.server.ts
@@ -41,7 +41,6 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 	const { data: classes, error: _classesError } = await supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.eq('is_active', true)
 		.order('name');
 

--- a/src/routes/(protected)/dashboard/tutor-stats/+page.server.ts
+++ b/src/routes/(protected)/dashboard/tutor-stats/+page.server.ts
@@ -19,7 +19,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
 		.select('id, name')
-		.eq('teacher_id', user.id)
 		.order('name');
 
 	if (classesError) {

--- a/src/routes/(protected)/organisation/kanban/+page.server.ts
+++ b/src/routes/(protected)/organisation/kanban/+page.server.ts
@@ -47,7 +47,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 		const { data: classRows, error: classError } = await locals.supabase
 			.from('classes')
 			.select('id, name')
-			.eq('teacher_id', user.id)
 			.order('name', { ascending: true });
 
 		if (classError) {

--- a/src/routes/(protected)/python-notebook/[id]/results/+page.server.ts
+++ b/src/routes/(protected)/python-notebook/[id]/results/+page.server.ts
@@ -108,10 +108,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		}));
 
 	// 5. Teacher's classes (for the class-filter dropdown + scoping students)
-	const { data: teacherClassesRaw } = await supabase
-		.from('classes')
-		.select('id, name')
-		.eq('teacher_id', user.id);
+	const { data: teacherClassesRaw } = await supabase.from('classes').select('id, name');
 	const teacherClasses: TeacherClass[] = teacherClassesRaw ?? [];
 	const teacherClassIds = teacherClasses.map((c) => c.id);
 

--- a/src/routes/(public)/python-exercises/[id]/results/+page.server.ts
+++ b/src/routes/(public)/python-exercises/[id]/results/+page.server.ts
@@ -96,10 +96,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	}
 
 	// 4. Teacher's classes (for the class-filter dropdown + scoping students)
-	const { data: teacherClassesRaw } = await supabase
-		.from('classes')
-		.select('id, name')
-		.eq('teacher_id', user.id);
+	const { data: teacherClassesRaw } = await supabase.from('classes').select('id, name');
 	const teacherClasses: TeacherClass[] = teacherClassesRaw ?? [];
 	const teacherClassIds = teacherClasses.map((c) => c.id);
 

--- a/src/routes/(public)/python-exercises/[id]/results/[student_id]/+page.server.ts
+++ b/src/routes/(public)/python-exercises/[id]/results/[student_id]/+page.server.ts
@@ -84,10 +84,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	}
 
 	// 4. Build the teacher's student scope.
-	const { data: teacherClassesRaw } = await supabase
-		.from('classes')
-		.select('id, name')
-		.eq('teacher_id', user.id);
+	const { data: teacherClassesRaw } = await supabase.from('classes').select('id, name');
 	const teacherClassIds = (teacherClassesRaw ?? []).map((c) => c.id);
 
 	const scope = new Set<string>();

--- a/src/routes/(public)/python-exercises/students/[student_id]/+page.server.ts
+++ b/src/routes/(public)/python-exercises/students/[student_id]/+page.server.ts
@@ -75,10 +75,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	const student: StudentSummary = studentRaw;
 
 	// 3. My classes
-	const { data: myClassesRaw } = await supabase
-		.from('classes')
-		.select('id, name')
-		.eq('teacher_id', user.id);
+	const { data: myClassesRaw } = await supabase.from('classes').select('id, name');
 	const myClassIds = (myClassesRaw ?? []).map((c) => c.id);
 
 	// 4. Class members of my classes (for the scope check)

--- a/src/routes/api/classes/[classId]/gidouilles/+server.ts
+++ b/src/routes/api/classes/[classId]/gidouilles/+server.ts
@@ -45,22 +45,21 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 		// Get teacher's test mode preference
 		const isTestMode = await getTeacherTestMode(user.id, locals.supabase);
 
-		// Verify teacher owns the class (security check)
+		// Verify class exists
 		const { data: classCheck, error: classError } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.maybeSingle();
 
 		if (classError) {
-			console.error('[GET /api/classes/gidouilles] Error verifying class ownership:', classError);
-			throw error(500, `Failed to verify class ownership: ${classError.message}`);
+			console.error('[GET /api/classes/gidouilles] Error verifying class:', classError);
+			throw error(500, `Failed to verify class: ${classError.message}`);
 		}
 
 		if (!classCheck) {
-			console.error('[GET /api/classes/gidouilles] Teacher does not own class:', classId);
-			throw error(403, 'You do not have permission to view this class');
+			console.error('[GET /api/classes/gidouilles] Class not found:', classId);
+			throw error(404, 'Class not found');
 		}
 
 		// Fetch gidouilles data via class_members join (active members only)

--- a/src/routes/api/classes/[classId]/students/+server.ts
+++ b/src/routes/api/classes/[classId]/students/+server.ts
@@ -46,22 +46,21 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 		// Get teacher's test mode preference
 		const isTestMode = await getTeacherTestMode(user.id, locals.supabase);
 
-		// Verify teacher owns the class (security check)
+		// Verify class exists
 		const { data: classCheck, error: classError } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.maybeSingle();
 
 		if (classError) {
-			console.error('[GET /api/classes/students] Error verifying class ownership:', classError);
-			throw error(500, `Failed to verify class ownership: ${classError.message}`);
+			console.error('[GET /api/classes/students] Error verifying class:', classError);
+			throw error(500, `Failed to verify class: ${classError.message}`);
 		}
 
 		if (!classCheck) {
-			console.error('[GET /api/classes/students] Teacher does not own class:', classId);
-			throw error(403, 'You do not have permission to view this class');
+			console.error('[GET /api/classes/students] Class not found:', classId);
+			throw error(404, 'Class not found');
 		}
 
 		// Fetch active student profiles via class_members join

--- a/src/routes/api/documents/[id]/+server.ts
+++ b/src/routes/api/documents/[id]/+server.ts
@@ -58,8 +58,7 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 				chapter:chapter_id!inner(
 					id,
 					is_visible,
-					class_id,
-					teacher_id
+					class_id
 				)
 			`
 			)
@@ -75,7 +74,6 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 			id: string;
 			is_visible: boolean;
 			class_id: string;
-			teacher_id: string;
 		}>;
 		const chapter = Array.isArray(chapterArray) ? chapterArray[0] : chapterArray;
 
@@ -86,8 +84,8 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 		if (profile.role === 'admin') {
 			hasAccess = true;
 		}
-		// Teacher has access to their own chapters
-		else if (profile.role === 'teacher' && chapter.teacher_id === profile.id) {
+		// Teacher has access to all chapters (mono-teacher owns every chapter)
+		else if (profile.role === 'teacher') {
 			hasAccess = true;
 		}
 		// Student has access to visible chapters in their enrolled classes

--- a/src/routes/api/google/courses/[courseId]/share/+server.ts
+++ b/src/routes/api/google/courses/[courseId]/share/+server.ts
@@ -87,7 +87,6 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (classError || !classData) {
@@ -115,7 +114,6 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', category.class_id)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (categoryClassError || !categoryClass) {
@@ -239,7 +237,6 @@ export const DELETE: RequestHandler = async ({ locals, url }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', validClassId)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (classError || !classData) {
@@ -312,7 +309,6 @@ export const DELETE: RequestHandler = async ({ locals, url }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', validClassId)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (classError || !classData) {

--- a/src/routes/api/google/coursework/bulk-share/+server.ts
+++ b/src/routes/api/google/coursework/bulk-share/+server.ts
@@ -87,7 +87,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	// Verify teacher owns all classes
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
-		.select('id, teacher_id')
+		.select('id')
 		.in('id', classIds)
 		.eq('is_active', true);
 
@@ -98,15 +98,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 	if (!classes || classes.length !== classIds.length) {
 		throw error(400, 'One or more classes not found or inactive');
-	}
-
-	const invalidClasses = classes.filter((c) => c.teacher_id !== user.id);
-	if (invalidClasses.length > 0) {
-		console.error(
-			`[Bulk Coursework Share] Unauthorized class access attempt by teacher ${user.id}:`,
-			invalidClasses.map((c) => c.id)
-		);
-		throw error(403, 'You do not own all selected classes');
 	}
 
 	// Verify category ownership if provided (SECURITY: Prevent authorization bypass)

--- a/src/routes/api/google/materials/[id]/share/+server.ts
+++ b/src/routes/api/google/materials/[id]/share/+server.ts
@@ -93,7 +93,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	// Verify teacher owns all classes
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
-		.select('id, teacher_id')
+		.select('id')
 		.in('id', classIds)
 		.eq('is_active', true);
 
@@ -104,15 +104,6 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 	if (!classes || classes.length !== classIds.length) {
 		throw error(400, 'Invalid request');
-	}
-
-	const invalidClasses = classes.filter((c) => c.teacher_id !== user.id);
-	if (invalidClasses.length > 0) {
-		console.error(
-			`[Material Share] Unauthorized class access attempt by teacher ${user.id}:`,
-			invalidClasses.map((c) => c.id)
-		);
-		throw error(403, 'Access denied');
 	}
 
 	// Create shared_materials records

--- a/src/routes/api/google/materials/[id]/share/__tests__/google-materials-share.test.ts
+++ b/src/routes/api/google/materials/[id]/share/__tests__/google-materials-share.test.ts
@@ -426,40 +426,6 @@ describe('POST /api/google/materials/[id]/share', () => {
 			await expectHttpError(POST(event as any), 'You do not own this material');
 		});
 
-		it('should reject if teacher does not own all classes', async () => {
-			const otherTeacherId = '9a9a9a9a-9a9a-9a9a-9a9a-9a9a9a9a9a9a';
-			mockRequest.json.mockResolvedValueOnce({
-				classIds: [classId1, classId2],
-				visible: true
-			});
-
-			mockLocals.supabase.single.mockResolvedValueOnce({
-				data: {
-					id: validMaterialId,
-					google_classroom_courses: { teacher_id: teacherId }
-				},
-				error: null
-			});
-
-			// Mock one class owned by different teacher
-			mockLocals.supabase.in.mockResolvedValueOnce({
-				data: [
-					{ id: classId1, teacher_id: teacherId },
-					{ id: classId2, teacher_id: otherTeacherId } // Different teacher
-				],
-				error: null
-			});
-
-			const event = {
-				params: { id: validMaterialId },
-				request: mockRequest,
-				locals: mockLocals
-			} as unknown as RequestEvent;
-
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			await expectHttpError(POST(event as any), 'Access denied');
-		});
-
 		it('should reject if trying to share with archived classes', async () => {
 			mockRequest.json.mockResolvedValueOnce({
 				classIds: [classId1],

--- a/src/routes/api/google/materials/bulk-share/+server.ts
+++ b/src/routes/api/google/materials/bulk-share/+server.ts
@@ -84,10 +84,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		throw error(403, 'You do not own all selected materials');
 	}
 
-	// Verify teacher owns all classes
+	// Verify all classes exist and are active. Mono-teacher: the sole teacher owns
+	// every class (classes.teacher_id dropped), so there is no per-class ownership
+	// to check beyond existence; RLS scopes the read to the teacher/admin.
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
-		.select('id, teacher_id')
+		.select('id')
 		.in('id', classIds)
 		.eq('is_active', true);
 
@@ -98,15 +100,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 	if (!classes || classes.length !== classIds.length) {
 		throw error(400, 'One or more classes not found or inactive');
-	}
-
-	const invalidClasses = classes.filter((c) => c.teacher_id !== user.id);
-	if (invalidClasses.length > 0) {
-		console.error(
-			`[Bulk Material Share] Unauthorized class access attempt by teacher ${user.id}:`,
-			invalidClasses.map((c) => c.id)
-		);
-		throw error(403, 'You do not own all selected classes');
 	}
 
 	// Create shared_materials records for all combinations

--- a/src/routes/api/google/shared-coursework/+server.ts
+++ b/src/routes/api/google/shared-coursework/+server.ts
@@ -363,7 +363,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		// Verify teacher owns all classes
 		const { data: classes, error: classesError } = await locals.supabase
 			.from('classes')
-			.select('id, teacher_id')
+			.select('id')
 			.in('id', classIds)
 			.eq('is_active', true);
 
@@ -374,15 +374,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		if (!classes || classes.length !== classIds.length) {
 			throw error(400, 'One or more classes not found or inactive');
-		}
-
-		const invalidClasses = classes.filter((c) => c.teacher_id !== user.id);
-		if (invalidClasses.length > 0) {
-			console.error(
-				`[Share Coursework] Unauthorized class access attempt by teacher ${user.id}:`,
-				invalidClasses.map((c) => c.id)
-			);
-			throw error(403, 'You do not own all selected classes');
 		}
 
 		// If categoryId is provided, verify it belongs to one of the teacher's classes
@@ -402,7 +393,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', category.class_id)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (categoryClassError || !categoryClass) {
@@ -517,8 +507,7 @@ export const DELETE: RequestHandler = async ({ request, locals }) => {
 		const { data: classes, error: classesError } = await locals.supabase
 			.from('classes')
 			.select('id')
-			.in('id', classIds)
-			.eq('teacher_id', user.id);
+			.in('id', classIds);
 
 		if (classesError) {
 			console.error('[Unshare Coursework] Error fetching classes:', classesError);

--- a/src/routes/api/google/shared-coursework/[id]/+server.ts
+++ b/src/routes/api/google/shared-coursework/[id]/+server.ts
@@ -76,8 +76,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 				id,
 				class_id,
 				classes!inner(
-					id,
-					teacher_id
+					id
 				)
 			`
 			)
@@ -92,20 +91,8 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 			throw error(404, 'Shared coursework not found');
 		}
 
-		// Verify the teacher owns the class
-		const classDataForAuth = existingRecord.classes as unknown as
-			| { id: string; teacher_id: string }
-			| { id: string; teacher_id: string }[];
-		const teacherId = Array.isArray(classDataForAuth)
-			? classDataForAuth[0]?.teacher_id
-			: classDataForAuth?.teacher_id;
-
-		if (teacherId !== user.id) {
-			console.error(
-				`[Update Shared Coursework] Unauthorized access attempt by teacher ${user.id}: record ${sharedCourseworkId}`
-			);
-			throw error(403, 'You do not have permission to update this record');
-		}
+		// Mono-teacher: the sole teacher owns every class; RLS on shared_coursework
+		// enforces ownership via class_id. The inner join above proves the class exists.
 
 		// If categoryId is being updated and is not null, verify it belongs to teacher (via class)
 		if (updates.categoryId !== undefined && updates.categoryId !== null) {
@@ -124,7 +111,6 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', category.class_id)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (categoryClassError || !categoryClass) {
@@ -290,7 +276,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
  */
 export const DELETE: RequestHandler = async ({ params, locals }) => {
 	// Only teachers can delete shared coursework
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate ID parameter
 	const paramValidation = sharedCourseworkIdParamSchema.safeParse(params);
@@ -308,8 +294,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 				`
 				id,
 				classes!inner(
-					id,
-					teacher_id
+					id
 				)
 			`
 			)
@@ -324,20 +309,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 			throw error(404, 'Shared coursework not found');
 		}
 
-		// Verify the teacher owns the class
-		const classDataForDelete = existingRecord.classes as unknown as
-			| { id: string; teacher_id: string }
-			| { id: string; teacher_id: string }[];
-		const teacherId = Array.isArray(classDataForDelete)
-			? classDataForDelete[0]?.teacher_id
-			: classDataForDelete?.teacher_id;
-
-		if (teacherId !== user.id) {
-			console.error(
-				`[Delete Shared Coursework] Unauthorized access attempt by teacher ${user.id}: record ${sharedCourseworkId}`
-			);
-			throw error(403, 'You do not have permission to delete this record');
-		}
+		// Mono-teacher: the sole teacher owns every class; RLS on shared_coursework
+		// enforces ownership via class_id. The inner join above proves the class exists.
 
 		// Delete the record
 		const { error: deleteError } = await locals.supabase

--- a/src/routes/api/google/shared-coursework/[id]/__tests__/google-shared-coursework-by-id.test.ts
+++ b/src/routes/api/google/shared-coursework/[id]/__tests__/google-shared-coursework-by-id.test.ts
@@ -28,7 +28,6 @@ vi.mock('$lib/server/middleware/auth', () => ({
 
 describe('Google Shared Coursework by ID API', () => {
 	const teacherId = '550e8400-e29b-41d4-a716-446655440000';
-	const otherTeacherId = '660e9500-f39c-52e5-b827-557766551111';
 	const sharedCourseworkId = 'bbbbbb99-bb68-44ab-849b-b4bbe5b34eb1';
 	const classId = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
 	const _categoryId = 'aaaa1111-aaaa-11aa-aaaa-111111111111';
@@ -143,35 +142,6 @@ describe('Google Shared Coursework by ID API', () => {
 
 				await expect(PATCH(event as unknown as RequestEvent)).rejects.toThrow(
 					'Unauthorized: teacher role required'
-				);
-			});
-
-			it('returns 403 when record does not belong to teacher', async () => {
-				const mockParams = { id: sharedCourseworkId };
-				const mockRequest = {
-					json: vi.fn().mockResolvedValue({ visible: false })
-				};
-
-				// Mock record exists but belongs to different teacher
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).single = vi.fn().mockResolvedValueOnce({
-					data: {
-						id: sharedCourseworkId,
-						class_id: classId,
-						classes: { id: classId, teacher_id: otherTeacherId }
-					},
-					error: null
-				});
-
-				const event = {
-					params: mockParams,
-					request: mockRequest,
-					locals: mockLocals
-				} as unknown as RequestEvent;
-
-				await expectRejectsWithMessage(
-					() => PATCH(event as unknown as RequestEvent),
-					'You do not have permission to update this record'
 				);
 			});
 		});
@@ -1086,30 +1056,6 @@ describe('Google Shared Coursework by ID API', () => {
 
 				await expect(DELETE(event as unknown as RequestEvent)).rejects.toThrow(
 					'Unauthorized: teacher role required'
-				);
-			});
-
-			it('returns 403 when record does not belong to teacher', async () => {
-				const mockParams = { id: sharedCourseworkId };
-
-				// Mock record exists but belongs to different teacher
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).single = vi.fn().mockResolvedValueOnce({
-					data: {
-						id: sharedCourseworkId,
-						classes: { id: classId, teacher_id: otherTeacherId }
-					},
-					error: null
-				});
-
-				const event = {
-					params: mockParams,
-					locals: mockLocals
-				} as unknown as RequestEvent;
-
-				await expectRejectsWithMessage(
-					() => DELETE(event as unknown as RequestEvent),
-					'You do not have permission to delete this record'
 				);
 			});
 		});

--- a/src/routes/api/google/shared-coursework/__tests__/google-shared-coursework.test.ts
+++ b/src/routes/api/google/shared-coursework/__tests__/google-shared-coursework.test.ts
@@ -914,47 +914,6 @@ describe('Google Shared Coursework API', () => {
 				);
 			});
 
-			it('returns 403 when class does not belong to teacher', async () => {
-				const mockRequest = {
-					json: vi.fn().mockResolvedValue(validRequest)
-				};
-
-				// Mock coursework belongs to teacher
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).single = vi.fn().mockResolvedValueOnce({
-					data: {
-						id: courseworkId,
-						google_classroom_courses: { teacher_id: teacherId }
-					},
-					error: null
-				});
-
-				// Mock classes - one belongs to different teacher
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).eq = vi.fn().mockReturnThis();
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).in = vi.fn().mockImplementation(() => ({
-					...mockLocals.supabase,
-					eq: vi.fn().mockResolvedValueOnce({
-						data: [
-							{ id: classId1, teacher_id: teacherId },
-							{ id: classId2, teacher_id: 'other-teacher-id' }
-						],
-						error: null
-					})
-				}));
-
-				const event = {
-					request: mockRequest,
-					locals: mockLocals
-				} as unknown as RequestEvent;
-
-				await expectRejectsWithMessage(
-					() => POST(event as unknown as RequestEvent),
-					'You do not own all selected classes'
-				);
-			});
-
 			it('returns 400 when category does not belong to teacher class', async () => {
 				const mockRequest = {
 					json: vi.fn().mockResolvedValue({
@@ -1415,11 +1374,10 @@ describe('Google Shared Coursework API', () => {
 					})
 				};
 
-				// Class fetch: both exist and belong to teacher (terminal .eq('teacher_id'))
+				// Class fetch: both exist (no teacher_id filter — RLS owns that now)
 				const classChain = {
 					select: vi.fn().mockReturnThis(),
-					in: vi.fn().mockReturnThis(),
-					eq: vi.fn().mockResolvedValueOnce({
+					in: vi.fn().mockResolvedValueOnce({
 						data: [{ id: classId1 }, { id: classId2 }],
 						error: null
 					})
@@ -1474,11 +1432,10 @@ describe('Google Shared Coursework API', () => {
 					})
 				};
 
-				// Class fetch: both exist (terminal .eq('teacher_id'))
+				// Class fetch: both exist (no teacher_id filter — RLS owns that now)
 				const classChain = {
 					select: vi.fn().mockReturnThis(),
-					in: vi.fn().mockReturnThis(),
-					eq: vi.fn().mockResolvedValueOnce({
+					in: vi.fn().mockResolvedValueOnce({
 						data: [{ id: classId1 }, { id: classId2 }],
 						error: null
 					})
@@ -1523,24 +1480,33 @@ describe('Google Shared Coursework API', () => {
 					json: vi.fn().mockResolvedValue(validRequest)
 				};
 
-				// Mock coursework exists
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).single = vi.fn().mockResolvedValueOnce({
-					data: { id: courseworkId },
-					error: null
-				});
+				// Coursework fetch: exists
+				const courseworkChain = {
+					select: vi.fn().mockReturnThis(),
+					eq: vi.fn().mockReturnThis(),
+					single: vi.fn().mockResolvedValueOnce({
+						data: { id: courseworkId },
+						error: null
+					})
+				};
 
-				// Mock database error during class verification
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).eq = vi.fn().mockReturnThis();
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				(mockLocals.supabase as any).in = vi.fn().mockImplementation(() => ({
-					...mockLocals.supabase,
-					eq: vi.fn().mockResolvedValueOnce({
+				// Class fetch: database error (no teacher_id filter — RLS owns that now)
+				const classChain = {
+					select: vi.fn().mockReturnThis(),
+					in: vi.fn().mockResolvedValueOnce({
 						data: null,
 						error: { code: 'PGRST999', message: 'Database error' }
 					})
-				}));
+				};
+
+				let callCount = 0;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				(mockLocals.supabase as any).from = vi.fn().mockImplementation(() => {
+					callCount++;
+					if (callCount === 1) return courseworkChain;
+					if (callCount === 2) return classChain;
+					return mockLocals.supabase;
+				});
 
 				const event = {
 					request: mockRequest,

--- a/src/routes/api/google/shared-materials/+server.ts
+++ b/src/routes/api/google/shared-materials/+server.ts
@@ -325,7 +325,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	// Verify teacher owns all classes
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
-		.select('id, teacher_id')
+		.select('id')
 		.in('id', classIds)
 		.eq('is_active', true);
 
@@ -336,15 +336,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 	if (!classes || classes.length !== classIds.length) {
 		throw error(400, 'One or more classes not found or inactive');
-	}
-
-	const invalidClasses = classes.filter((c) => c.teacher_id !== user.id);
-	if (invalidClasses.length > 0) {
-		console.error(
-			`[Share Material] Unauthorized class access attempt by teacher ${user.id}:`,
-			invalidClasses.map((c) => c.id)
-		);
-		throw error(403, 'You do not own all selected classes');
 	}
 
 	// If categoryId is provided, verify it belongs to one of the teacher's classes
@@ -364,7 +355,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			.from('classes')
 			.select('id')
 			.eq('id', category.class_id)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (categoryClassError || !categoryClass) {
@@ -465,8 +455,7 @@ export const DELETE: RequestHandler = async ({ request, locals }) => {
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
 		.select('id')
-		.in('id', classIds)
-		.eq('teacher_id', user.id);
+		.in('id', classIds);
 
 	if (classesError) {
 		console.error('[Unshare Material] Error fetching classes:', classesError);
@@ -505,7 +494,7 @@ export const DELETE: RequestHandler = async ({ request, locals }) => {
  */
 export const PATCH: RequestHandler = async ({ locals, request }) => {
 	// Only teachers can update shared materials
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Parse request body
 	let requestBody: unknown;
@@ -570,7 +559,6 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
 				.from('classes')
 				.select('id')
 				.eq('id', category.class_id)
-				.eq('teacher_id', user.id)
 				.single();
 
 			if (categoryClassError || !categoryClass) {

--- a/src/routes/api/google/shared-materials/[id]/+server.ts
+++ b/src/routes/api/google/shared-materials/[id]/+server.ts
@@ -156,7 +156,6 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 			.from('classes')
 			.select('id')
 			.eq('id', category.class_id)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (categoryClassError || !categoryClass) {

--- a/src/routes/api/marketplace/admin/activity/+server.ts
+++ b/src/routes/api/marketplace/admin/activity/+server.ts
@@ -62,8 +62,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		// Get teacher's classes
 		const { data: teacherClasses, error: classesError } = await supabase
 			.from('classes')
-			.select('id')
-			.eq('teacher_id', userId);
+			.select('id');
 
 		if (classesError) {
 			throw error(500, 'Erreur lors de la récupération des classes');

--- a/src/routes/api/marketplace/admin/analytics/+server.ts
+++ b/src/routes/api/marketplace/admin/analytics/+server.ts
@@ -58,8 +58,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		// Get teacher's classes
 		const { data: teacherClasses, error: classesError } = await supabase
 			.from('classes')
-			.select('id')
-			.eq('teacher_id', userId);
+			.select('id');
 
 		if (classesError) {
 			throw error(500, 'Erreur lors de la récupération des classes');

--- a/src/routes/api/marketplace/admin/stats/+server.ts
+++ b/src/routes/api/marketplace/admin/stats/+server.ts
@@ -72,14 +72,14 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 	if (profile.role === 'teacher') {
 		if (class_id) {
-			// Verify teacher owns this class
+			// Verify class exists
 			const { data: classData } = await supabase
 				.from('classes')
-				.select('teacher_id')
+				.select('id')
 				.eq('id', class_id)
 				.single();
 
-			if (!classData || classData.teacher_id !== userId) {
+			if (!classData) {
 				throw error(403, 'Accès non autorisé à cette classe');
 			}
 
@@ -92,10 +92,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			studentIds = classStudents?.map((m: { student_id: string }) => m.student_id) || [];
 		} else {
 			// Get all students in teacher's classes
-			const { data: classMembers } = await supabase
-				.from('class_members')
-				.select('student_id, class:classes!class_members_class_id_fkey(teacher_id)')
-				.eq('class.teacher_id', userId);
+			const { data: classMembers } = await supabase.from('class_members').select('student_id');
 
 			studentIds = classMembers?.map((m: { student_id: string }) => m.student_id) || [];
 		}

--- a/src/routes/api/marketplace/admin/trades/+server.ts
+++ b/src/routes/api/marketplace/admin/trades/+server.ts
@@ -74,8 +74,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		// First get teacher's classes
 		const { data: teacherClasses, error: classesError } = await supabase
 			.from('classes')
-			.select('id')
-			.eq('teacher_id', userId);
+			.select('id');
 
 		if (classesError) {
 			console.error('Error fetching teacher classes:', classesError);
@@ -130,14 +129,14 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 		// If specific class_id is provided, further filter
 		if (class_id) {
-			// Verify teacher owns this class
+			// Verify class exists
 			const { data: classData } = await supabase
 				.from('classes')
-				.select('teacher_id')
+				.select('id')
 				.eq('id', class_id)
 				.single();
 
-			if (!classData || classData.teacher_id !== userId) {
+			if (!classData) {
 				throw error(403, 'Accès non autorisé à cette classe');
 			}
 

--- a/src/routes/api/marketplace/config/+server.ts
+++ b/src/routes/api/marketplace/config/+server.ts
@@ -133,14 +133,14 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	} else if (profile.role === 'teacher') {
 		// Teacher can only see configs for their classes
 		if (class_id) {
-			// Verify teacher owns this class
+			// Verify class exists
 			const { data: classData, error: classError } = await supabase
 				.from('classes')
-				.select('teacher_id')
+				.select('id')
 				.eq('id', class_id)
 				.single();
 
-			if (classError || !classData || classData.teacher_id !== userId) {
+			if (classError || !classData) {
 				throw error(403, 'Accès non autorisé à cette classe');
 			}
 
@@ -168,8 +168,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             grade
           )
         `
-				)
-				.eq('class.teacher_id', userId);
+				);
 
 			if (configsError) {
 				console.error('Error fetching configs:', configsError);
@@ -231,14 +230,14 @@ export const PATCH: RequestHandler = async ({ url, request, locals }) => {
 	if (classId) {
 		// Updating class-level config
 		if (profile.role === 'teacher') {
-			// Verify teacher owns this class
+			// Verify class exists
 			const { data: classData, error: classError } = await supabase
 				.from('classes')
-				.select('teacher_id, school_id')
+				.select('school_id')
 				.eq('id', classId)
 				.single();
 
-			if (classError || !classData || classData.teacher_id !== userId) {
+			if (classError || !classData) {
 				throw error(403, 'Vous ne pouvez pas modifier la configuration de cette classe');
 			}
 

--- a/src/routes/api/messages/recipients/+server.ts
+++ b/src/routes/api/messages/recipients/+server.ts
@@ -41,11 +41,9 @@ export const GET: RequestHandler = async ({ locals }) => {
 		// If teacher, also get classes for group messaging
 		let classes = null;
 		if (profile.role === 'teacher') {
+			// Mono-teacher: the RPC scopes to the sole teacher via auth.uid().
 			const { data: classesData, error: classesError } = await supabase.rpc(
-				'get_teacher_classes_for_messaging',
-				{
-					p_teacher_id: user.id
-				}
+				'get_teacher_classes_for_messaging'
 			);
 
 			if (classesError) {

--- a/src/routes/api/messages/templates/+server.ts
+++ b/src/routes/api/messages/templates/+server.ts
@@ -209,15 +209,15 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		return error(400, 'Un template de classe doit avoir un class_id');
 	}
 
-	// If teacher creating class template, verify they own the class
+	// If teacher creating class template, verify the class exists
 	if (profile.role === 'teacher' && templateInput.scope === 'class') {
 		const { data: classData } = await supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', templateInput.class_id!)
 			.single();
 
-		if (!classData || classData.teacher_id !== user.id) {
+		if (!classData) {
 			return error(403, 'Vous ne pouvez créer des templates que pour vos propres classes');
 		}
 	}

--- a/src/routes/api/messages/templates/[id]/+server.ts
+++ b/src/routes/api/messages/templates/[id]/+server.ts
@@ -162,15 +162,15 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 			return error(400, 'Un template de classe doit avoir un class_id');
 		}
 
-		// Verify teacher owns the class if changing class_id
+		// Verify the class exists if changing class_id
 		if (profile.role === 'teacher' && newScope === 'class') {
 			const { data: classData } = await supabase
 				.from('classes')
-				.select('teacher_id')
+				.select('id')
 				.eq('id', newClassId!)
 				.single();
 
-			if (!classData || classData.teacher_id !== user.id) {
+			if (!classData) {
 				return error(403, 'Vous ne pouvez utiliser que vos propres classes');
 			}
 		}

--- a/src/routes/api/messages/templates/[id]/duplicate/+server.ts
+++ b/src/routes/api/messages/templates/[id]/duplicate/+server.ts
@@ -58,14 +58,14 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 	// If class_id provided, update the duplicate
 	if (class_id) {
-		// Verify user owns the class
+		// Verify class exists
 		const { data: classData } = await supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', class_id)
 			.single();
 
-		if (classData && classData.teacher_id === user.id) {
+		if (classData) {
 			await supabase
 				.from('message_templates')
 				.update({ class_id: class_id })

--- a/src/routes/api/organisation/kanban/__tests__/api-routes.test.ts
+++ b/src/routes/api/organisation/kanban/__tests__/api-routes.test.ts
@@ -219,9 +219,9 @@ describe('POST /api/organisation/kanban/boards', () => {
 		const locals = createMockLocals(TEST_IDS.user, supabase);
 		const request = createMockRequest({ title: 'Tableau classe', class_id: TEST_IDS.class });
 
-		// isClassTeacher → classes.maybeSingle() → teacher_id matches user
+		// isClassTeacher → profiles.maybeSingle() → role is 'teacher'
 		supabase._mockChain.maybeSingle.mockResolvedValueOnce({
-			data: { teacher_id: TEST_IDS.user },
+			data: { role: 'teacher' },
 			error: null
 		});
 

--- a/src/routes/api/python-exercises/[id]/assign/+server.ts
+++ b/src/routes/api/python-exercises/[id]/assign/+server.ts
@@ -78,42 +78,29 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 		throw error(400, 'Vous devez fournir soit class_id soit student_id, mais pas les deux');
 	}
 
-	// If assigning to class, verify teacher owns the class
+	// If assigning to class, verify the class exists
 	if (data.class_id) {
 		const { data: classData, error: classError } = await supabase
 			.from('classes')
-			.select('teacher_id')
+			.select('id')
 			.eq('id', data.class_id)
 			.single();
 
 		if (classError || !classData) {
 			throw error(404, 'Classe introuvable');
 		}
-
-		if (classData.teacher_id !== user.id) {
-			throw error(403, "Vous ne pouvez assigner qu'à vos propres classes");
-		}
 	}
 
-	// If assigning to student, verify student is in one of teacher's classes
+	// If assigning to student, verify student is enrolled in at least one class
 	if (data.student_id) {
 		const { data: studentClasses } = await supabase
 			.from('class_members')
-			.select('class_id, classes!inner(teacher_id)')
+			.select('class_id')
 			.eq('student_id', data.student_id)
 			.eq('status', 'active');
 
 		if (!studentClasses || studentClasses.length === 0) {
-			throw error(404, 'Étudiant introuvable dans vos classes');
-		}
-
-		const isInTeacherClass = studentClasses.some((sc) => {
-			const classes = sc.classes as unknown as { teacher_id: string };
-			return classes.teacher_id === user.id;
-		});
-
-		if (!isInTeacherClass) {
-			throw error(403, "Vous ne pouvez assigner qu'à vos propres étudiants");
+			throw error(404, 'Étudiant introuvable dans une classe');
 		}
 	}
 

--- a/src/routes/api/python-exercises/[id]/assign/__tests__/server.test.ts
+++ b/src/routes/api/python-exercises/[id]/assign/__tests__/server.test.ts
@@ -128,22 +128,6 @@ describe('POST /api/python-exercises/[id]/assign', () => {
 		).rejects.toMatchObject({ status: 400 });
 	});
 
-	it('class assignment: 403 when teacher does not own the class', async () => {
-		const { POST } = await import('../+server');
-		const supabase = createMockSupabase();
-		mockSuccess(supabase, { role: 'teacher' }, 'single'); // profile
-		mockSuccess(supabase, ownExercise, 'single'); // exercise
-		mockSuccess(supabase, { teacher_id: OTHER_TEACHER_ID }, 'single'); // class
-		const locals = createMockLocals(TEACHER_ID, supabase);
-		await expect(
-			POST({
-				params: { id: EXERCISE_ID },
-				locals,
-				request: createMockRequest({ class_id: CLASS_ID })
-			} as any)
-		).rejects.toMatchObject({ status: 403 });
-	});
-
 	it('class assignment: 201 when teacher owns the class', async () => {
 		const { POST } = await import('../+server');
 		const supabase = createMockSupabase();

--- a/src/routes/api/python-exercises/[id]/results/+server.ts
+++ b/src/routes/api/python-exercises/[id]/results/+server.ts
@@ -139,14 +139,12 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 		const studentIds = classMembers.map((cm) => cm.student_id);
 		query = query.in('student_id', studentIds);
 	} else {
-		// If no class filter, only show submissions from teacher's students
-		const { data: teacherClasses } = await supabase
-			.from('classes')
-			.select('id')
-			.eq('teacher_id', user.id);
+		// If no class filter, show submissions from all students in any class.
+		// Mono-teacher: RLS ensures only the teacher's own data is visible.
+		const { data: allClasses } = await supabase.from('classes').select('id');
 
-		if (teacherClasses && teacherClasses.length > 0) {
-			const classIds = teacherClasses.map((c) => c.id);
+		if (allClasses && allClasses.length > 0) {
+			const classIds = allClasses.map((c) => c.id);
 
 			const { data: classMembers } = await supabase
 				.from('class_members')
@@ -158,11 +156,9 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 				const studentIds = classMembers.map((cm) => cm.student_id);
 				query = query.in('student_id', studentIds);
 			} else {
-				// No students in teacher's classes
 				return json({ results: [] });
 			}
 		} else {
-			// Teacher has no classes
 			return json({ results: [] });
 		}
 	}

--- a/src/routes/api/python-files/[id]/assign/+server.ts
+++ b/src/routes/api/python-files/[id]/assign/+server.ts
@@ -61,11 +61,10 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 		throw error(403, 'Vous ne pouvez assigner que vos propres fichiers Python');
 	}
 
-	// Verify user is teacher of all specified classes
+	// Verify all specified classes exist
 	const { data: classes, error: classesError } = await locals.supabase
 		.from('classes')
 		.select('id')
-		.eq('teacher_id', user.id)
 		.in('id', class_ids);
 
 	if (classesError) {
@@ -76,10 +75,7 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 	if (!classes || classes.length !== class_ids.length) {
 		const validClassIds = new Set(classes?.map((c) => c.id) ?? []);
 		const invalidClassIds = class_ids.filter((id) => !validClassIds.has(id));
-		throw error(
-			403,
-			`Vous n'etes pas le professeur de certaines classes: ${invalidClassIds.join(', ')}`
-		);
+		throw error(403, `Certaines classes sont introuvables: ${invalidClassIds.join(', ')}`);
 	}
 
 	// Create assignments (upsert to handle duplicates)

--- a/src/routes/api/python-files/students/+server.ts
+++ b/src/routes/api/python-files/students/+server.ts
@@ -18,7 +18,7 @@ import { studentFilesQuerySchema } from '$lib/server/validation/python-files';
  * Teacher only - can filter by class_id or student_id
  */
 export const GET: RequestHandler = async ({ locals, url }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate query parameters
 	const queryResult = studentFilesQuerySchema.safeParse({
@@ -39,18 +39,17 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 	const offset = (page - 1) * limit;
 
 	// Get all students in teacher's classes
+	// Mono-teacher: RLS scopes class_members to the teacher's own classes automatically.
 	let studentIdsQuery = locals.supabase
 		.from('class_members')
 		.select(
 			`
 			student_id,
 			classes!inner (
-				id,
-				teacher_id
+				id
 			)
 		`
 		)
-		.eq('classes.teacher_id', user.id)
 		.eq('status', 'active');
 
 	if (class_id) {
@@ -123,7 +122,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 	// Enrich with class information for each student
 	const filesWithClasses = await Promise.all(
 		(files ?? []).map(async (file) => {
-			// Get classes where this student is enrolled (that belong to this teacher)
+			// Get classes where this student is enrolled
 			const { data: studentClasses } = await locals.supabase
 				.from('class_members')
 				.select(
@@ -136,8 +135,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 				`
 				)
 				.eq('student_id', file.owner_id)
-				.eq('status', 'active')
-				.eq('classes.teacher_id', user.id);
+				.eq('status', 'active');
 
 			return {
 				...file,

--- a/src/routes/api/python-notebooks/[id]/share/+server.ts
+++ b/src/routes/api/python-notebooks/[id]/share/+server.ts
@@ -84,17 +84,16 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 		throw error(400, "Un template ne peut pas être partagé directement. Clonez-le d'abord.");
 	}
 
-	// Check if user is teacher of the class
+	// Verify the class exists
 	const { data: teacherClass, error: classError } = await locals.supabase
 		.from('classes')
 		.select('id, name')
 		.eq('id', class_id)
-		.eq('teacher_id', user.id)
 		.single();
 
 	if (classError || !teacherClass) {
 		if (classError?.code === 'PGRST116') {
-			throw error(404, "Classe introuvable ou vous n'en etes pas l'enseignant");
+			throw error(404, 'Classe introuvable');
 		}
 		console.error('Error fetching class for sharing:', classError);
 		throw error(500, 'Erreur lors de la verification de la classe');

--- a/src/routes/api/student/profile/+server.ts
+++ b/src/routes/api/student/profile/+server.ts
@@ -56,7 +56,8 @@ export const GET: RequestHandler = async ({ locals }) => {
 	}
 
 	try {
-		// Fetch active class memberships with class and teacher details
+		// Fetch active class memberships with class details.
+		// Mono-teacher: teacher_id was dropped from classes; resolve the sole teacher once below.
 		const { data: memberships, error: membershipError } = await supabase
 			.from('class_members')
 			.select(
@@ -66,11 +67,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 				classes:class_id (
 					id,
 					name,
-					is_active,
-					teacher:teacher_id (
-						id,
-						full_name
-					)
+					is_active
 				)
 			`
 			)
@@ -83,18 +80,23 @@ export const GET: RequestHandler = async ({ locals }) => {
 			throw error(500, 'Failed to fetch class memberships');
 		}
 
+		// Resolve the sole teacher once for display attribution.
+		const { data: soleTeacher } = await supabase
+			.from('profiles')
+			.select('id, full_name')
+			.eq('role', 'teacher')
+			.maybeSingle();
+
 		// Transform database response to ClassMembership[]
 		const classes: ClassMembership[] = (memberships || [])
 			.filter((m) => m.classes) // Filter out null classes
 			.map((m) => {
-				// Handle case where classes or teacher might be arrays
 				const classData = Array.isArray(m.classes) ? m.classes[0] : m.classes;
-				const teacher = Array.isArray(classData.teacher) ? classData.teacher[0] : classData.teacher;
 				return {
 					class_id: m.class_id,
 					class_name: classData.name,
-					teacher_name: teacher?.full_name || 'Unknown Teacher',
-					teacher_id: teacher?.id || '',
+					teacher_name: soleTeacher?.full_name || 'Unknown Teacher',
+					teacher_id: soleTeacher?.id || '',
 					joined_at: m.joined_at,
 					is_active: classData.is_active
 				};

--- a/src/routes/api/teacher/categories/[classId]/+server.ts
+++ b/src/routes/api/teacher/categories/[classId]/+server.ts
@@ -30,7 +30,7 @@ import { uuidSchema } from '$lib/server/validation';
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
 	// Only teachers can fetch categories
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate classId parameter
 	const validation = uuidSchema.safeParse(params.classId);
@@ -41,20 +41,19 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const classId = validation.data;
 
 	try {
-		// Verify class belongs to teacher
+		// Verify class exists
 		const { data: classData, error: classError } = await locals.supabase
 			.from('classes')
 			.select('id')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (classError || !classData) {
 			if (classError?.code === 'PGRST116') {
-				throw error(404, 'Class not found or access denied');
+				throw error(404, 'Class not found');
 			}
 			console.error('[Categories] Class verification error:', classError);
-			throw error(403, 'Class does not belong to you');
+			throw error(500, 'Failed to verify class');
 		}
 
 		// Fetch categories for this class

--- a/src/routes/api/teacher/chapter-templates/[id]/instantiate/+server.ts
+++ b/src/routes/api/teacher/chapter-templates/[id]/instantiate/+server.ts
@@ -72,19 +72,15 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 	const data = validation.data;
 
-	// Verify teacher owns the class
+	// Verify the class exists
 	const { data: classData, error: classError } = await locals.supabase
 		.from('classes')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', data.classId)
 		.single();
 
 	if (classError || !classData) {
 		throw error(404, 'Class not found');
-	}
-
-	if (classData.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - not your class');
 	}
 
 	// Instantiate template

--- a/src/routes/api/teacher/chapters/+server.ts
+++ b/src/routes/api/teacher/chapters/+server.ts
@@ -81,20 +81,15 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 	const data: CreateChapterInput = validation.data;
 
-	// Verify the teacher owns the class
+	// Verify the class exists
 	const { data: classData, error: classError } = await locals.supabase
 		.from('classes')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', data.classId)
 		.single();
 
 	if (classError || !classData) {
 		throw error(404, 'Class not found');
-	}
-
-	const { user } = await locals.safeGetSession();
-	if (classData.teacher_id !== user?.id) {
-		throw error(403, 'Forbidden - Not your class');
 	}
 
 	// Create chapter

--- a/src/routes/api/teacher/chapters/[id]/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/+server.ts
@@ -15,25 +15,17 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id, class_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -44,7 +36,7 @@ async function verifyChapterOwnership(
  * Get a single chapter with all its content
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -55,7 +47,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch chapter with all related content
 	const { data: chapter, error: chapterError } = await locals.supabase
@@ -84,7 +76,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
  * Update a chapter
  */
 export const PUT: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -95,7 +87,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;
@@ -130,7 +122,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
  * Delete a chapter
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -141,7 +133,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Delete chapter
 	const result = await deleteChapter(chapterId, locals.supabase);

--- a/src/routes/api/teacher/chapters/[id]/checklist/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/checklist/+server.ts
@@ -14,25 +14,17 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -43,7 +35,7 @@ async function verifyChapterOwnership(
  * List all checklist items for a chapter
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -54,7 +46,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch checklist items
 	const { data: items, error: itemsError } = await locals.supabase
@@ -79,7 +71,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
  * Add a checklist item to a chapter
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -90,7 +82,7 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;

--- a/src/routes/api/teacher/chapters/[id]/checklist/[itemId]/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/checklist/[itemId]/+server.ts
@@ -14,27 +14,22 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter and checklist item exists
+ * Verify the chapter exists and checklist item belongs to it
  */
 async function verifyChecklistItemOwnership(
 	chapterId: string,
 	itemId: string,
-	teacherId: string,
 	supabase: App.Locals['supabase']
 ) {
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	// Verify item exists and belongs to chapter
@@ -60,7 +55,7 @@ async function verifyChecklistItemOwnership(
  * Update a checklist item
  */
 export const PUT: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -77,7 +72,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
 	const itemId = itemIdValidation.data;
 
 	// Verify ownership
-	await verifyChecklistItemOwnership(chapterId, itemId, user.id, locals.supabase);
+	await verifyChecklistItemOwnership(chapterId, itemId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;
@@ -112,7 +107,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
  * Delete a checklist item
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -129,7 +124,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 	const itemId = itemIdValidation.data;
 
 	// Verify ownership
-	await verifyChecklistItemOwnership(chapterId, itemId, user.id, locals.supabase);
+	await verifyChecklistItemOwnership(chapterId, itemId, locals.supabase);
 
 	// Delete item
 	const result = await deleteChecklistItem(itemId, locals.supabase);

--- a/src/routes/api/teacher/chapters/[id]/create-template/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/create-template/+server.ts
@@ -38,19 +38,15 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 	const chapterId = idValidation.data;
 
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await locals.supabase
 		.from('class_chapters')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - not the chapter owner');
 	}
 
 	// Parse and validate request body

--- a/src/routes/api/teacher/chapters/[id]/detach/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/detach/+server.ts
@@ -23,7 +23,7 @@ import { uuidSchema } from '$lib/server/validation/common';
  * - This action is reversible (can be re-attached manually in DB if needed)
  */
 export const POST: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -33,19 +33,15 @@ export const POST: RequestHandler = async ({ locals, params }) => {
 
 	const chapterId = idValidation.data;
 
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await locals.supabase
 		.from('class_chapters')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - not the chapter owner');
 	}
 
 	// Check if chapter is linked to a template

--- a/src/routes/api/teacher/chapters/[id]/documents/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/documents/+server.ts
@@ -14,25 +14,17 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -43,7 +35,7 @@ async function verifyChapterOwnership(
  * List all documents for a chapter
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -54,7 +46,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch documents
 	const { data: documents, error: docsError } = await locals.supabase
@@ -79,7 +71,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
  * Add a document to a chapter
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -90,7 +82,7 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;

--- a/src/routes/api/teacher/chapters/[id]/documents/[docId]/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/documents/[docId]/+server.ts
@@ -14,27 +14,22 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter and document exists
+ * Verify the chapter exists and document belongs to it
  */
 async function verifyDocumentOwnership(
 	chapterId: string,
 	docId: string,
-	teacherId: string,
 	supabase: App.Locals['supabase']
 ) {
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	// Verify document exists and belongs to chapter
@@ -60,7 +55,7 @@ async function verifyDocumentOwnership(
  * Update a document
  */
 export const PUT: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -77,7 +72,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
 	const docId = docIdValidation.data;
 
 	// Verify ownership
-	await verifyDocumentOwnership(chapterId, docId, user.id, locals.supabase);
+	await verifyDocumentOwnership(chapterId, docId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;
@@ -112,7 +107,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
  * Delete a document
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -129,7 +124,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 	const docId = docIdValidation.data;
 
 	// Verify ownership
-	await verifyDocumentOwnership(chapterId, docId, user.id, locals.supabase);
+	await verifyDocumentOwnership(chapterId, docId, locals.supabase);
 
 	// Delete document
 	const result = await deleteChapterDocument(docId, locals.supabase);

--- a/src/routes/api/teacher/chapters/[id]/exercises/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/exercises/+server.ts
@@ -14,25 +14,17 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -43,7 +35,7 @@ async function verifyChapterOwnership(
  * List all linked exercises for a chapter
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -54,7 +46,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch chapter exercises with exercise details
 	const { data: exerciseLinks, error: linksError } = await locals.supabase
@@ -84,7 +76,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
  * Link an exercise to a chapter
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -95,7 +87,7 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;

--- a/src/routes/api/teacher/chapters/[id]/exercises/[linkId]/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/exercises/[linkId]/+server.ts
@@ -10,27 +10,22 @@ import { unlinkExercise } from '$lib/server/chapters';
 import { uuidSchema } from '$lib/server/validation/common';
 
 /**
- * Verify the teacher owns the chapter and exercise link exists
+ * Verify the chapter exists and exercise link belongs to it
  */
 async function verifyExerciseLinkOwnership(
 	chapterId: string,
 	linkId: string,
-	teacherId: string,
 	supabase: App.Locals['supabase']
 ) {
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	// Verify link exists and belongs to chapter
@@ -56,7 +51,7 @@ async function verifyExerciseLinkOwnership(
  * Unlink an exercise from a chapter
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -73,7 +68,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 	const linkId = linkIdValidation.data;
 
 	// Verify ownership
-	await verifyExerciseLinkOwnership(chapterId, linkId, user.id, locals.supabase);
+	await verifyExerciseLinkOwnership(chapterId, linkId, locals.supabase);
 
 	// Unlink exercise
 	const result = await unlinkExercise(linkId, locals.supabase);

--- a/src/routes/api/teacher/chapters/[id]/migrate/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/migrate/+server.ts
@@ -27,7 +27,7 @@ type ZodIssue = { path: (string | number)[]; message: string };
  * - Only the chapter owner can migrate
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -37,19 +37,15 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 	const chapterId = idValidation.data;
 
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await locals.supabase
 		.from('class_chapters')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - not the chapter owner');
 	}
 
 	// Check if chapter is linked to a template

--- a/src/routes/api/teacher/chapters/[id]/progress/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/progress/+server.ts
@@ -16,25 +16,17 @@ const progressQuerySchema = z.object({
 });
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists and return its class_id
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id, class_id')
+		.select('id, class_id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -46,7 +38,7 @@ async function verifyChapterOwnership(
  * Optionally filter by studentId query parameter
  */
 export const GET: RequestHandler = async ({ locals, params, url }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -67,8 +59,8 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 
 	const { studentId } = queryValidation.data;
 
-	// Verify ownership
-	const chapter = await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	// Verify chapter exists
+	const chapter = await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch checklist progress
 	const checklistResult = await getStudentChecklistProgress(chapterId, locals.supabase, studentId);

--- a/src/routes/api/teacher/chapters/[id]/quiz/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/quiz/+server.ts
@@ -14,25 +14,17 @@ import { uuidSchema } from '$lib/server/validation/common';
 type ZodIssue = { path: (string | number)[]; message: string };
 
 /**
- * Verify the teacher owns the chapter
+ * Verify the chapter exists
  */
-async function verifyChapterOwnership(
-	chapterId: string,
-	teacherId: string,
-	supabase: App.Locals['supabase']
-) {
+async function verifyChapterExists(chapterId: string, supabase: App.Locals['supabase']) {
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	return chapter;
@@ -43,7 +35,7 @@ async function verifyChapterOwnership(
  * List all quiz questions for a chapter
  */
 export const GET: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -54,7 +46,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Fetch quiz questions with template info
 	const { data: questions, error: questionsError } = await locals.supabase
@@ -79,7 +71,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
  * Add a question to the chapter quiz
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -90,7 +82,7 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 	const chapterId = idValidation.data;
 
 	// Verify ownership
-	await verifyChapterOwnership(chapterId, user.id, locals.supabase);
+	await verifyChapterExists(chapterId, locals.supabase);
 
 	// Parse and validate request body
 	let body: unknown;

--- a/src/routes/api/teacher/chapters/[id]/quiz/[questionId]/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/quiz/[questionId]/+server.ts
@@ -10,27 +10,22 @@ import { removeQuizQuestion } from '$lib/server/chapters';
 import { uuidSchema } from '$lib/server/validation/common';
 
 /**
- * Verify the teacher owns the chapter and quiz question exists
+ * Verify the chapter exists and quiz question belongs to it
  */
 async function verifyQuizQuestionOwnership(
 	chapterId: string,
 	questionId: string,
-	teacherId: string,
 	supabase: App.Locals['supabase']
 ) {
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await supabase
 		.from('class_chapters')
-		.select('id, teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== teacherId) {
-		throw error(403, 'Forbidden - Not your chapter');
 	}
 
 	// Verify question exists and belongs to chapter
@@ -56,7 +51,7 @@ async function verifyQuizQuestionOwnership(
  * Remove a question from the chapter quiz
  */
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate IDs
 	const chapterIdValidation = uuidSchema.safeParse(params.id);
@@ -73,7 +68,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 	const questionId = questionIdValidation.data;
 
 	// Verify ownership
-	await verifyQuizQuestionOwnership(chapterId, questionId, user.id, locals.supabase);
+	await verifyQuizQuestionOwnership(chapterId, questionId, locals.supabase);
 
 	// Remove question
 	const result = await removeQuizQuestion(questionId, locals.supabase);

--- a/src/routes/api/teacher/chapters/[id]/reorder/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/reorder/+server.ts
@@ -20,7 +20,7 @@ type ZodIssue = { path: (string | number)[]; message: string };
  * [id] = class ID
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate class ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -30,19 +30,15 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 	const classId = idValidation.data;
 
-	// Verify the teacher owns the class
+	// Verify the class exists
 	const { data: classData, error: classError } = await locals.supabase
 		.from('classes')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', classId)
 		.single();
 
 	if (classError || !classData) {
 		throw error(404, 'Class not found');
-	}
-
-	if (classData.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - Not your class');
 	}
 
 	// Parse and validate request body

--- a/src/routes/api/teacher/chapters/[id]/template-updates/+server.ts
+++ b/src/routes/api/teacher/chapters/[id]/template-updates/+server.ts
@@ -28,7 +28,7 @@ import { uuidSchema } from '$lib/server/validation/common';
  * - Only the chapter owner can check for updates
  */
 export const GET: RequestHandler = async ({ locals, params, url }) => {
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	// Validate chapter ID
 	const idValidation = uuidSchema.safeParse(params.id);
@@ -38,19 +38,15 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 
 	const chapterId = idValidation.data;
 
-	// Verify chapter ownership
+	// Verify chapter exists
 	const { data: chapter, error: chapterError } = await locals.supabase
 		.from('class_chapters')
-		.select('teacher_id')
+		.select('id')
 		.eq('id', chapterId)
 		.single();
 
 	if (chapterError || !chapter) {
 		throw error(404, 'Chapter not found');
-	}
-
-	if (chapter.teacher_id !== user.id) {
-		throw error(403, 'Forbidden - not the chapter owner');
 	}
 
 	// Check if chapter is linked to a template

--- a/src/routes/api/tutor/stats/+server.ts
+++ b/src/routes/api/tutor/stats/+server.ts
@@ -75,7 +75,7 @@ interface StatsResponse {
 
 export const GET: RequestHandler = async ({ url, locals }) => {
 	// 1. Auth check (require teacher or admin)
-	const { user, profile } = await requireRoles(locals, ['teacher', 'admin']);
+	const { profile } = await requireRoles(locals, ['teacher', 'admin']);
 
 	// 2. Parse and validate query params
 	const validation = statsQuerySchema.safeParse({
@@ -140,10 +140,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	// For teachers (non-admins), only show conversations from their classes
 	if (profile.role === 'teacher') {
 		// Get teacher's class IDs first
-		const { data: teacherClasses } = await locals.supabase
-			.from('classes')
-			.select('id')
-			.eq('teacher_id', user.id);
+		const { data: teacherClasses } = await locals.supabase.from('classes').select('id');
 
 		if (teacherClasses && teacherClasses.length > 0) {
 			const classIds = teacherClasses.map((c) => c.id);

--- a/src/routes/api/whiteboard/classes-for-drawer/+server.ts
+++ b/src/routes/api/whiteboard/classes-for-drawer/+server.ts
@@ -33,7 +33,7 @@ import { requireRole } from '$lib/server/middleware/auth';
  */
 export const GET: RequestHandler = async ({ locals }) => {
 	// Require teacher role
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	try {
 		// Fetch all active classes with schedules
@@ -55,7 +55,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 				)
 			`
 			)
-			.eq('teacher_id', user.id)
 			.eq('is_active', true)
 			.order('name');
 

--- a/src/routes/api/whiteboard/classes-with-course/+server.ts
+++ b/src/routes/api/whiteboard/classes-with-course/+server.ts
@@ -28,7 +28,7 @@ import { requireRole } from '$lib/server/middleware/auth';
  */
 export const GET: RequestHandler = async ({ locals }) => {
 	// Require teacher role
-	const { user } = await requireRole(locals, 'teacher');
+	await requireRole(locals, 'teacher');
 
 	try {
 		// Fetch classes with course association and schedules
@@ -51,7 +51,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 				)
 			`
 			)
-			.eq('teacher_id', user.id)
 			.eq('is_active', true)
 			.not('google_classroom_course_id', 'is', null)
 			.order('name');

--- a/src/routes/api/whiteboard/export-to-classroom/+server.ts
+++ b/src/routes/api/whiteboard/export-to-classroom/+server.ts
@@ -107,7 +107,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			`
 			)
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (classError) {

--- a/src/routes/api/worksheets/[id]/assignments/+server.ts
+++ b/src/routes/api/worksheets/[id]/assignments/+server.ts
@@ -300,7 +300,7 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 		if (classIds.length > 0) {
 			const { data: classesData, error: classesError } = await locals.supabase
 				.from('classes')
-				.select('id, name, teacher_id')
+				.select('id, name')
 				.in('id', classIds);
 
 			if (classesError) {
@@ -313,17 +313,6 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 			const missingIds = classIds.filter((id) => !foundIds.has(id));
 			if (missingIds.length > 0) {
 				throw error(404, `Classes non trouvees: ${missingIds.length} classe(s) invalide(s)`);
-			}
-
-			// Verify user has access to all classes
-			if (profile?.role !== 'admin') {
-				const unauthorizedClasses = classesData?.filter((c) => c.teacher_id !== user.id) || [];
-				if (unauthorizedClasses.length > 0) {
-					throw error(
-						403,
-						`Acces non autorise a ${unauthorizedClasses.length} classe(s): ${unauthorizedClasses.map((c) => c.name).join(', ')}`
-					);
-				}
 			}
 		}
 

--- a/src/routes/api/worksheets/[id]/instances/+server.ts
+++ b/src/routes/api/worksheets/[id]/instances/+server.ts
@@ -57,11 +57,10 @@ export const POST: RequestHandler = async ({ params, request, locals: { supabase
 			.from('classes')
 			.select('id, name')
 			.eq('id', classId)
-			.eq('teacher_id', user.id)
 			.single();
 
 		if (classError || !classData) {
-			return error(403, 'Class not found or access denied');
+			return error(404, 'Class not found');
 		}
 
 		// Fetch worksheet details

--- a/src/routes/api/worksheets/assignments/[assignmentId]/+server.ts
+++ b/src/routes/api/worksheets/assignments/[assignmentId]/+server.ts
@@ -239,7 +239,7 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
 			if (class_ids.length > 0) {
 				const { data: classesData, error: classesError } = await locals.supabase
 					.from('classes')
-					.select('id, name, teacher_id')
+					.select('id, name')
 					.in('id', class_ids);
 
 				if (classesError) {
@@ -252,14 +252,6 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
 				const missingIds = class_ids.filter((id) => !foundIds.has(id));
 				if (missingIds.length > 0) {
 					throw error(404, `Classes non trouvees: ${missingIds.length} classe(s) invalide(s)`);
-				}
-
-				// Verify user has access to all classes
-				if (profile?.role !== 'admin') {
-					const unauthorizedClasses = classesData?.filter((c) => c.teacher_id !== user.id) || [];
-					if (unauthorizedClasses.length > 0) {
-						throw error(403, `Acces non autorise a ${unauthorizedClasses.length} classe(s)`);
-					}
 				}
 			}
 

--- a/supabase/migrations/20260620090000_drop_class_teacher_id_mono_teacher.sql
+++ b/supabase/migrations/20260620090000_drop_class_teacher_id_mono_teacher.sql
@@ -1,0 +1,3588 @@
+-- Drop teacher_id from the class-ownership cluster (mono-teacher refactor).
+--
+-- UbuMaths is a mono-teacher application: there is exactly ONE role='teacher'
+-- (David) who can elevate to the single admin. The multi-teacher scoping that
+-- `teacher_id` carried on the class-ownership cluster is therefore dead weight.
+--
+-- Ownership moves from `teacher_id = auth.uid()` to the role helper
+-- `public.is_teacher_or_admin()`. Effective permissions are IDENTICAL: with a
+-- single teacher, "owns this class" and "is the teacher (or admin)" coincide.
+-- This is a refactor, NOT a privilege change.
+--
+-- NOTE: `public.is_admin()` checks role='admin' ONLY (its comment is misleading)
+-- so it does NOT cover the teacher. We use `public.is_teacher_or_admin()`
+-- everywhere ownership previously meant `teacher_id = auth.uid()`.
+--
+-- 6 tables lose teacher_id (+ their FK, auto-dropped with the column):
+--   classes, class_chapters, class_journal_entries, class_schedules,
+--   game_timeslots, evaluation_tasks
+-- These KEEP teacher_id (untouched): google_classroom_courses,
+--   google_integrations, orphaned_documents, rag_documents,
+--   teacher_vip_card_overrides.
+
+BEGIN;
+
+-- ===== 1. Helpers =====
+-- Rebase the class-ownership helpers onto the role check. Signatures, SECURITY
+-- DEFINER, search_path and EXCEPTION handlers preserved.
+
+CREATE OR REPLACE FUNCTION "public"."is_class_teacher"("p_class_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+    -- Mono-teacher: the sole teacher (or admin) owns every class.
+    RETURN public.is_teacher_or_admin();
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN FALSE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."is_class_teacher_of"("p_teacher_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    -- Mono-teacher: a target profile is "a teacher of the current user" iff that
+    -- profile is the (sole) teacher/admin. The enrolment join is now redundant.
+    RETURN EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = p_teacher_id
+          AND role IN ('teacher', 'admin')
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN FALSE;
+END;
+$$;
+
+-- ===== 2. RLS policies on the 6 tables =====
+-- Replace every `teacher_id = auth.uid()` predicate with
+-- `public.is_teacher_or_admin()`. Student SELECT policies are kept verbatim
+-- (they use is_class_student()/class_members, not teacher_id). The now-redundant
+-- admin-only policies are dropped (is_admin() ⊂ is_teacher_or_admin()).
+
+-- --- classes ---
+DROP POLICY IF EXISTS "delete_own_classes" ON "public"."classes";
+CREATE POLICY "delete_own_classes" ON "public"."classes" FOR DELETE TO "authenticated"
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "insert_own_classes" ON "public"."classes";
+CREATE POLICY "insert_own_classes" ON "public"."classes" FOR INSERT TO "authenticated"
+    WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "update_own_classes" ON "public"."classes";
+CREATE POLICY "update_own_classes" ON "public"."classes" FOR UPDATE TO "authenticated"
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "view_own_classes" ON "public"."classes";
+CREATE POLICY "view_own_classes" ON "public"."classes" FOR SELECT TO "authenticated"
+    USING ("public"."is_teacher_or_admin"());
+
+-- Redundant admin-only policies (is_admin() ⊂ is_teacher_or_admin()).
+DROP POLICY IF EXISTS "admins_delete_classes" ON "public"."classes";
+DROP POLICY IF EXISTS "admins_insert_classes" ON "public"."classes";
+DROP POLICY IF EXISTS "admins_update_classes" ON "public"."classes";
+DROP POLICY IF EXISTS "admins_view_all_classes" ON "public"."classes";
+-- KEEP "view_member_classes" (student SELECT via class_members) verbatim.
+
+-- --- class_chapters ---
+DROP POLICY IF EXISTS "Teachers can manage chapters of their classes" ON "public"."class_chapters";
+CREATE POLICY "Teachers can manage chapters of their classes" ON "public"."class_chapters" TO "authenticated"
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Admins can manage all chapters" ON "public"."class_chapters";
+-- KEEP "Students can view visible chapters of their classes" verbatim.
+
+-- --- class_journal_entries ---
+-- create/view drop the extra `EXISTS (... classes ...)` clause (redundant once
+-- the predicate is role-based).
+DROP POLICY IF EXISTS "Teachers can create journal entries for their classes" ON "public"."class_journal_entries";
+CREATE POLICY "Teachers can create journal entries for their classes" ON "public"."class_journal_entries" FOR INSERT
+    WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can delete their journal entries" ON "public"."class_journal_entries";
+CREATE POLICY "Teachers can delete their journal entries" ON "public"."class_journal_entries" FOR DELETE
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can update their journal entries" ON "public"."class_journal_entries";
+CREATE POLICY "Teachers can update their journal entries" ON "public"."class_journal_entries" FOR UPDATE
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can view journal entries" ON "public"."class_journal_entries";
+CREATE POLICY "Teachers can view journal entries" ON "public"."class_journal_entries" FOR SELECT
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Admins can manage all journal entries" ON "public"."class_journal_entries";
+-- KEEP "Students can view published journal entries" verbatim.
+
+-- --- class_schedules ---
+DROP POLICY IF EXISTS "Teachers can create schedules for their classes" ON "public"."class_schedules";
+CREATE POLICY "Teachers can create schedules for their classes" ON "public"."class_schedules" FOR INSERT
+    WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can delete their class schedules" ON "public"."class_schedules";
+CREATE POLICY "Teachers can delete their class schedules" ON "public"."class_schedules" FOR DELETE
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can update their class schedules" ON "public"."class_schedules";
+CREATE POLICY "Teachers can update their class schedules" ON "public"."class_schedules" FOR UPDATE
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Teachers can view their class schedules" ON "public"."class_schedules";
+CREATE POLICY "Teachers can view their class schedules" ON "public"."class_schedules" FOR SELECT
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Admins can manage all schedules" ON "public"."class_schedules";
+DROP POLICY IF EXISTS "Admins can view all schedules" ON "public"."class_schedules";
+-- KEEP "Students can view schedules for their classes" verbatim.
+
+-- --- game_timeslots ---
+DROP POLICY IF EXISTS "Teachers can manage own class timeslots" ON "public"."game_timeslots";
+CREATE POLICY "Teachers can manage own class timeslots" ON "public"."game_timeslots"
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+-- KEEP "Students can view class timeslots" verbatim.
+
+-- --- evaluation_tasks ---
+-- Drop the `teacher_id = auth.uid() AND` part; predicate becomes just the role check.
+DROP POLICY IF EXISTS "evaluation_tasks_select_teacher" ON "public"."evaluation_tasks";
+CREATE POLICY "evaluation_tasks_select_teacher" ON "public"."evaluation_tasks" FOR SELECT TO "authenticated"
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "evaluation_tasks_insert_teacher" ON "public"."evaluation_tasks";
+CREATE POLICY "evaluation_tasks_insert_teacher" ON "public"."evaluation_tasks" FOR INSERT TO "authenticated"
+    WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "evaluation_tasks_update_teacher" ON "public"."evaluation_tasks";
+CREATE POLICY "evaluation_tasks_update_teacher" ON "public"."evaluation_tasks" FOR UPDATE TO "authenticated"
+    USING ("public"."is_teacher_or_admin"()) WITH CHECK ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "evaluation_tasks_delete_teacher" ON "public"."evaluation_tasks";
+CREATE POLICY "evaluation_tasks_delete_teacher" ON "public"."evaluation_tasks" FOR DELETE TO "authenticated"
+    USING ("public"."is_teacher_or_admin"());
+
+DROP POLICY IF EXISTS "Admins can manage all evaluation_tasks" ON "public"."evaluation_tasks";
+-- KEEP "evaluation_tasks_select_student" (class_members) verbatim.
+
+-- ===== 3. Class-fetch RPCs =====
+-- Drop the p_teacher_id param, remove teacher_id from RETURNS TABLE, and remove
+-- the `WHERE c.teacher_id = p_teacher_id` filter (mono -> all classes).
+-- Old signatures are dropped first because the parameter list changes.
+
+-- --- get_teacher_classes_with_data ---
+DROP FUNCTION IF EXISTS "public"."get_teacher_classes_with_data"("uuid", boolean);
+CREATE FUNCTION "public"."get_teacher_classes_with_data"("p_is_test_mode" boolean DEFAULT false)
+    RETURNS TABLE("id" "uuid", "name" "text", "description" "text", "join_code" "text", "is_active" boolean, "created_at" timestamp with time zone, "updated_at" timestamp with time zone, "google_classroom_course_id" "uuid", "student_count" bigint, "schedules" "jsonb")
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.name,
+    c.description,
+    c.join_code,
+    c.is_active,
+    c.created_at,
+    c.updated_at,
+    c.google_classroom_course_id,
+    -- Count students filtered by test mode
+    COALESCE(
+      COUNT(DISTINCT cm.student_id) FILTER (
+        WHERE p.id IS NOT NULL
+        AND p.is_test = p_is_test_mode
+      ),
+      0
+    ) AS student_count,
+    -- Aggregate schedules into JSONB array
+    COALESCE(
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
+          'id', cs.id,
+          'class_id', cs.class_id,
+          'day_of_week', cs.day_of_week,
+          'start_time', cs.start_time,
+          'end_time', cs.end_time,
+          'subject', cs.subject,
+          'room', cs.room,
+          'notes', cs.notes
+        )
+        ORDER BY cs.day_of_week, cs.start_time
+      ) FILTER (WHERE cs.id IS NOT NULL),
+      '[]'::JSONB
+    ) AS schedules
+  FROM classes c
+  LEFT JOIN class_members cm ON c.id = cm.class_id
+  LEFT JOIN profiles p ON cm.student_id = p.id
+  LEFT JOIN class_schedules cs ON c.id = cs.class_id
+  WHERE c.is_active = TRUE
+  GROUP BY c.id, c.name, c.description, c.join_code,
+           c.is_active, c.created_at, c.updated_at, c.google_classroom_course_id
+  ORDER BY c.name;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_teacher_classes_with_data"(boolean) OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."get_teacher_classes_with_data"(boolean) IS 'Optimized function to fetch all classes with student counts, schedules, and Google Classroom course association. Mono-teacher: returns every class. Supports test mode filtering for student counts.';
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_data"(boolean) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_data"(boolean) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_data"(boolean) TO "service_role";
+
+-- --- get_teacher_classes_with_students ---
+DROP FUNCTION IF EXISTS "public"."get_teacher_classes_with_students"("uuid", boolean);
+CREATE FUNCTION "public"."get_teacher_classes_with_students"("p_is_test_mode" boolean DEFAULT false)
+    RETURNS TABLE("id" "uuid", "name" "text", "description" "text", "join_code" "text", "is_active" boolean, "created_at" timestamp with time zone, "updated_at" timestamp with time zone, "students" "jsonb")
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.name,
+    c.description,
+    c.join_code,
+    c.is_active,
+    c.created_at,
+    c.updated_at,
+    -- Aggregate students into JSONB array with all required fields
+    -- Filter by is_test to match the requested mode
+    COALESCE(
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
+          'id', p.id,
+          'firstname', p.firstname,
+          'lastname', p.lastname,
+          'full_name', p.full_name,
+          'avatar_url', p.avatar_url,
+          'gidouilles', p.gidouilles,
+          'vip_cards', p.vip_cards,
+          'role', p.role,
+          'is_test', p.is_test
+        )
+        ORDER BY p.firstname NULLS LAST
+      ) FILTER (WHERE p.id IS NOT NULL AND p.is_test = p_is_test_mode),
+      '[]'::JSONB
+    ) AS students
+  FROM classes c
+  LEFT JOIN class_members cm ON c.id = cm.class_id
+  LEFT JOIN profiles p ON cm.student_id = p.id
+  WHERE c.is_active = TRUE
+  GROUP BY c.id, c.name, c.description, c.join_code,
+           c.is_active, c.created_at, c.updated_at
+  ORDER BY c.name;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_teacher_classes_with_students"(boolean) OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."get_teacher_classes_with_students"(boolean) IS 'Optimized function to fetch all classes with full student data filtered by test mode. Mono-teacher: returns every class. When p_is_test_mode = TRUE, returns only test students; when FALSE, only real students. Ensures complete data isolation between test and production environments.';
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_students"(boolean) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_students"(boolean) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_with_students"(boolean) TO "service_role";
+
+-- --- get_teacher_classes_for_messaging ---
+DROP FUNCTION IF EXISTS "public"."get_teacher_classes_for_messaging"("uuid");
+CREATE FUNCTION "public"."get_teacher_classes_for_messaging"()
+    RETURNS TABLE("class_id" "uuid", "class_name" "text", "student_count" integer)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id AS class_id,
+    c.name AS class_name,
+    COUNT(cm.student_id)::INT AS student_count
+  FROM classes c
+  LEFT JOIN class_members cm ON cm.class_id = c.id
+  WHERE c.is_active = TRUE
+  GROUP BY c.id, c.name
+  ORDER BY c.name;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_teacher_classes_for_messaging"() OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."get_teacher_classes_for_messaging"() IS 'Returns all classes for group messaging with student counts (mono-teacher).';
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_for_messaging"() TO "anon";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_for_messaging"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_teacher_classes_for_messaging"() TO "service_role";
+
+-- --- get_teacher_assignment_stats ---
+-- This one filters exercise_assignments.assigned_by (NOT classes.teacher_id).
+-- Replace the p_teacher_id param with auth.uid() (the calling teacher).
+DROP FUNCTION IF EXISTS "public"."get_teacher_assignment_stats"("uuid");
+CREATE FUNCTION "public"."get_teacher_assignment_stats"()
+    RETURNS TABLE("total_assignments" bigint, "active_assignments" bigint, "student_assignments" bigint, "class_assignments" bigint, "public_assignments" bigint, "total_completions" bigint, "unique_students_engaged" bigint)
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+    SELECT
+        COUNT(*) as total_assignments,
+        COUNT(*) FILTER (WHERE is_active = TRUE) as active_assignments,
+        COUNT(*) FILTER (WHERE assigned_to_type = 'student') as student_assignments,
+        COUNT(*) FILTER (WHERE assigned_to_type = 'class') as class_assignments,
+        COUNT(*) FILTER (WHERE assigned_to_type = 'public') as public_assignments,
+        (
+            SELECT COUNT(*)
+            FROM exercise_completions ec
+            JOIN exercise_assignments ea ON ec.assignment_id = ea.id
+            WHERE ea.assigned_by = auth.uid()
+            AND ec.completed_at IS NOT NULL
+        ) as total_completions,
+        (
+            SELECT COUNT(DISTINCT ec.student_id)
+            FROM exercise_completions ec
+            JOIN exercise_assignments ea ON ec.assignment_id = ea.id
+            WHERE ea.assigned_by = auth.uid()
+        ) as unique_students_engaged
+    FROM exercise_assignments
+    WHERE assigned_by = auth.uid();
+$$;
+
+ALTER FUNCTION "public"."get_teacher_assignment_stats"() OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."get_teacher_assignment_stats"() IS 'Returns comprehensive statistics for the calling teacher''s exercise assignments and student engagement (mono-teacher: scoped to auth.uid()).';
+GRANT ALL ON FUNCTION "public"."get_teacher_assignment_stats"() TO "anon";
+GRANT ALL ON FUNCTION "public"."get_teacher_assignment_stats"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_teacher_assignment_stats"() TO "service_role";
+
+-- ===== 4. Other functions referencing classes-cluster teacher_id =====
+
+-- add_student_gidouilles: "student in teacher's classes" -> "student in any class"
+CREATE OR REPLACE FUNCTION "public"."add_student_gidouilles"("p_student_id" "uuid", "p_amount" integer) RETURNS integer
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_is_teacher BOOLEAN;
+  v_student_in_class BOOLEAN;
+  v_current_gidouilles INTEGER;
+  v_new_gidouilles INTEGER;
+BEGIN
+  -- Check if caller is a teacher or admin
+  v_is_teacher := is_teacher_or_admin();
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers can modify gidouilles';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_student_in_class;
+
+  IF NOT v_student_in_class THEN
+    RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+  END IF;
+
+  -- Get current gidouilles
+  SELECT gidouilles INTO v_current_gidouilles
+  FROM profiles
+  WHERE id = p_student_id;
+
+  -- Calculate new balance
+  v_new_gidouilles := v_current_gidouilles + p_amount;
+
+  -- Ensure balance doesn't go negative
+  IF v_new_gidouilles < 0 THEN
+    RAISE EXCEPTION 'Insufficient gidouilles: Cannot go below 0 (current: %, attempted change: %)', v_current_gidouilles, p_amount;
+  END IF;
+
+  -- Update gidouilles
+  UPDATE profiles
+  SET
+    gidouilles = v_new_gidouilles,
+    updated_at = NOW()
+  WHERE id = p_student_id;
+
+  RETURN v_new_gidouilles;
+END;
+$$;
+
+-- approve_vip_card: only the ownership join changes; the activation-approval logic
+-- and audit log are preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."approve_vip_card"("p_student_id" "uuid", "p_instance_id" "text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_vip_cards JSONB;
+  v_card_data JSONB;
+  v_card_id TEXT;
+  v_template RECORD;
+  v_now TIMESTAMPTZ := NOW();
+  v_now_str TEXT;
+BEGIN
+  v_teacher_id := auth.uid();
+
+  IF NOT is_teacher_or_admin() THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Only teachers can approve VIP cards'
+    );
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Student is not in your active classes'
+    );
+  END IF;
+
+  SELECT vip_cards INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  IF v_vip_cards IS NULL THEN
+    v_vip_cards := '{}'::JSONB;
+  END IF;
+
+  v_card_data := v_vip_cards->p_instance_id;
+
+  IF v_card_data IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card instance not found: ' || p_instance_id
+    );
+  END IF;
+
+  IF v_card_data->>'usedAt' IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card has already been used'
+    );
+  END IF;
+
+  IF v_card_data->>'activationApprovedAt' IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card has already been approved'
+    );
+  END IF;
+
+  v_card_id := v_card_data->>'cardId';
+
+  SELECT id, name INTO v_template
+  FROM vip_card_templates
+  WHERE id = v_card_id;
+
+  IF v_template IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card template not found: ' || v_card_id
+    );
+  END IF;
+
+  v_now_str := to_char(v_now, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+
+  v_vip_cards := jsonb_set(
+    v_vip_cards,
+    ARRAY[p_instance_id],
+    v_card_data || jsonb_build_object(
+      'activationApprovedAt', v_now_str,
+      'activationApprovedBy', v_teacher_id::TEXT
+    )
+  );
+
+  INSERT INTO public.vip_cards_activity (
+    student_id, card_instance_id, card_template_id, action, metadata
+  ) VALUES (
+    p_student_id, p_instance_id, v_card_id, 'approved',
+    jsonb_build_object('approved_by', v_teacher_id::TEXT, 'approved_at', v_now_str)
+  );
+
+  UPDATE profiles
+  SET vip_cards = v_vip_cards, updated_at = v_now
+  WHERE id = p_student_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'cardName', v_template.name,
+    'instanceId', p_instance_id,
+    'cardId', v_card_id
+  );
+END;
+$$;
+
+-- award_achievement_manual: keep p_teacher_id param (it stamps unlocked_by/awarded_by),
+-- but drop the classes.teacher_id ownership join -> any class membership.
+CREATE OR REPLACE FUNCTION "public"."award_achievement_manual"("p_teacher_id" "uuid", "p_student_id" "uuid", "p_achievement_id" "text", "p_reason" "text" DEFAULT NULL::"text") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_achievement RECORD;
+  v_is_teacher BOOLEAN;
+BEGIN
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1 FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_is_teacher;
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Teacher does not have access to this student';
+  END IF;
+
+  -- Get achievement
+  SELECT * INTO v_achievement
+  FROM achievements
+  WHERE id = p_achievement_id
+  AND is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Achievement not found';
+  END IF;
+
+  -- Check if achievement allows manual awarding
+  IF v_achievement.unlock_type NOT IN ('manual', 'event_based') THEN
+    RAISE EXCEPTION 'This achievement cannot be manually awarded';
+  END IF;
+
+  -- Award the achievement
+  INSERT INTO student_achievements (
+    student_id,
+    achievement_id,
+    unlocked_by,
+    unlock_reason,
+    points_awarded,
+    gidouilles_awarded
+  )
+  VALUES (
+    p_student_id,
+    p_achievement_id,
+    p_teacher_id,
+    COALESCE(p_reason, 'Manually awarded by teacher'),
+    COALESCE((v_achievement.metadata->>'points')::INTEGER, 0),
+    COALESCE((v_achievement.metadata->>'gidouilles_reward')::INTEGER, 0)
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN FOUND;
+END;
+$$;
+
+-- award_random_vip_card: "student in teacher's classes" -> "student in any class".
+-- Only the ownership join changes; the gidouilles deduction / template pick /
+-- activity log are preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."award_random_vip_card"("p_student_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_is_teacher BOOLEAN;
+  v_student_in_class BOOLEAN;
+  v_current_gidouilles INTEGER;
+  v_new_gidouilles INTEGER;
+  v_card_id TEXT;
+  v_instance_id UUID;
+  v_new_card_instance JSONB;
+  v_earned_at TIMESTAMPTZ;
+  v_template RECORD;
+BEGIN
+  -- Get the current user's ID (the teacher calling this function)
+  v_teacher_id := auth.uid();
+
+  -- Check if caller is a teacher or admin
+  v_is_teacher := is_teacher_or_admin();
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers can award VIP cards';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_student_in_class;
+
+  IF NOT v_student_in_class THEN
+    RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+  END IF;
+
+  -- Get current gidouilles count
+  SELECT gidouilles INTO v_current_gidouilles
+  FROM profiles
+  WHERE id = p_student_id;
+
+  -- Check if student has enough gidouilles (at least 3)
+  IF v_current_gidouilles < 3 THEN
+    RAISE EXCEPTION 'Insufficient gidouilles: Student needs at least 3 gidouilles (current: %)', v_current_gidouilles;
+  END IF;
+
+  -- Calculate new gidouilles value
+  v_new_gidouilles := v_current_gidouilles - 3;
+
+  -- Select random VIP card from enabled templates
+  SELECT id, rarity, uses_total INTO v_template
+  FROM vip_card_templates
+  WHERE is_enabled = TRUE
+  ORDER BY random()
+  LIMIT 1;
+
+  IF v_template IS NULL THEN
+    RAISE EXCEPTION 'No VIP cards available';
+  END IF;
+
+  v_card_id := v_template.id;
+
+  -- Generate unique instance ID
+  v_instance_id := gen_random_uuid();
+
+  -- Capture earned timestamp
+  v_earned_at := now();
+
+  -- Create new card instance
+  v_new_card_instance := jsonb_build_object(
+    'cardId', v_card_id,
+    'earnedAt', v_earned_at,
+    'usedAt', null,
+    'acquiredFrom', 'teacher_draw',
+    'usesRemaining', v_template.uses_total
+  );
+
+  -- Update student profile: deduct gidouilles and add VIP card
+  UPDATE profiles
+  SET
+    gidouilles = v_new_gidouilles,
+    vip_cards = COALESCE(vip_cards, '{}'::jsonb) || jsonb_build_object(v_instance_id::TEXT, v_new_card_instance),
+    updated_at = NOW()
+  WHERE id = p_student_id;
+
+  -- Log activity
+  INSERT INTO vip_cards_activity (
+    student_id,
+    card_instance_id,
+    card_template_id,
+    action,
+    metadata
+  ) VALUES (
+    p_student_id,
+    v_instance_id::TEXT,
+    v_card_id,
+    'gained',
+    jsonb_build_object(
+      'acquired_from', 'teacher_draw',
+      'awarded_by', v_teacher_id,
+      'gidouilles_cost', 3,
+      'old_balance', v_current_gidouilles,
+      'new_balance', v_new_gidouilles,
+      'rarity', v_template.rarity
+    )
+  );
+
+  -- Return complete card information as JSONB
+  RETURN jsonb_build_object(
+    'cardId', v_card_id,
+    'instanceId', v_instance_id,
+    'earnedAt', v_earned_at
+  );
+END;
+$$;
+
+-- award_vip_cards_with_filters: only the ownership join changes; the entire
+-- filter-parsing / weighted-draw loop is preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."award_vip_cards_with_filters"("p_student_id" "uuid", "p_count" integer, "p_filters" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  -- Constants
+  c_min_count CONSTANT INT := 1;
+  c_max_count CONSTANT INT := 10;
+
+  -- Authorization variables
+  v_caller_id UUID;
+  v_is_teacher BOOLEAN;
+  v_student_in_class BOOLEAN;
+
+  -- Filter variables (parsed from p_filters JSONB)
+  v_force_rarity TEXT;
+  v_min_rarity TEXT;
+  v_exclude_card_ids TEXT[];
+  v_only_cards_with_actions BOOLEAN;
+
+  -- Rarity probabilities (for normal draw and minRarity enforcement)
+  v_common_prob INTEGER;
+  v_rare_prob INTEGER;
+  v_epic_prob INTEGER;
+  v_legendary_prob INTEGER;
+  v_common_max INTEGER;
+  v_rare_max INTEGER;
+  v_epic_max INTEGER;
+
+  -- Student profile variables
+  v_vip_cards JSONB;
+
+  -- Card drawing variables
+  v_drawn_cards JSONB := '[]'::jsonb;
+  v_card_id TEXT;
+  v_instance_id UUID;
+  v_earned_at TIMESTAMPTZ;
+  v_new_card_instance JSONB;
+  v_loop_counter INT;
+
+  -- Rarity selection (for minRarity and normal draws)
+  v_roll INTEGER;
+  v_selected_rarity TEXT;
+
+  -- Card details for return value
+  v_card_name TEXT;
+  v_card_rarity TEXT;
+
+  -- Available cards count (for validation)
+  v_available_cards_count INT;
+
+BEGIN
+  -- ========================================
+  -- 1. VALIDATE INPUT PARAMETERS
+  -- ========================================
+
+  -- Validate count range
+  IF p_count < c_min_count OR p_count > c_max_count THEN
+    RAISE EXCEPTION 'Invalid count: Must be between % and % (received: %)',
+      c_min_count, c_max_count, p_count;
+  END IF;
+
+  -- Validate student exists
+  IF NOT EXISTS (SELECT 1 FROM profiles WHERE id = p_student_id) THEN
+    RAISE EXCEPTION 'Student not found: %', p_student_id;
+  END IF;
+
+  -- ========================================
+  -- 2. AUTHORIZATION
+  -- ========================================
+
+  v_caller_id := auth.uid();
+  v_is_teacher := is_teacher_or_admin();
+
+  -- Only teachers can call this function
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers and admins can award VIP cards with filters';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_student_in_class;
+
+  IF NOT v_student_in_class THEN
+    RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+  END IF;
+
+  -- ========================================
+  -- 3. PARSE FILTERS FROM JSONB
+  -- ========================================
+
+  -- Extract forceRarity filter (optional)
+  v_force_rarity := p_filters->>'forceRarity';
+
+  -- Validate forceRarity value if provided
+  IF v_force_rarity IS NOT NULL AND v_force_rarity NOT IN ('common', 'rare', 'epic', 'legendary') THEN
+    RAISE EXCEPTION 'Invalid forceRarity filter: Must be common, rare, epic, or legendary (received: %)', v_force_rarity;
+  END IF;
+
+  -- Extract minRarity filter (optional)
+  v_min_rarity := p_filters->>'minRarity';
+
+  -- Validate minRarity value if provided
+  IF v_min_rarity IS NOT NULL AND v_min_rarity NOT IN ('common', 'rare', 'epic', 'legendary') THEN
+    RAISE EXCEPTION 'Invalid minRarity filter: Must be common, rare, epic, or legendary (received: %)', v_min_rarity;
+  END IF;
+
+  -- Extract excludeCardIds filter (optional array)
+  IF p_filters ? 'excludeCardIds' THEN
+    SELECT ARRAY(
+      SELECT jsonb_array_elements_text(p_filters->'excludeCardIds')
+    ) INTO v_exclude_card_ids;
+  ELSE
+    v_exclude_card_ids := ARRAY[]::TEXT[];
+  END IF;
+
+  -- Extract onlyCardsWithActions filter (optional boolean)
+  v_only_cards_with_actions := COALESCE((p_filters->>'onlyCardsWithActions')::boolean, FALSE);
+
+  RAISE NOTICE 'Filters parsed: forceRarity=%, minRarity=%, excludeCardIds=%, onlyCardsWithActions=%',
+    v_force_rarity, v_min_rarity, v_exclude_card_ids, v_only_cards_with_actions;
+
+  -- ========================================
+  -- 4. VALIDATE FILTERS COMPATIBILITY
+  -- ========================================
+
+  -- forceRarity and minRarity are mutually exclusive
+  IF v_force_rarity IS NOT NULL AND v_min_rarity IS NOT NULL THEN
+    RAISE EXCEPTION 'Invalid filters: forceRarity and minRarity cannot be used together';
+  END IF;
+
+  -- Check if any cards match the filters
+  SELECT COUNT(*) INTO v_available_cards_count
+  FROM vip_card_templates
+  WHERE is_enabled = TRUE
+    AND (v_force_rarity IS NULL OR rarity = v_force_rarity)
+    AND (v_exclude_card_ids IS NULL OR NOT (id = ANY(v_exclude_card_ids)))
+    AND (NOT v_only_cards_with_actions OR action IS NOT NULL);
+
+  IF v_available_cards_count = 0 THEN
+    RAISE EXCEPTION 'No cards available matching filters: forceRarity=%, excludeCardIds=%, onlyCardsWithActions=%',
+      v_force_rarity, v_exclude_card_ids, v_only_cards_with_actions;
+  END IF;
+
+  RAISE NOTICE 'Available cards matching filters: %', v_available_cards_count;
+
+  -- ========================================
+  -- 5. LOCK STUDENT PROFILE (PREVENT RACE CONDITIONS)
+  -- ========================================
+
+  -- Use SELECT FOR UPDATE to prevent concurrent modifications
+  SELECT vip_cards
+  INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  -- Initialize vip_cards if null
+  v_vip_cards := COALESCE(v_vip_cards, '{}'::jsonb);
+
+  -- ========================================
+  -- 6. LOAD RARITY PROBABILITIES (FOR NON-FORCED DRAWS)
+  -- ========================================
+
+  -- Only load probabilities if not using forceRarity
+  IF v_force_rarity IS NULL THEN
+    -- Read active config from vip_card_config table
+    SELECT
+      common_probability,
+      rare_probability,
+      epic_probability,
+      legendary_probability
+    INTO
+      v_common_prob, v_rare_prob, v_epic_prob, v_legendary_prob
+    FROM vip_card_config
+    WHERE is_active = TRUE
+    LIMIT 1;
+
+    -- Fallback to default probabilities if no active config found
+    IF v_common_prob IS NULL THEN
+      v_common_prob := 60;
+      v_rare_prob := 25;
+      v_epic_prob := 12;
+      v_legendary_prob := 3;
+      RAISE NOTICE 'No active config found, using default probabilities';
+    END IF;
+
+    -- Calculate cumulative probability ranges
+    v_common_max := v_common_prob;                          -- 1-60
+    v_rare_max := v_common_max + v_rare_prob;               -- 61-85
+    v_epic_max := v_rare_max + v_epic_prob;                 -- 86-97
+    -- legendary is anything above v_epic_max (98-100)
+
+    RAISE NOTICE 'Using rarity probabilities: common=%, rare=%, epic=%, legendary=%',
+      v_common_prob, v_rare_prob, v_epic_prob, v_legendary_prob;
+  END IF;
+
+  -- ========================================
+  -- 7. DRAW CARDS WITH FILTERS
+  -- ========================================
+
+  FOR v_loop_counter IN 1..p_count LOOP
+
+    -- ------------------------------------
+    -- STEP 1: Determine Rarity for This Card
+    -- ------------------------------------
+
+    IF v_force_rarity IS NOT NULL THEN
+      -- FILTER MODE: forceRarity
+      -- All cards must be of the forced rarity
+      v_selected_rarity := v_force_rarity;
+
+      RAISE NOTICE 'Draw %: forced rarity=%', v_loop_counter, v_selected_rarity;
+
+    ELSIF v_min_rarity IS NOT NULL AND v_loop_counter = 1 THEN
+      -- FILTER MODE: minRarity (FIRST CARD ONLY)
+      -- First card must be at least minRarity or higher
+      -- Use weighted selection from eligible rarities only
+
+      -- Map minRarity to eligible rarities (current and higher)
+      -- Rarity hierarchy: common < rare < epic < legendary
+      v_roll := floor(random() * 100 + 1)::int;
+
+      IF v_min_rarity = 'common' THEN
+        -- All rarities eligible (normal draw)
+        IF v_roll <= v_common_max THEN
+          v_selected_rarity := 'common';
+        ELSIF v_roll <= v_rare_max THEN
+          v_selected_rarity := 'rare';
+        ELSIF v_roll <= v_epic_max THEN
+          v_selected_rarity := 'epic';
+        ELSE
+          v_selected_rarity := 'legendary';
+        END IF;
+
+      ELSIF v_min_rarity = 'rare' THEN
+        -- Only rare, epic, legendary eligible
+        -- Recalculate probabilities: rare/(rare+epic+legendary), etc.
+        DECLARE
+          v_eligible_total INT;
+          v_rare_cutoff INT;
+          v_epic_cutoff INT;
+        BEGIN
+          v_eligible_total := v_rare_prob + v_epic_prob + v_legendary_prob;
+          v_rare_cutoff := (v_rare_prob * 100 / v_eligible_total);
+          v_epic_cutoff := v_rare_cutoff + (v_epic_prob * 100 / v_eligible_total);
+
+          IF v_roll <= v_rare_cutoff THEN
+            v_selected_rarity := 'rare';
+          ELSIF v_roll <= v_epic_cutoff THEN
+            v_selected_rarity := 'epic';
+          ELSE
+            v_selected_rarity := 'legendary';
+          END IF;
+        END;
+
+      ELSIF v_min_rarity = 'epic' THEN
+        -- Only epic, legendary eligible
+        DECLARE
+          v_eligible_total INT;
+          v_epic_cutoff INT;
+        BEGIN
+          v_eligible_total := v_epic_prob + v_legendary_prob;
+          v_epic_cutoff := (v_epic_prob * 100 / v_eligible_total);
+
+          IF v_roll <= v_epic_cutoff THEN
+            v_selected_rarity := 'epic';
+          ELSE
+            v_selected_rarity := 'legendary';
+          END IF;
+        END;
+
+      ELSIF v_min_rarity = 'legendary' THEN
+        -- Only legendary eligible
+        v_selected_rarity := 'legendary';
+
+      END IF;
+
+      RAISE NOTICE 'Draw % (minRarity=%): rolled %, selected rarity=%',
+        v_loop_counter, v_min_rarity, v_roll, v_selected_rarity;
+
+    ELSE
+      -- NORMAL MODE: Weighted rarity selection (no filters or subsequent minRarity cards)
+      v_roll := floor(random() * 100 + 1)::int;
+
+      IF v_roll <= v_common_max THEN
+        v_selected_rarity := 'common';
+      ELSIF v_roll <= v_rare_max THEN
+        v_selected_rarity := 'rare';
+      ELSIF v_roll <= v_epic_max THEN
+        v_selected_rarity := 'epic';
+      ELSE
+        v_selected_rarity := 'legendary';
+      END IF;
+
+      RAISE NOTICE 'Draw %: rolled %, selected rarity=%', v_loop_counter, v_roll, v_selected_rarity;
+
+    END IF;
+
+    -- ------------------------------------
+    -- STEP 2: Select Random Card from Filtered Pool
+    -- ------------------------------------
+
+    SELECT id, name, rarity INTO v_card_id, v_card_name, v_card_rarity
+    FROM vip_card_templates
+    WHERE is_enabled = TRUE
+      AND rarity = v_selected_rarity
+      AND (v_exclude_card_ids IS NULL OR NOT (id = ANY(v_exclude_card_ids)))
+      AND (NOT v_only_cards_with_actions OR action IS NOT NULL)
+    ORDER BY random()
+    LIMIT 1;
+
+    -- ------------------------------------
+    -- STEP 3: Fallback if No Cards Match Filters
+    -- ------------------------------------
+
+    IF v_card_id IS NULL THEN
+      RAISE NOTICE 'No enabled cards for rarity=% with filters, falling back to common', v_selected_rarity;
+
+      -- Fallback to common rarity with same filters
+      SELECT id, name, rarity INTO v_card_id, v_card_name, v_card_rarity
+      FROM vip_card_templates
+      WHERE rarity = 'common'
+        AND is_enabled = TRUE
+        AND (v_exclude_card_ids IS NULL OR NOT (id = ANY(v_exclude_card_ids)))
+        AND (NOT v_only_cards_with_actions OR action IS NOT NULL)
+      ORDER BY random()
+      LIMIT 1;
+
+      -- If still no cards, abort
+      IF v_card_id IS NULL THEN
+        RAISE EXCEPTION 'No enabled VIP cards available matching filters (checked % and common)', v_selected_rarity;
+      END IF;
+    END IF;
+
+    RAISE NOTICE 'Drew card: % (name=%, rarity=%)', v_card_id, v_card_name, v_card_rarity;
+
+    -- ------------------------------------
+    -- STEP 4: Create Card Instance
+    -- ------------------------------------
+
+    -- Generate unique instance ID
+    v_instance_id := gen_random_uuid();
+
+    -- Capture earned timestamp
+    v_earned_at := NOW();
+
+    -- Create new card instance
+    v_new_card_instance := jsonb_build_object(
+      'cardId', v_card_id,
+      'earnedAt', v_earned_at,
+      'usedAt', null
+    );
+
+    -- Add to student's vip_cards JSONB
+    v_vip_cards := v_vip_cards || jsonb_build_object(
+      v_instance_id::text,
+      v_new_card_instance
+    );
+
+    -- Add to results array with full card details
+    v_drawn_cards := v_drawn_cards || jsonb_build_object(
+      'cardId', v_card_id,
+      'instanceId', v_instance_id,
+      'name', v_card_name,
+      'rarity', v_card_rarity,
+      'earnedAt', v_earned_at
+    );
+
+  END LOOP;
+
+  -- ========================================
+  -- 8. UPDATE STUDENT PROFILE
+  -- ========================================
+
+  UPDATE profiles
+  SET
+    vip_cards = v_vip_cards,
+    updated_at = NOW()
+  WHERE id = p_student_id;
+
+  -- ========================================
+  -- 9. RETURN RESULTS
+  -- ========================================
+
+  RETURN jsonb_build_object(
+    'cards', v_drawn_cards
+  );
+
+END;
+$$;
+
+-- can_view_student_profile: "teacher's class has student" -> teacher/admin AND
+-- student is in some class.
+CREATE OR REPLACE FUNCTION "public"."can_view_student_profile"("student_profile_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  -- Mono-teacher: the sole teacher/admin may view any student that is enrolled
+  -- in at least one class.
+  RETURN public.is_teacher_or_admin() AND EXISTS (
+    SELECT 1
+    FROM public.class_members cm
+    WHERE cm.student_id = student_profile_id
+  );
+END;
+$$;
+
+-- create_class_chat_room: trigger on classes INSERT. NEW.teacher_id is gone;
+-- attribute the chat room to the sole teacher.
+CREATE OR REPLACE FUNCTION "public"."create_class_chat_room"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  new_conversation_id UUID;
+  v_teacher_id UUID;
+BEGIN
+  -- Mono-teacher: resolve the sole teacher (the class creator/owner).
+  SELECT id INTO v_teacher_id
+  FROM profiles
+  WHERE role = 'teacher'
+  LIMIT 1;
+
+  -- Create a conversation for the new class
+  INSERT INTO conversations (
+    name,
+    is_group,
+    class_id,
+    created_by,
+    created_at
+  ) VALUES (
+    NEW.name || ' - Chat de classe', -- e.g., "6ème A - Chat de classe"
+    true, -- is_group
+    NEW.id, -- class_id
+    v_teacher_id, -- created_by (sole teacher)
+    NOW()
+  )
+  RETURNING id INTO new_conversation_id;
+
+  -- Add the teacher as a participant
+  IF v_teacher_id IS NOT NULL THEN
+    INSERT INTO conversation_participants (
+      conversation_id,
+      user_id,
+      joined_at
+    ) VALUES (
+      new_conversation_id,
+      v_teacher_id,
+      NOW()
+    );
+  END IF;
+
+  -- Add all existing class members as participants
+  INSERT INTO conversation_participants (
+    conversation_id,
+    user_id,
+    joined_at
+  )
+  SELECT
+    new_conversation_id,
+    cm.student_id,
+    NOW()
+  FROM class_members cm
+  WHERE cm.class_id = NEW.id;
+
+  RETURN NEW;
+END;
+$$;
+
+-- create_tournament: drop the per-class `classes.teacher_id = v_user_id`
+-- ownership check; the sole teacher owns every class, so only verify existence.
+CREATE OR REPLACE FUNCTION "public"."create_tournament"("p_name" "text", "p_difficulty" "text", "p_start_date" timestamp with time zone, "p_end_date" timestamp with time zone, "p_class_ids" "uuid"[] DEFAULT NULL::"uuid"[], "p_description" "text" DEFAULT NULL::"text", "p_top_x_games" integer DEFAULT 3, "p_podium_rewards" "jsonb" DEFAULT '{"1": 10, "2": 5, "3": 3}'::"jsonb", "p_podium_places" integer DEFAULT 3) RETURNS "uuid"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_user_id UUID;
+  v_user_role TEXT;
+  v_scope TEXT;
+  v_class_id UUID;
+  v_tournament_id UUID;
+BEGIN
+  -- Step 1: Get authenticated user
+  v_user_id := auth.uid();
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Must be authenticated to create a tournament';
+  END IF;
+
+  -- Step 2: Get user role
+  SELECT role INTO v_user_role
+  FROM public.profiles
+  WHERE id = v_user_id;
+
+  IF v_user_role NOT IN ('teacher', 'admin') THEN
+    RAISE EXCEPTION 'Only teachers and admins can create tournaments';
+  END IF;
+
+  -- Step 3: Validate inputs
+  IF p_name IS NULL OR length(trim(p_name)) < 3 THEN
+    RAISE EXCEPTION 'Tournament name must be at least 3 characters';
+  END IF;
+
+  IF p_difficulty NOT IN ('beginner', 'intermediate', 'expert') THEN
+    RAISE EXCEPTION 'Invalid difficulty: must be beginner, intermediate, or expert';
+  END IF;
+
+  IF p_end_date <= p_start_date THEN
+    RAISE EXCEPTION 'End date must be after start date';
+  END IF;
+
+  IF p_top_x_games < 1 OR p_top_x_games > 20 THEN
+    RAISE EXCEPTION 'top_x_games must be between 1 and 20';
+  END IF;
+
+  IF p_podium_places < 1 OR p_podium_places > 10 THEN
+    RAISE EXCEPTION 'podium_places must be between 1 and 10';
+  END IF;
+
+  -- Step 4: Determine scope and validate classes
+  IF p_class_ids IS NULL OR array_length(p_class_ids, 1) IS NULL THEN
+    -- Global tournament (admin only)
+    IF v_user_role != 'admin' THEN
+      RAISE EXCEPTION 'Only admins can create global tournaments (no classes specified)';
+    END IF;
+    v_scope := 'global';
+  ELSE
+    -- Class-scoped tournament
+    v_scope := 'classes';
+
+    -- Mono-teacher: the sole teacher owns every class, so only verify existence.
+    FOREACH v_class_id IN ARRAY p_class_ids
+    LOOP
+      IF NOT EXISTS (
+        SELECT 1 FROM public.classes WHERE id = v_class_id
+      ) THEN
+        RAISE EXCEPTION 'Class not found: %', v_class_id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- Step 5: Validate podium_rewards has entries for all places
+  FOR i IN 1..p_podium_places
+  LOOP
+    IF NOT (p_podium_rewards ? i::TEXT) THEN
+      RAISE EXCEPTION 'podium_rewards must have entry for place %', i;
+    END IF;
+    IF NOT ((p_podium_rewards->>i::TEXT)::INTEGER >= 0) THEN
+      RAISE EXCEPTION 'podium_rewards for place % must be non-negative integer', i;
+    END IF;
+  END LOOP;
+
+  -- Step 6: Create tournament
+  INSERT INTO public.minesweeper_tournaments (
+    creator_id,
+    creator_role,
+    scope,
+    name,
+    description,
+    difficulty,
+    start_date,
+    end_date,
+    top_x_games,
+    podium_rewards,
+    podium_places
+  ) VALUES (
+    v_user_id,
+    v_user_role,
+    v_scope,
+    trim(p_name),
+    p_description,
+    p_difficulty,
+    p_start_date,
+    p_end_date,
+    p_top_x_games,
+    p_podium_rewards,
+    p_podium_places
+  )
+  RETURNING id INTO v_tournament_id;
+
+  -- Step 7: Create class associations (if class-scoped)
+  IF v_scope = 'classes' THEN
+    INSERT INTO public.minesweeper_tournament_classes (tournament_id, class_id)
+    SELECT v_tournament_id, unnest(p_class_ids);
+  END IF;
+
+  RETURN v_tournament_id;
+END;
+$$;
+
+-- draw_multiple_vip_cards: only two things change; everything else is verbatim:
+-- (1) the ownership join `class_members cm JOIN classes c ... AND c.teacher_id`
+--     becomes a bare class_members membership check (mono-teacher);
+-- (2) the two `tvo.teacher_id IN (SELECT DISTINCT c.teacher_id ...)` blocked-card
+--     subqueries become `tvo.teacher_id IN (SELECT id FROM profiles WHERE role='teacher')`
+--     (a card disabled by the sole teacher stays blocked).
+CREATE OR REPLACE FUNCTION "public"."draw_multiple_vip_cards"("p_student_id" "uuid", "p_count" integer, "p_payment_method" "text", "p_gidouilles_cost" integer DEFAULT NULL::integer, "p_vip_card_instance_id" "uuid" DEFAULT NULL::"uuid", "p_force_rarity" "text" DEFAULT NULL::"text", "p_min_rarity" "text" DEFAULT NULL::"text", "p_exclude_card_ids" "text"[] DEFAULT NULL::"text"[], "p_only_cards_with_actions" boolean DEFAULT false) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  -- Constants
+  c_max_cost_per_card CONSTANT INT := 10;
+  c_min_count CONSTANT INT := 1;
+  c_max_count CONSTANT INT := 10;
+
+  -- Authorization variables
+  v_caller_id UUID;
+  v_is_teacher BOOLEAN;
+  v_is_authorized BOOLEAN;
+  v_student_in_class BOOLEAN;
+
+  -- Student profile variables
+  v_current_gidouilles INT;
+  v_vip_cards JSONB;
+  v_card_instance JSONB;
+  v_card_used_at TEXT;
+  v_payment_card_id TEXT;
+  v_payment_card_name TEXT;
+
+  -- Card drawing variables (weighted by rarity)
+  v_common_prob INTEGER;
+  v_rare_prob INTEGER;
+  v_epic_prob INTEGER;
+  v_legendary_prob INTEGER;
+  v_common_max INTEGER;
+  v_rare_max INTEGER;
+  v_epic_max INTEGER;
+  v_roll INTEGER;
+  v_selected_rarity TEXT;
+  v_drawn_cards JSONB := '[]'::jsonb;
+  v_card_id TEXT;
+  v_available_card_ids TEXT[];
+  v_instance_id UUID;
+  v_earned_at TIMESTAMPTZ;
+  v_new_card_instance JSONB;
+  v_loop_counter INT;
+
+  -- Filter variables
+  v_min_rarity_level INT;
+  v_rolled_rarity_level INT;
+
+  -- Timestamp for audit
+  v_now_str TEXT;
+
+  -- Acquisition source for JSONB instance + audit
+  v_acquired_from TEXT;
+
+  -- Class ID for audit trail
+  v_class_id UUID;
+
+BEGIN
+  -- ========================================
+  -- 1. VALIDATE INPUT PARAMETERS
+  -- ========================================
+
+  IF p_count < c_min_count OR p_count > c_max_count THEN
+    RAISE EXCEPTION 'Invalid count: Must be between % and % (received: %)',
+      c_min_count, c_max_count, p_count;
+  END IF;
+
+  IF p_payment_method NOT IN ('gidouilles', 'vip_card') THEN
+    RAISE EXCEPTION 'Invalid payment_method: Must be ''gidouilles'' or ''vip_card'' (received: ''%'')',
+      p_payment_method;
+  END IF;
+
+  IF p_force_rarity IS NOT NULL AND p_force_rarity NOT IN ('common', 'rare', 'epic', 'legendary') THEN
+    RAISE EXCEPTION 'Invalid force_rarity: Must be ''common'', ''rare'', ''epic'', or ''legendary'' (received: ''%'')',
+      p_force_rarity;
+  END IF;
+
+  IF p_min_rarity IS NOT NULL AND p_min_rarity NOT IN ('common', 'rare', 'epic', 'legendary') THEN
+    RAISE EXCEPTION 'Invalid min_rarity: Must be ''common'', ''rare'', ''epic'', or ''legendary'' (received: ''%'')',
+      p_min_rarity;
+  END IF;
+
+  IF p_force_rarity IS NOT NULL AND p_min_rarity IS NOT NULL THEN
+    RAISE EXCEPTION 'Invalid filters: force_rarity and min_rarity are mutually exclusive';
+  END IF;
+
+  -- Compute acquiredFrom once based on payment method
+  v_acquired_from := CASE p_payment_method
+    WHEN 'gidouilles' THEN 'draw_gidouilles'
+    WHEN 'vip_card' THEN 'draw_vip_card'
+  END;
+
+  -- ========================================
+  -- 2. AUTHORIZATION
+  -- ========================================
+
+  v_caller_id := auth.uid();
+  v_is_teacher := is_teacher_or_admin();
+
+  IF v_is_teacher THEN
+    -- Mono-teacher: any class membership means the sole teacher teaches this student.
+    SELECT EXISTS (
+      SELECT 1
+      FROM class_members cm
+      WHERE cm.student_id = p_student_id
+    ) INTO v_student_in_class;
+
+    IF NOT v_student_in_class THEN
+      RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+    END IF;
+
+    v_is_authorized := TRUE;
+  ELSIF v_caller_id = p_student_id THEN
+    v_is_authorized := TRUE;
+  ELSE
+    RAISE EXCEPTION 'Unauthorized: You can only draw cards for yourself or your students';
+  END IF;
+
+  -- ========================================
+  -- 3. LOCK STUDENT PROFILE
+  -- ========================================
+
+  SELECT gidouilles, vip_cards
+  INTO v_current_gidouilles, v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Student profile not found';
+  END IF;
+
+  -- Get student's active class for audit trail
+  SELECT cm.class_id INTO v_class_id
+  FROM class_members cm
+  WHERE cm.student_id = p_student_id
+    AND cm.status = 'active'
+  LIMIT 1;
+
+  -- ========================================
+  -- 4. LOAD RARITY PROBABILITIES FROM CONFIG
+  -- ========================================
+
+  SELECT
+    common_probability,
+    rare_probability,
+    epic_probability,
+    legendary_probability
+  INTO
+    v_common_prob, v_rare_prob, v_epic_prob, v_legendary_prob
+  FROM vip_card_config
+  WHERE is_active = TRUE
+  LIMIT 1;
+
+  IF v_common_prob IS NULL THEN
+    v_common_prob := 60;
+    v_rare_prob := 25;
+    v_epic_prob := 12;
+    v_legendary_prob := 3;
+  END IF;
+
+  v_common_max := v_common_prob;
+  v_rare_max := v_common_max + v_rare_prob;
+  v_epic_max := v_rare_max + v_epic_prob;
+
+  IF p_min_rarity IS NOT NULL THEN
+    v_min_rarity_level := CASE p_min_rarity
+      WHEN 'common' THEN 1
+      WHEN 'rare' THEN 2
+      WHEN 'epic' THEN 3
+      WHEN 'legendary' THEN 4
+    END;
+  END IF;
+
+  -- ========================================
+  -- 5. PROCESS PAYMENT
+  -- ========================================
+
+  IF p_payment_method = 'gidouilles' THEN
+    IF p_gidouilles_cost IS NULL THEN
+      RAISE EXCEPTION 'Missing parameter: gidouilles_cost is required for gidouilles payment';
+    END IF;
+
+    IF p_gidouilles_cost < 0 THEN
+      RAISE EXCEPTION 'Invalid gidouilles_cost: Cannot be negative (received: %)', p_gidouilles_cost;
+    END IF;
+
+    IF p_gidouilles_cost > (p_count * c_max_cost_per_card) THEN
+      RAISE EXCEPTION 'Invalid gidouilles_cost: Maximum % gidouilles for % cards (received: %)',
+        (p_count * c_max_cost_per_card), p_count, p_gidouilles_cost;
+    END IF;
+
+    IF p_gidouilles_cost = 0 AND NOT v_is_teacher THEN
+      RAISE EXCEPTION 'Unauthorized: Students cannot draw free cards (cost must be > 0)';
+    END IF;
+
+    IF v_current_gidouilles < p_gidouilles_cost THEN
+      RAISE EXCEPTION 'Insufficient gidouilles: Required %, available % (shortfall: %)',
+        p_gidouilles_cost, v_current_gidouilles, (p_gidouilles_cost - v_current_gidouilles);
+    END IF;
+
+    v_current_gidouilles := v_current_gidouilles - p_gidouilles_cost;
+
+    -- Log gidouilles spent for audit trail
+    IF p_gidouilles_cost > 0 THEN
+      INSERT INTO gidouilles_activity (
+        student_id,
+        class_id,
+        delta,
+        reason,
+        created_by
+      ) VALUES (
+        p_student_id,
+        v_class_id,
+        -p_gidouilles_cost,
+        'Tirage de ' || p_count || ' carte' || CASE WHEN p_count > 1 THEN 's' ELSE '' END || ' VIP',
+        NULL
+      );
+    END IF;
+
+  ELSIF p_payment_method = 'vip_card' THEN
+    IF p_vip_card_instance_id IS NULL THEN
+      RAISE EXCEPTION 'Missing parameter: vip_card_instance_id is required for vip_card payment';
+    END IF;
+
+    v_vip_cards := COALESCE(v_vip_cards, '{}'::jsonb);
+    v_card_instance := v_vip_cards->p_vip_card_instance_id::text;
+
+    IF v_card_instance IS NULL THEN
+      RAISE EXCEPTION 'VIP card not found: Instance ID % does not exist in student''s cards',
+        p_vip_card_instance_id;
+    END IF;
+
+    v_card_used_at := v_card_instance->>'usedAt';
+
+    IF v_card_used_at IS NOT NULL THEN
+      RAISE EXCEPTION 'VIP card already used: This card was used at %', v_card_used_at;
+    END IF;
+
+    -- Extract template ID and look up card name for audit trail
+    v_payment_card_id := v_card_instance->>'cardId';
+
+    SELECT name INTO v_payment_card_name
+    FROM vip_card_templates
+    WHERE id = v_payment_card_id;
+
+    v_payment_card_name := COALESCE(v_payment_card_name, v_payment_card_id);
+
+    -- Mark card as used
+    v_now_str := to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+    v_vip_cards := jsonb_set(
+      v_vip_cards,
+      ARRAY[p_vip_card_instance_id::text, 'usedAt'],
+      to_jsonb(v_now_str)
+    );
+
+    -- AUDIT: Log VIP card payment atomically within this transaction
+    INSERT INTO public.vip_cards_activity (
+      student_id, card_instance_id, card_template_id, action, metadata
+    ) VALUES (
+      p_student_id,
+      p_vip_card_instance_id::text,
+      COALESCE(v_payment_card_id, 'unknown'),
+      'used',
+      jsonb_build_object(
+        'used_at', v_now_str,
+        'action_type', 'draw_cards',
+        'cards_drawn', p_count,
+        'filters', jsonb_build_object(
+          'force_rarity', p_force_rarity,
+          'min_rarity', p_min_rarity,
+          'exclude_card_ids', to_jsonb(COALESCE(p_exclude_card_ids, ARRAY[]::TEXT[])),
+          'only_cards_with_actions', p_only_cards_with_actions
+        )
+      )
+    );
+
+  END IF;
+
+  -- ========================================
+  -- 6. DRAW RANDOM VIP CARDS
+  -- ========================================
+
+  FOR v_loop_counter IN 1..p_count LOOP
+
+    IF p_force_rarity IS NOT NULL THEN
+      v_selected_rarity := p_force_rarity;
+    ELSE
+      v_roll := floor(random() * 100 + 1)::int;
+
+      IF v_roll <= v_common_max THEN
+        v_selected_rarity := 'common';
+        v_rolled_rarity_level := 1;
+      ELSIF v_roll <= v_rare_max THEN
+        v_selected_rarity := 'rare';
+        v_rolled_rarity_level := 2;
+      ELSIF v_roll <= v_epic_max THEN
+        v_selected_rarity := 'epic';
+        v_rolled_rarity_level := 3;
+      ELSE
+        v_selected_rarity := 'legendary';
+        v_rolled_rarity_level := 4;
+      END IF;
+
+      IF p_min_rarity IS NOT NULL AND v_rolled_rarity_level < v_min_rarity_level THEN
+        v_selected_rarity := p_min_rarity;
+      END IF;
+    END IF;
+
+    SELECT ARRAY_AGG(vct.id)
+    INTO v_available_card_ids
+    FROM vip_card_templates vct
+    WHERE vct.rarity = v_selected_rarity
+      AND vct.is_enabled = TRUE
+      AND NOT EXISTS (
+        SELECT 1
+        FROM teacher_vip_card_overrides tvo
+        WHERE tvo.card_id = vct.id
+          AND tvo.is_enabled = FALSE
+          AND tvo.teacher_id IN (
+            SELECT id FROM profiles WHERE role = 'teacher'
+          )
+      )
+      AND (p_exclude_card_ids IS NULL OR vct.id != ALL(p_exclude_card_ids))
+      AND (NOT p_only_cards_with_actions OR vct.action IS NOT NULL);
+
+    IF v_available_card_ids IS NULL OR array_length(v_available_card_ids, 1) IS NULL THEN
+      IF p_force_rarity IS NOT NULL THEN
+        RAISE EXCEPTION 'No enabled VIP cards available for forced rarity ''%'' (all cards may be disabled by teacher overrides, excluded, or filtered out)',
+          p_force_rarity;
+      END IF;
+
+      SELECT ARRAY_AGG(vct.id)
+      INTO v_available_card_ids
+      FROM vip_card_templates vct
+      WHERE vct.rarity = 'common'
+        AND vct.is_enabled = TRUE
+        AND NOT EXISTS (
+          SELECT 1
+          FROM teacher_vip_card_overrides tvo
+          WHERE tvo.card_id = vct.id
+            AND tvo.is_enabled = FALSE
+            AND tvo.teacher_id IN (
+              SELECT id FROM profiles WHERE role = 'teacher'
+            )
+        )
+        AND (p_exclude_card_ids IS NULL OR vct.id != ALL(p_exclude_card_ids))
+        AND (NOT p_only_cards_with_actions OR vct.action IS NOT NULL);
+
+      IF v_available_card_ids IS NULL OR array_length(v_available_card_ids, 1) IS NULL THEN
+        RAISE EXCEPTION 'No enabled VIP cards available to draw (all cards disabled by teacher overrides, excluded, or filtered out)';
+      END IF;
+    END IF;
+
+    v_card_id := v_available_card_ids[floor(random() * array_length(v_available_card_ids, 1) + 1)::int];
+
+    v_instance_id := gen_random_uuid();
+    v_earned_at := NOW();
+
+    v_new_card_instance := jsonb_build_object(
+      'cardId', v_card_id,
+      'earnedAt', v_earned_at,
+      'usedAt', null,
+      'acquiredFrom', v_acquired_from
+    );
+
+    v_vip_cards := COALESCE(v_vip_cards, '{}'::jsonb) || jsonb_build_object(
+      v_instance_id::text,
+      v_new_card_instance
+    );
+
+    v_drawn_cards := v_drawn_cards || jsonb_build_object(
+      'cardId', v_card_id,
+      'instanceId', v_instance_id,
+      'earnedAt', v_earned_at
+    );
+
+    -- Log 'gained' audit entry for each drawn card
+    INSERT INTO public.vip_cards_activity (
+      student_id, card_instance_id, card_template_id, action, metadata
+    ) VALUES (
+      p_student_id,
+      v_instance_id::text,
+      v_card_id,
+      'gained',
+      jsonb_build_object(
+        'acquired_from', v_acquired_from,
+        'rarity', v_selected_rarity,
+        'payment_method', p_payment_method,
+        'payment_card_name', v_payment_card_name
+      )
+    );
+
+  END LOOP;
+
+  -- ========================================
+  -- 7. UPDATE STUDENT PROFILE
+  -- ========================================
+
+  UPDATE profiles
+  SET
+    gidouilles = v_current_gidouilles,
+    vip_cards = v_vip_cards,
+    updated_at = NOW()
+  WHERE id = p_student_id;
+
+  -- ========================================
+  -- 8. RETURN RESULTS
+  -- ========================================
+
+  RETURN jsonb_build_object(
+    'cards', v_drawn_cards
+  );
+
+END;
+$$;
+
+-- get_allowed_recipients: intentionally NOT redefined. Its live version (migration
+-- 20260618093000, Option B) is already role-based, references neither classes
+-- nor teacher_id nor the dead RPCs, and lets a hors-classe student message the
+-- sole teacher. Redefining it from the baseline body would REGRESS Option B.
+
+-- get_available_cards_for_student: replace the blocked-card subquery with the
+-- sole teacher.
+CREATE OR REPLACE FUNCTION "public"."get_available_cards_for_student"("p_student_id" "uuid") RETURNS TABLE("card_id" "text", "card_name" "text", "rarity" "text", "is_globally_enabled" boolean, "blocked_by_teachers" "text"[])
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    vct.id as card_id,
+    vct.name as card_name,
+    vct.rarity,
+    vct.is_enabled as is_globally_enabled,
+    ARRAY_AGG(DISTINCT p.full_name) FILTER (WHERE tvo.is_enabled = FALSE) as blocked_by_teachers
+  FROM vip_card_templates vct
+  LEFT JOIN teacher_vip_card_overrides tvo ON tvo.card_id = vct.id
+    AND tvo.teacher_id IN (
+      SELECT id FROM profiles WHERE role = 'teacher'
+    )
+  LEFT JOIN profiles p ON p.id = tvo.teacher_id
+  GROUP BY vct.id, vct.name, vct.rarity, vct.is_enabled
+  ORDER BY
+    CASE vct.rarity
+      WHEN 'common' THEN 1
+      WHEN 'rare' THEN 2
+      WHEN 'epic' THEN 3
+      WHEN 'legendary' THEN 4
+    END,
+    vct.name;
+END;
+$$;
+
+-- get_consent_info: the teacher-name lookup joined classes by teacher_id; with
+-- it gone, resolve the teacher name from class_members -> classes -> sole teacher.
+CREATE OR REPLACE FUNCTION "public"."get_consent_info"("p_token" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_consent_id UUID;
+    v_student_id UUID;
+    v_status consent_status;
+    v_expires_at TIMESTAMPTZ;
+    v_parent_email TEXT;
+    v_student RECORD;
+    v_teacher_name TEXT;
+    v_school_name TEXT;
+BEGIN
+    -- Find the consent record by token
+    SELECT id, student_id, status, expires_at, parent_email
+    INTO v_consent_id, v_student_id, v_status, v_expires_at, v_parent_email
+    FROM parental_consents
+    WHERE consent_token = p_token;
+
+    -- Token not found
+    IF v_consent_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'TOKEN_NOT_FOUND',
+            'message', 'Lien de consentement invalide.'
+        );
+    END IF;
+
+    -- Already granted
+    IF v_status = 'granted' THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'ALREADY_GRANTED',
+            'message', 'Ce consentement a déjà été accordé.'
+        );
+    END IF;
+
+    -- Token expired
+    IF v_expires_at < NOW() THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'TOKEN_EXPIRED',
+            'message', 'Ce lien a expiré. Contactez l''enseignant pour recevoir un nouveau lien.'
+        );
+    END IF;
+
+    -- Get student info (limited fields for privacy)
+    SELECT firstname, lastname, grade
+    INTO v_student
+    FROM profiles
+    WHERE id = v_student_id;
+
+    -- Mono-teacher: the consenting student's teacher is the sole teacher.
+    SELECT p.firstname || ' ' || p.lastname
+    INTO v_teacher_name
+    FROM profiles p
+    WHERE p.role = 'teacher'
+    LIMIT 1;
+
+    -- Try to get school name
+    SELECT s.name
+    INTO v_school_name
+    FROM class_members cm
+    JOIN classes c ON cm.class_id = c.id
+    JOIN schools s ON c.school_id = s.id
+    WHERE cm.student_id = v_student_id
+    LIMIT 1;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'student', jsonb_build_object(
+            'firstname', v_student.firstname,
+            'lastname', v_student.lastname,
+            'grade', v_student.grade
+        ),
+        'teacher_name', v_teacher_name,
+        'school_name', v_school_name,
+        'parent_email', v_parent_email,
+        'expires_at', v_expires_at
+    );
+END;
+$$;
+
+-- get_teacher_override_impact: keep the p_teacher_id param (it refers to a tvo
+-- override). The classes.teacher_id filter is gone -> count ALL classes/students.
+CREATE OR REPLACE FUNCTION "public"."get_teacher_override_impact"("p_teacher_id" "uuid", "p_card_id" "text") RETURNS TABLE("student_count" bigint, "class_count" bigint)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(DISTINCT cm.student_id) as student_count,
+    COUNT(DISTINCT c.id) as class_count
+  FROM classes c
+  INNER JOIN class_members cm ON cm.class_id = c.id;
+END;
+$$;
+
+-- grant_specific_vip_card: only the ownership join changes (the p_count loop and
+-- activity log are preserved verbatim).
+CREATE OR REPLACE FUNCTION "public"."grant_specific_vip_card"("p_student_id" "uuid", "p_card_id" "text", "p_count" integer DEFAULT 1) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_is_teacher BOOLEAN;
+  v_vip_cards JSONB;
+  v_new_instance JSONB;
+  v_new_instance_id UUID;
+  v_earned_at TIMESTAMPTZ;
+  v_result JSONB;
+  v_cards JSONB[];
+  v_template RECORD;
+  i INT;
+BEGIN
+  -- Get the calling user ID
+  v_teacher_id := auth.uid();
+
+  -- Check if the user is a teacher or admin
+  SELECT is_teacher_or_admin()
+  INTO v_is_teacher;
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Only teachers and admins can grant VIP cards';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) THEN
+    RAISE EXCEPTION 'You do not have permission to grant cards to this student';
+  END IF;
+
+  -- Get template info (validate card exists and get rarity)
+  SELECT id, rarity, uses_total INTO v_template
+  FROM vip_card_templates WHERE id = p_card_id;
+
+  IF v_template IS NULL THEN
+    RAISE EXCEPTION 'Invalid card ID: %', p_card_id;
+  END IF;
+
+  -- Validate count
+  IF p_count < 1 OR p_count > 10 THEN
+    RAISE EXCEPTION 'Count must be between 1 and 10';
+  END IF;
+
+  -- Lock the student's profile row to prevent race conditions
+  SELECT vip_cards
+  INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  -- Initialize empty array if vip_cards is null
+  IF v_vip_cards IS NULL THEN
+    v_vip_cards := '{}'::JSONB;
+  END IF;
+
+  -- Initialize result array
+  v_cards := ARRAY[]::JSONB[];
+  v_earned_at := NOW();
+
+  -- Add the specified card p_count times
+  FOR i IN 1..p_count LOOP
+    v_new_instance_id := gen_random_uuid();
+
+    v_new_instance := jsonb_build_object(
+      'cardId', p_card_id,
+      'earnedAt', v_earned_at,
+      'usedAt', NULL,
+      'acquiredFrom', 'teacher_award',
+      'usesRemaining', v_template.uses_total
+    );
+
+    -- Add to vip_cards JSONB object
+    v_vip_cards := v_vip_cards || jsonb_build_object(v_new_instance_id::TEXT, v_new_instance);
+
+    -- Log activity
+    INSERT INTO vip_cards_activity (
+      student_id,
+      card_instance_id,
+      card_template_id,
+      action,
+      metadata
+    ) VALUES (
+      p_student_id,
+      v_new_instance_id::TEXT,
+      p_card_id,
+      'gained',
+      jsonb_build_object(
+        'acquired_from', 'teacher_award',
+        'awarded_by', v_teacher_id,
+        'rarity', v_template.rarity
+      )
+    );
+
+    -- Add to result array
+    v_cards := v_cards || jsonb_build_object(
+      'cardId', p_card_id,
+      'instanceId', v_new_instance_id,
+      'earnedAt', v_earned_at
+    );
+  END LOOP;
+
+  -- Update the student's profile
+  UPDATE profiles
+  SET vip_cards = v_vip_cards
+  WHERE id = p_student_id;
+
+  -- Build result object
+  v_result := jsonb_build_object('cards', to_jsonb(v_cards));
+
+  RETURN v_result;
+END;
+$$;
+
+-- initialize_default_categories: drop the classes.teacher_id ownership check.
+CREATE OR REPLACE FUNCTION "public"."initialize_default_categories"("p_class_id" "uuid") RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+    -- SECURITY CHECK: mono-teacher -> any teacher/admin may initialize categories.
+    IF auth.uid() IS NULL OR NOT public.is_teacher_or_admin() THEN
+        RAISE EXCEPTION 'Unauthorized: You do not have permission to initialize categories for this class';
+    END IF;
+
+    -- Insert default categories (ON CONFLICT DO NOTHING to handle re-runs)
+    INSERT INTO public.coursework_categories (class_id, name, icon, color, display_order, created_by)
+    VALUES
+        (p_class_id, 'Cours', '📚', '#3B82F6', 1, auth.uid()),
+        (p_class_id, 'Exercices', '✏️', '#10B981', 2, auth.uid()),
+        (p_class_id, 'Corrections', '✅', '#8B5CF6', 3, auth.uid()),
+        (p_class_id, 'Devoirs', '📝', '#F59E0B', 4, auth.uid()),
+        (p_class_id, 'Évaluations', '🎯', '#EF4444', 5, auth.uid())
+    ON CONFLICT (class_id, name) DO NOTHING;
+END;
+$$;
+
+-- is_teacher_for_shared_coursework: "owns the linked class" -> teacher/admin.
+CREATE OR REPLACE FUNCTION "public"."is_teacher_for_shared_coursework"("p_shared_coursework_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+    -- Mono-teacher: the sole teacher/admin owns every class, hence every shared
+    -- coursework. SECURITY DEFINER bypasses RLS, preventing infinite recursion.
+    RETURN public.is_teacher_or_admin();
+END;
+$$;
+
+-- is_teacher_of_class: "owns this class" -> teacher/admin.
+CREATE OR REPLACE FUNCTION "public"."is_teacher_of_class"("p_class_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+begin
+    -- Mono-teacher: the sole teacher (or admin) is the teacher of every class.
+    return public.is_teacher_or_admin();
+exception
+    when others then
+        return false;
+end;
+$$;
+
+-- is_teacher_of_student: "owns a class with this student" -> teacher/admin AND
+-- the student is enrolled somewhere.
+CREATE OR REPLACE FUNCTION "public"."is_teacher_of_student"("p_student_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+begin
+    -- Mono-teacher: the sole teacher/admin teaches any enrolled student.
+    return public.is_teacher_or_admin() and exists (
+        select 1
+        from class_members cm
+        where cm.student_id = p_student_id
+    );
+exception
+    when others then
+        return false;
+end;
+$$;
+
+-- orphan_chapter_documents: trigger archiving deleted chapter documents.
+-- It read class_chapters.teacher_id (dropped) to attribute the orphaned doc and
+-- build its storage path -> use the sole teacher's id instead.
+CREATE OR REPLACE FUNCTION "public"."orphan_chapter_documents"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_teacher_id UUID;
+BEGIN
+    -- Mono-teacher: attribute orphaned documents to the sole teacher.
+    SELECT id INTO v_teacher_id
+    FROM public.profiles
+    WHERE role = 'teacher'
+    LIMIT 1;
+
+    -- Only process uploaded documents (not Google Drive links)
+    INSERT INTO public.orphaned_documents (
+        original_document_id,
+        original_chapter_id,
+        original_class_id,
+        teacher_id,
+        title,
+        file_name,
+        mime_type,
+        file_size,
+        orphaned_storage_path,
+        original_created_at
+    )
+    SELECT
+        cd.id,
+        cd.chapter_id,
+        ch.class_id,
+        v_teacher_id,
+        cd.title,
+        cd.file_name,
+        cd.mime_type,
+        cd.file_size,
+        'orphaned-documents/' || v_teacher_id || '/' || cd.id || '/' || cd.file_name,
+        cd.created_at
+    FROM public.chapter_documents cd
+    JOIN public.class_chapters ch ON ch.id = cd.chapter_id
+    WHERE cd.chapter_id = OLD.id
+      AND cd.source_type = 'upload'
+      AND cd.storage_path IS NOT NULL;
+
+    RETURN OLD;
+END;
+$$;
+
+-- reject_vip_card: only the ownership join changes; the activation-clearing logic
+-- and audit log are preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."reject_vip_card"("p_student_id" "uuid", "p_instance_id" "text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_vip_cards JSONB;
+  v_card_data JSONB;
+  v_card_id TEXT;
+  v_template RECORD;
+  v_now TIMESTAMPTZ := NOW();
+  v_now_str TEXT;
+BEGIN
+  v_teacher_id := auth.uid();
+
+  IF NOT is_teacher_or_admin() THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Only teachers can reject VIP card activations'
+    );
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Student is not in your active classes'
+    );
+  END IF;
+
+  SELECT vip_cards INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  IF v_vip_cards IS NULL THEN
+    v_vip_cards := '{}'::JSONB;
+  END IF;
+
+  v_card_data := v_vip_cards->p_instance_id;
+
+  IF v_card_data IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card instance not found: ' || p_instance_id
+    );
+  END IF;
+
+  IF v_card_data->>'activationRequestedAt' IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'No pending activation request for this card'
+    );
+  END IF;
+
+  v_card_id := v_card_data->>'cardId';
+
+  SELECT id, name INTO v_template
+  FROM vip_card_templates
+  WHERE id = v_card_id;
+
+  v_now_str := to_char(v_now, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+
+  v_vip_cards := jsonb_set(
+    v_vip_cards,
+    ARRAY[p_instance_id],
+    (v_vip_cards->p_instance_id)
+      - 'activationRequestedAt'
+      - 'activationRequestedBy'
+      - 'activationApprovedAt'
+      - 'activationApprovedBy'
+  );
+
+  INSERT INTO public.vip_cards_activity (
+    student_id, card_instance_id, card_template_id, action, metadata
+  ) VALUES (
+    p_student_id, p_instance_id, v_card_id, 'rejected',
+    jsonb_build_object('rejected_by', v_teacher_id::TEXT, 'rejected_at', v_now_str)
+  );
+
+  UPDATE profiles
+  SET vip_cards = v_vip_cards, updated_at = v_now
+  WHERE id = p_student_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'cardName', COALESCE(v_template.name, v_card_id),
+    'instanceId', p_instance_id,
+    'cardId', v_card_id
+  );
+END;
+$$;
+
+-- remove_student_vip_card: only the ownership join changes; the FIFO oldest-unused
+-- removal logic is preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."remove_student_vip_card"("p_student_id" "uuid", "p_card_id" "text") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_is_teacher BOOLEAN;
+  v_student_in_class BOOLEAN;
+  v_vip_cards JSONB;
+  v_instance_id TEXT;
+  v_oldest_date TIMESTAMPTZ;
+  v_oldest_instance_id TEXT;
+BEGIN
+  -- Get the current user's ID (the teacher calling this function)
+  v_teacher_id := auth.uid();
+
+  -- Check if caller is a teacher or admin
+  v_is_teacher := is_teacher_or_admin();
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers can remove VIP cards';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_student_in_class;
+
+  IF NOT v_student_in_class THEN
+    RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+  END IF;
+
+  -- Get student's VIP cards
+  SELECT vip_cards INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id;
+
+  -- If no cards, return FALSE
+  IF v_vip_cards IS NULL OR v_vip_cards = '{}'::jsonb THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Find oldest unused instance of the specified card
+  -- Loop through all card instances
+  FOR v_instance_id IN
+    SELECT key
+    FROM jsonb_each(v_vip_cards)
+  LOOP
+    DECLARE
+      v_card_data JSONB;
+      v_card_id_check TEXT;
+      v_used_at TEXT;
+      v_earned_at TIMESTAMPTZ;
+    BEGIN
+      v_card_data := v_vip_cards->v_instance_id;
+      v_card_id_check := v_card_data->>'cardId';
+      v_used_at := v_card_data->>'usedAt';
+
+      -- Check if this is the card we're looking for and it's unused
+      IF v_card_id_check = p_card_id AND v_used_at IS NULL THEN
+        v_earned_at := (v_card_data->>'earnedAt')::timestamptz;
+
+        -- Track the oldest instance
+        IF v_oldest_date IS NULL OR v_earned_at < v_oldest_date THEN
+          v_oldest_date := v_earned_at;
+          v_oldest_instance_id := v_instance_id;
+        END IF;
+      END IF;
+    END;
+  END LOOP;
+
+  -- If we found an instance to remove, delete it from JSONB
+  IF v_oldest_instance_id IS NOT NULL THEN
+    -- Remove the instance from vip_cards JSONB
+    v_vip_cards := v_vip_cards - v_oldest_instance_id;
+
+    -- Update the database
+    UPDATE profiles
+    SET
+      vip_cards = v_vip_cards,
+      updated_at = NOW()
+    WHERE id = p_student_id;
+
+    RETURN TRUE;
+  ELSE
+    -- No matching card found
+    RETURN FALSE;
+  END IF;
+END;
+$$;
+
+-- remove_vip_card: only the ownership join changes; the instance/FIFO resolution,
+-- reason metadata and audit log are preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."remove_vip_card"("p_student_id" "uuid", "p_card_id" "text" DEFAULT NULL::"text", "p_instance_id" "text" DEFAULT NULL::"text", "p_reason" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_teacher_id UUID;
+  v_vip_cards JSONB;
+  v_instance_id TEXT;
+  v_card_data JSONB;
+  v_card_id TEXT;
+  v_template RECORD;
+  v_now TIMESTAMPTZ := NOW();
+  v_oldest_instance_id TEXT;
+  v_oldest_date TIMESTAMPTZ;
+  v_loop_key TEXT;
+  v_metadata JSONB;
+BEGIN
+  v_teacher_id := auth.uid();
+
+  IF NOT is_teacher_or_admin() THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Only teachers can remove VIP cards'
+    );
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Unauthorized: Student is not in your active classes'
+    );
+  END IF;
+
+  IF p_instance_id IS NULL AND p_card_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Either p_instance_id or p_card_id must be provided'
+    );
+  END IF;
+
+  SELECT vip_cards INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  IF v_vip_cards IS NULL THEN
+    v_vip_cards := '{}'::JSONB;
+  END IF;
+
+  IF p_instance_id IS NOT NULL THEN
+    v_instance_id := p_instance_id;
+  ELSE
+    FOR v_loop_key IN
+      SELECT key FROM jsonb_each(v_vip_cards)
+    LOOP
+      DECLARE
+        v_loop_data JSONB;
+        v_loop_card_id TEXT;
+        v_loop_used_at TEXT;
+        v_loop_earned_at TIMESTAMPTZ;
+      BEGIN
+        v_loop_data := v_vip_cards->v_loop_key;
+        v_loop_card_id := v_loop_data->>'cardId';
+        v_loop_used_at := v_loop_data->>'usedAt';
+
+        IF v_loop_card_id = p_card_id AND v_loop_used_at IS NULL THEN
+          v_loop_earned_at := (v_loop_data->>'earnedAt')::TIMESTAMPTZ;
+
+          IF v_oldest_date IS NULL OR v_loop_earned_at < v_oldest_date THEN
+            v_oldest_date := v_loop_earned_at;
+            v_oldest_instance_id := v_loop_key;
+          END IF;
+        END IF;
+      END;
+    END LOOP;
+
+    IF v_oldest_instance_id IS NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'No unused instance found for card: ' || COALESCE(p_card_id, 'unknown')
+      );
+    END IF;
+
+    v_instance_id := v_oldest_instance_id;
+  END IF;
+
+  v_card_data := v_vip_cards->v_instance_id;
+
+  IF v_card_data IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card instance not found: ' || v_instance_id
+    );
+  END IF;
+
+  IF v_card_data->>'usedAt' IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Cannot remove a card that has already been used'
+    );
+  END IF;
+
+  v_card_id := v_card_data->>'cardId';
+
+  SELECT id, name INTO v_template
+  FROM vip_card_templates
+  WHERE id = v_card_id;
+
+  v_vip_cards := v_vip_cards - v_instance_id;
+
+  -- Build metadata with optional reason
+  v_metadata := jsonb_build_object(
+    'removed_by', v_teacher_id::TEXT,
+    'removed_at', to_char(v_now, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  IF p_reason IS NOT NULL THEN
+    v_metadata := v_metadata || jsonb_build_object('reason', p_reason);
+  END IF;
+
+  INSERT INTO public.vip_cards_activity (
+    student_id, card_instance_id, card_template_id, action, metadata
+  ) VALUES (
+    p_student_id, v_instance_id, v_card_id, 'removed', v_metadata
+  );
+
+  UPDATE profiles
+  SET vip_cards = v_vip_cards, updated_at = v_now
+  WHERE id = p_student_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'cardName', COALESCE(v_template.name, v_card_id),
+    'instanceId', v_instance_id,
+    'cardId', v_card_id
+  );
+END;
+$$;
+
+-- soft_delete_warning: drop the classes.teacher_id ownership join from the
+-- EXISTS guard. Mono-teacher: teacher/admin may delete a warning for any
+-- student enrolled in the warning's class.
+CREATE OR REPLACE FUNCTION "public"."soft_delete_warning"("p_warning_id" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_affected INTEGER;
+    v_caller_role TEXT;
+BEGIN
+    -- Get caller's role to enforce authorization (SECURITY DEFINER bypasses RLS).
+    SELECT role INTO v_caller_role
+    FROM public.profiles
+    WHERE id = auth.uid();
+
+    -- Only teachers and admins can delete warnings.
+    IF v_caller_role NOT IN ('teacher', 'admin') THEN
+        RAISE EXCEPTION 'Unauthorized: Only teachers and admins can delete warnings';
+    END IF;
+
+    -- Attempt to soft delete the warning
+    UPDATE public.student_warnings
+    SET
+        deleted_at = NOW(),
+        deleted_by = auth.uid()
+    WHERE id = p_warning_id
+    AND deleted_at IS NULL  -- Only delete active warnings
+    AND EXISTS (
+        -- Mono-teacher: the student is enrolled in the warning's class.
+        SELECT 1 FROM public.class_members cm
+        WHERE cm.student_id = student_warnings.student_id
+        AND cm.class_id = student_warnings.class_id
+    );
+
+    GET DIAGNOSTICS v_affected = ROW_COUNT;
+
+    RETURN v_affected > 0;
+END;
+$$;
+
+-- update_class_gidouilles: drop the classes.teacher_id ownership check; verify
+-- the class exists instead (the sole teacher owns it).
+CREATE OR REPLACE FUNCTION "public"."update_class_gidouilles"("p_class_id" "uuid", "p_delta" integer) RETURNS integer
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_is_teacher BOOLEAN;
+  v_class_exists BOOLEAN;
+  v_affected_rows INTEGER;
+BEGIN
+  v_is_teacher := is_teacher_or_admin();
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers can update gidouilles';
+  END IF;
+
+  -- Mono-teacher: the sole teacher owns every class; just verify it exists.
+  SELECT EXISTS (
+    SELECT 1
+    FROM classes
+    WHERE id = p_class_id
+  ) INTO v_class_exists;
+
+  IF NOT v_class_exists THEN
+    RAISE EXCEPTION 'Class not found';
+  END IF;
+
+  -- Update all ACTIVE students in the class
+  UPDATE profiles
+  SET gidouilles = GREATEST(0, gidouilles + p_delta),
+      updated_at = NOW()
+  WHERE id IN (
+    SELECT cm.student_id
+    FROM class_members cm
+    WHERE cm.class_id = p_class_id
+      AND cm.status = 'active'
+  );
+
+  GET DIAGNOSTICS v_affected_rows = ROW_COUNT;
+  RETURN v_affected_rows;
+END;
+$$;
+
+-- update_student_bonus: drop the classes.teacher_id ownership join from the
+-- authorization branch.
+CREATE OR REPLACE FUNCTION "public"."update_student_bonus"("p_student_id" "uuid", "p_class_id" "uuid", "p_delta" integer, "p_reason" "text" DEFAULT NULL::"text", "p_created_by" "uuid" DEFAULT NULL::"uuid") RETURNS integer
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_new_bonus INTEGER;
+    v_caller_role TEXT;
+BEGIN
+    SELECT role INTO v_caller_role
+    FROM public.profiles
+    WHERE id = auth.uid();
+
+    -- Mono-teacher: admin, or teacher with an active member in this class.
+    IF auth.uid() IS NOT NULL AND NOT (
+        v_caller_role = 'admin'
+        OR (v_caller_role = 'teacher' AND EXISTS (
+            SELECT 1 FROM public.class_members cm
+            WHERE cm.student_id = p_student_id
+            AND cm.class_id = p_class_id
+            AND cm.status = 'active'
+        ))
+    ) THEN
+        RAISE EXCEPTION 'Unauthorized: You do not have permission to update bonus for this student';
+    END IF;
+
+    IF p_delta < -10000 OR p_delta > 10000 THEN
+        RAISE EXCEPTION 'Invalid delta: must be between -10000 and 10000, got %', p_delta;
+    END IF;
+
+    IF (ABS(p_delta) > 100) AND (p_reason IS NULL OR p_reason = '') THEN
+        RAISE EXCEPTION 'Reason required for large bonus changes (|delta| = %)', ABS(p_delta);
+    END IF;
+
+    -- Verify ACTIVE membership
+    IF NOT EXISTS (
+        SELECT 1 FROM public.class_members
+        WHERE student_id = p_student_id
+        AND class_id = p_class_id
+        AND status = 'active'
+    ) THEN
+        RAISE EXCEPTION 'Student % is not an active member of class %', p_student_id, p_class_id;
+    END IF;
+
+    UPDATE public.profiles
+    SET bonus = GREATEST(0, COALESCE(bonus, 0) + p_delta)
+    WHERE id = p_student_id
+    RETURNING bonus INTO v_new_bonus;
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bonus_history') THEN
+        INSERT INTO public.bonus_history (
+            student_id,
+            class_id,
+            delta,
+            reason,
+            created_by
+        ) VALUES (
+            p_student_id,
+            p_class_id,
+            p_delta,
+            p_reason,
+            COALESCE(p_created_by, auth.uid())
+        );
+    END IF;
+
+    RETURN v_new_bonus;
+END;
+$$;
+
+-- update_student_gidouilles (2-arg): "student in teacher's classes" -> any class.
+CREATE OR REPLACE FUNCTION "public"."update_student_gidouilles"("p_student_id" "uuid", "p_delta" integer) RETURNS integer
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_is_teacher BOOLEAN;
+  v_student_in_class BOOLEAN;
+  v_new_gidouilles INTEGER;
+BEGIN
+  -- Check if caller is a teacher or admin
+  v_is_teacher := is_teacher_or_admin();
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Unauthorized: Only teachers can update gidouilles';
+  END IF;
+
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1
+    FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_student_in_class;
+
+  IF NOT v_student_in_class THEN
+    RAISE EXCEPTION 'Unauthorized: Student is not in your classes';
+  END IF;
+
+  -- Update the gidouilles field ONLY (atomic, with built-in minimum enforcement)
+  UPDATE profiles
+  SET gidouilles = GREATEST(0, gidouilles + p_delta),
+      updated_at = NOW()
+  WHERE id = p_student_id
+  RETURNING gidouilles INTO v_new_gidouilles;
+
+  RETURN v_new_gidouilles;
+END;
+$$;
+
+-- update_student_gidouilles (5-arg): drop the classes.teacher_id ownership join
+-- from the authorization branch.
+CREATE OR REPLACE FUNCTION "public"."update_student_gidouilles"("p_student_id" "uuid", "p_class_id" "uuid", "p_delta" integer, "p_reason" "text" DEFAULT NULL::"text", "p_created_by" "uuid" DEFAULT NULL::"uuid") RETURNS integer
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_new_gidouilles INTEGER;
+    v_caller_role TEXT;
+BEGIN
+    -- SECURITY CHECK: Get caller's role to enforce authorization
+    SELECT role INTO v_caller_role
+    FROM public.profiles
+    WHERE id = auth.uid();
+
+    -- Mono-teacher: admin, teacher with an active member in this class, or system (NULL caller).
+    IF auth.uid() IS NOT NULL AND NOT (
+        v_caller_role = 'admin'
+        OR (v_caller_role = 'teacher' AND EXISTS (
+            SELECT 1 FROM public.class_members cm
+            WHERE cm.student_id = p_student_id
+            AND cm.class_id = p_class_id
+            AND cm.status = 'active'
+        ))
+    ) THEN
+        RAISE EXCEPTION 'Non autorisé: seuls les professeurs de cet élève peuvent modifier ses gidouilles';
+    END IF;
+
+    -- Update gidouilles with floor at 0
+    UPDATE public.profiles
+    SET gidouilles = GREATEST(0, COALESCE(gidouilles, 0) + p_delta)
+    WHERE id = p_student_id
+    RETURNING gidouilles INTO v_new_gidouilles;
+
+    -- Log the change in activity table
+    INSERT INTO public.gidouilles_activity (
+        student_id,
+        class_id,
+        delta,
+        reason,
+        created_by
+    ) VALUES (
+        p_student_id,
+        p_class_id,
+        p_delta,
+        p_reason,
+        COALESCE(p_created_by, auth.uid())
+    );
+
+    RETURN v_new_gidouilles;
+END;
+$$;
+
+-- use_vip_card: only the ownership join changes; the self-use bypass, FIFO
+-- resolution, multi-use accounting, context validation and audit trail are all
+-- preserved verbatim.
+CREATE OR REPLACE FUNCTION "public"."use_vip_card"("p_student_id" "uuid", "p_instance_id" "text" DEFAULT NULL::"text", "p_card_id" "text" DEFAULT NULL::"text", "p_metadata" "jsonb" DEFAULT NULL::"jsonb", "p_context" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_caller_id UUID;
+  v_vip_cards JSONB;
+  v_instance_id TEXT;
+  v_card_data JSONB;
+  v_card_id TEXT;
+  v_template RECORD;
+  v_now TIMESTAMPTZ := NOW();
+  v_now_str TEXT;
+  v_oldest_instance_id TEXT;
+  v_oldest_date TIMESTAMPTZ;
+  v_loop_key TEXT;
+  v_audit_metadata JSONB;
+  v_uses_remaining INTEGER;
+  v_is_fully_consumed BOOLEAN;
+  v_use_number INTEGER;
+  v_action_context TEXT;
+BEGIN
+  -- ========================================================================
+  -- PARAMETER VALIDATION
+  -- ========================================================================
+
+  IF p_instance_id IS NULL AND p_card_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Either p_instance_id or p_card_id must be provided'
+    );
+  END IF;
+
+  v_caller_id := auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Authentication required'
+    );
+  END IF;
+
+  -- ========================================================================
+  -- AUTHORIZATION
+  -- ========================================================================
+
+  IF v_caller_id != p_student_id THEN
+    IF NOT is_teacher_or_admin() THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'Unauthorized: Only the card owner or a teacher can use cards'
+      );
+    END IF;
+
+    -- Mono-teacher: any class membership means the sole teacher teaches this student.
+    IF NOT EXISTS (
+      SELECT 1
+      FROM class_members cm
+      WHERE cm.student_id = p_student_id
+    ) THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'Unauthorized: Student is not in your active classes'
+      );
+    END IF;
+  END IF;
+
+  -- ========================================================================
+  -- GET AND LOCK STUDENT'S VIP CARDS
+  -- ========================================================================
+
+  SELECT vip_cards INTO v_vip_cards
+  FROM profiles
+  WHERE id = p_student_id
+  FOR UPDATE;
+
+  IF v_vip_cards IS NULL THEN
+    v_vip_cards := '{}'::JSONB;
+  END IF;
+
+  -- ========================================================================
+  -- RESOLVE CARD INSTANCE (by instance_id or card_id FIFO)
+  -- ========================================================================
+
+  IF p_instance_id IS NOT NULL THEN
+    v_instance_id := p_instance_id;
+  ELSE
+    FOR v_loop_key IN
+      SELECT key FROM jsonb_each(v_vip_cards)
+    LOOP
+      DECLARE
+        v_loop_data JSONB;
+        v_loop_card_id TEXT;
+        v_loop_used_at TEXT;
+        v_loop_earned_at TIMESTAMPTZ;
+        v_loop_uses_remaining INTEGER;
+      BEGIN
+        v_loop_data := v_vip_cards->v_loop_key;
+        v_loop_card_id := v_loop_data->>'cardId';
+        v_loop_used_at := v_loop_data->>'usedAt';
+
+        IF v_loop_card_id = p_card_id AND v_loop_used_at IS NULL THEN
+          v_loop_uses_remaining := (v_loop_data->>'usesRemaining')::INTEGER;
+          IF v_loop_uses_remaining IS NOT NULL AND v_loop_uses_remaining <= 0 THEN
+            CONTINUE;
+          END IF;
+
+          v_loop_earned_at := (v_loop_data->>'earnedAt')::TIMESTAMPTZ;
+
+          IF v_oldest_date IS NULL OR v_loop_earned_at < v_oldest_date THEN
+            v_oldest_date := v_loop_earned_at;
+            v_oldest_instance_id := v_loop_key;
+          END IF;
+        END IF;
+      END;
+    END LOOP;
+
+    IF v_oldest_instance_id IS NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'No unused instance found for card: ' || COALESCE(p_card_id, 'unknown')
+      );
+    END IF;
+
+    v_instance_id := v_oldest_instance_id;
+  END IF;
+
+  -- ========================================================================
+  -- VALIDATE CARD INSTANCE
+  -- ========================================================================
+
+  v_card_data := v_vip_cards->v_instance_id;
+
+  IF v_card_data IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card instance not found: ' || v_instance_id
+    );
+  END IF;
+
+  IF v_card_data->>'usedAt' IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card has already been used'
+    );
+  END IF;
+
+  v_card_id := v_card_data->>'cardId';
+
+  -- ========================================================================
+  -- GET TEMPLATE (for name, action->context, uses_total)
+  -- ========================================================================
+
+  SELECT id, name, action, uses_total INTO v_template
+  FROM vip_card_templates
+  WHERE id = v_card_id;
+
+  IF v_template IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card template not found: ' || v_card_id
+    );
+  END IF;
+
+  -- ========================================================================
+  -- VALIDATE ACTIVATION CONTEXT (read from action JSONB)
+  -- ========================================================================
+
+  v_action_context := v_template.action->>'context';
+
+  IF v_action_context IS NOT NULL AND v_action_context != 'any' THEN
+    IF p_context IS NULL OR p_context != v_action_context THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'This card requires context: ' || v_action_context
+      );
+    END IF;
+  END IF;
+
+  -- ========================================================================
+  -- PROCESS CARD USE (unified single-use / multi-use logic)
+  -- ========================================================================
+
+  v_uses_remaining := COALESCE((v_card_data->>'usesRemaining')::INTEGER, 1);
+
+  IF v_uses_remaining <= 0 THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Card has no remaining uses'
+    );
+  END IF;
+
+  v_use_number := COALESCE(v_template.uses_total, 1) - v_uses_remaining + 1;
+  v_uses_remaining := v_uses_remaining - 1;
+  v_is_fully_consumed := (v_uses_remaining = 0);
+
+  v_now_str := to_char(v_now, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+
+  IF v_is_fully_consumed THEN
+    v_card_data := v_card_data
+      - 'activationRequestedAt'
+      - 'activationRequestedBy'
+      - 'activationApprovedAt'
+      - 'activationApprovedBy'
+      || jsonb_build_object(
+        'usedAt', v_now_str,
+        'usesRemaining', 0
+      );
+  ELSE
+    v_card_data := v_card_data || jsonb_build_object(
+      'usesRemaining', v_uses_remaining
+    );
+  END IF;
+
+  v_vip_cards := jsonb_set(v_vip_cards, ARRAY[v_instance_id], v_card_data);
+
+  -- ========================================================================
+  -- UPDATE PROFILE
+  -- ========================================================================
+
+  UPDATE profiles
+  SET vip_cards = v_vip_cards, updated_at = v_now
+  WHERE id = p_student_id;
+
+  -- ========================================================================
+  -- AUDIT TRAIL
+  -- ========================================================================
+
+  v_audit_metadata := jsonb_build_object(
+    'used_at', v_now_str,
+    'usesRemaining', v_uses_remaining,
+    'useNumber', v_use_number,
+    'totalUses', COALESCE(v_template.uses_total, 1),
+    'fullyConsumed', v_is_fully_consumed,
+    'context', p_context
+  ) || COALESCE(p_metadata, '{}'::JSONB);
+
+  INSERT INTO public.vip_cards_activity (
+    student_id, card_instance_id, card_template_id, action, metadata
+  ) VALUES (
+    p_student_id, v_instance_id, v_card_id, 'used',
+    v_audit_metadata
+  );
+
+  -- ========================================================================
+  -- RETURN UNIFIED RESULT
+  -- ========================================================================
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'cardName', v_template.name,
+    'instanceId', v_instance_id,
+    'cardId', v_card_id,
+    'usesRemaining', v_uses_remaining,
+    'isFullyConsumed', v_is_fully_consumed,
+    'usedAt', CASE WHEN v_is_fully_consumed THEN v_now_str ELSE NULL END
+  );
+END;
+$$;
+
+-- validate_class_message_recipients: drop the classes.teacher_id ownership check.
+CREATE OR REPLACE FUNCTION "public"."validate_class_message_recipients"("sender_uuid" "uuid", "class_uuid" "uuid") RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  sender_role TEXT;
+  v_class_exists BOOLEAN;
+BEGIN
+  -- Get sender's role
+  SELECT role INTO sender_role
+  FROM profiles
+  WHERE id = sender_uuid;
+
+  -- Only teachers/admins can send class messages
+  IF sender_role != 'teacher' AND sender_role != 'admin' THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Mono-teacher: the sole teacher owns every active class; just verify it exists.
+  SELECT EXISTS (
+    SELECT 1
+    FROM classes
+    WHERE id = class_uuid
+      AND is_active = TRUE
+  ) INTO v_class_exists;
+
+  RETURN v_class_exists;
+END;
+$$;
+
+-- validate_message_recipients: intentionally NOT redefined. Its live version (migration
+-- 20260618093000, Option B) is already role-based, references neither classes
+-- nor teacher_id nor the dead RPCs, and lets a hors-classe student message the
+-- sole teacher. Redefining it from the baseline body would REGRESS Option B.
+
+-- validate_riddle_attempt: keep p_teacher_id (stamps validated_by); drop the
+-- classes.teacher_id ownership join -> any class membership.
+CREATE OR REPLACE FUNCTION "public"."validate_riddle_attempt"("p_attempt_id" "uuid", "p_teacher_id" "uuid", "p_is_correct" boolean) RETURNS TABLE("success" boolean, "theoretical_reward" numeric, "actual_reward" numeric, "is_first_win" boolean, "week_best_reward" numeric)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_student_id UUID;
+  v_riddle_id UUID;
+  v_difficulty INTEGER;
+  v_attempt_number INTEGER;
+  v_theoretical_gidouilles NUMERIC(10,2);
+  v_actual_gidouilles NUMERIC(10,2);
+  v_is_first_win BOOLEAN;
+  v_week_best NUMERIC(10,2);
+  v_school_id UUID;
+  v_daily_result RECORD;
+BEGIN
+  -- Get attempt details
+  SELECT ra.student_id, ra.riddle_id, ra.attempt_number
+  INTO v_student_id, v_riddle_id, v_attempt_number
+  FROM riddle_attempts ra
+  WHERE ra.id = p_attempt_id AND ra.is_correct IS NULL; -- Only validate pending attempts
+
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'Attempt not found or already validated';
+  END IF;
+
+  -- Mono-teacher: the sole teacher teaches any enrolled student.
+  IF NOT EXISTS (
+    SELECT 1 FROM class_members cm
+    WHERE cm.student_id = v_student_id
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: You do not teach this student';
+  END IF;
+
+  -- Get riddle difficulty
+  SELECT difficulty INTO v_difficulty
+  FROM riddles
+  WHERE id = v_riddle_id;
+
+  IF v_difficulty IS NULL THEN
+    RAISE EXCEPTION 'Riddle not found';
+  END IF;
+
+  IF NOT p_is_correct THEN
+    UPDATE riddle_attempts
+    SET is_correct = FALSE,
+        validated_at = NOW(),
+        validated_by = p_teacher_id
+    WHERE id = p_attempt_id;
+
+    RETURN QUERY SELECT TRUE, 0::NUMERIC(10,2), 0::NUMERIC(10,2), FALSE, 0::NUMERIC(10,2);
+    RETURN;
+  END IF;
+
+  v_theoretical_gidouilles := public.calculate_riddle_gidouilles(v_difficulty, v_attempt_number)::NUMERIC(10,2);
+
+  SELECT NOT EXISTS (
+    SELECT 1 FROM riddle_attempts ra2
+    WHERE ra2.student_id = v_student_id
+      AND ra2.riddle_id = v_riddle_id
+      AND ra2.is_correct = TRUE
+      AND ra2.id != p_attempt_id
+  ) INTO v_is_first_win;
+
+  IF v_is_first_win THEN
+    v_actual_gidouilles := v_theoretical_gidouilles;
+  ELSE
+    v_actual_gidouilles := 0;
+  END IF;
+
+  UPDATE riddle_attempts
+  SET is_correct = TRUE,
+      validated_at = NOW(),
+      validated_by = p_teacher_id,
+      gidouilles_awarded = v_actual_gidouilles
+  WHERE id = p_attempt_id;
+
+  IF v_actual_gidouilles > 0 THEN
+    PERFORM public.update_student_gidouilles(
+      v_student_id,
+      v_actual_gidouilles::INTEGER
+    );
+  END IF;
+
+  SELECT COALESCE(MAX(gidouilles_awarded), 0)::NUMERIC(10,2)
+  INTO v_week_best
+  FROM riddle_attempts ra3
+  WHERE ra3.student_id = v_student_id
+    AND ra3.is_correct = TRUE
+    AND ra3.validated_at >= date_trunc('week', NOW());
+
+  RETURN QUERY SELECT TRUE, v_theoretical_gidouilles, v_actual_gidouilles, v_is_first_win, v_week_best;
+END;
+$$;
+
+-- ===== 4b. plpgsql authz functions still referencing classes.teacher_id =====
+-- award_weekly_reward / compute_daily_summary gate on "teacher of this class".
+-- Mono-teacher: the sole teacher owns every class -> public.is_teacher_or_admin().
+
+CREATE OR REPLACE FUNCTION "public"."award_weekly_reward"("p_student_id" "uuid", "p_class_id" "uuid", "p_week_start" "date", "p_week_end" "date", "p_gidouilles" integer DEFAULT 1, "p_reason" "text" DEFAULT 'no_warnings'::"text") RETURNS "uuid"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_reward_id UUID;
+    v_caller_role TEXT;
+BEGIN
+    -- SECURITY CHECK (Issue #1): Get caller's role to enforce authorization
+    -- SECURITY DEFINER functions bypass RLS, so we must check permissions explicitly
+    SELECT role INTO v_caller_role
+    FROM public.profiles
+    WHERE id = auth.uid();
+
+    -- Authorization: Only admins, teachers of the class, or service_role can award rewards
+    IF auth.uid() IS NOT NULL AND NOT (
+        v_caller_role = 'admin'
+        OR (v_caller_role = 'teacher' AND public.is_teacher_or_admin())
+    ) THEN
+        RAISE EXCEPTION 'Unauthorized: You do not have permission to award rewards for this class';
+    END IF;
+
+    -- FIX (Issue #6): Use atomic INSERT with WHERE NOT EXISTS to prevent race condition
+    -- Insert the reward record only if student had no warnings that week
+    INSERT INTO public.weekly_rewards (
+        student_id,
+        class_id,
+        week_start,
+        week_end,
+        gidouilles_awarded,
+        reason
+    )
+    SELECT p_student_id, p_class_id, p_week_start, p_week_end, p_gidouilles, p_reason
+    WHERE NOT EXISTS (
+        SELECT 1 FROM public.student_warnings
+        WHERE student_id = p_student_id
+        AND class_id = p_class_id
+        AND DATE(created_at) BETWEEN p_week_start AND p_week_end
+        AND deleted_at IS NULL
+    )
+    ON CONFLICT (student_id, class_id, week_start) DO NOTHING
+    RETURNING id INTO v_reward_id;
+
+    -- Only update gidouilles if we actually inserted a new record
+    IF v_reward_id IS NOT NULL THEN
+        -- Update student's gidouilles (and log in history)
+        PERFORM public.update_student_gidouilles(
+            p_student_id,
+            p_class_id,
+            p_gidouilles,
+            p_reason,
+            NULL  -- System-generated
+        );
+    END IF;
+
+    RETURN v_reward_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."compute_daily_summary"("p_student_id" "uuid", "p_class_id" "uuid", "p_summary_date" "date") RETURNS "uuid"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+    v_summary_id UUID;
+    v_gidouilles_gained INTEGER;
+    v_gidouilles_lost INTEGER;
+    v_bonus_gained INTEGER;
+    v_bonus_used INTEGER;
+    v_warnings_issued INTEGER;
+    v_warnings_removed INTEGER;
+    v_vip_cards_gained INTEGER;
+    v_vip_cards_used INTEGER;
+    v_caller_role TEXT;
+BEGIN
+    -- SECURITY CHECK (Issue #1): Get caller's role to enforce authorization
+    -- SECURITY DEFINER functions bypass RLS, so we must check permissions explicitly
+    SELECT role INTO v_caller_role
+    FROM public.profiles
+    WHERE id = auth.uid();
+
+    -- Authorization: Only admins, teachers of the student, or service_role can compute summaries
+    IF auth.uid() IS NOT NULL AND NOT (
+        v_caller_role = 'admin'
+        OR (v_caller_role = 'teacher' AND public.is_teacher_or_admin())
+    ) THEN
+        RAISE EXCEPTION 'Unauthorized: You do not have permission to compute summaries for this student';
+    END IF;
+    -- Calculate gidouilles (positive = gained, negative = lost)
+    SELECT
+        COALESCE(SUM(CASE WHEN delta > 0 THEN delta ELSE 0 END), 0),
+        COALESCE(SUM(CASE WHEN delta < 0 THEN delta ELSE 0 END), 0)
+    INTO v_gidouilles_gained, v_gidouilles_lost
+    FROM public.gidouilles_history
+    WHERE student_id = p_student_id
+    AND class_id = p_class_id
+    AND DATE(created_at) = p_summary_date;
+
+    -- Calculate bonus (positive = gained, negative = used)
+    SELECT
+        COALESCE(SUM(CASE WHEN delta > 0 THEN delta ELSE 0 END), 0),
+        COALESCE(SUM(CASE WHEN delta < 0 THEN delta ELSE 0 END), 0)
+    INTO v_bonus_gained, v_bonus_used
+    FROM public.bonus_history
+    WHERE student_id = p_student_id
+    AND class_id = p_class_id
+    AND DATE(created_at) = p_summary_date;
+
+    -- Calculate warnings (issued vs removed)
+    -- FIX (Issue #9): Simplify confusing logic for warning calculations
+    SELECT
+        COUNT(*) FILTER (WHERE deleted_at IS NULL),
+        COUNT(*) FILTER (WHERE deleted_at IS NOT NULL)
+    INTO v_warnings_issued, v_warnings_removed
+    FROM public.student_warnings
+    WHERE student_id = p_student_id
+    AND class_id = p_class_id
+    AND DATE(created_at) = p_summary_date;
+
+    -- Calculate VIP cards (gained vs used)
+    SELECT
+        COUNT(*) FILTER (WHERE action = 'gained'),
+        COUNT(*) FILTER (WHERE action = 'used')
+    INTO v_vip_cards_gained, v_vip_cards_used
+    FROM public.vip_cards_activity
+    WHERE student_id = p_student_id
+    AND DATE(created_at) = p_summary_date;
+
+    -- Insert or update the summary
+    INSERT INTO public.daily_summaries (
+        student_id,
+        class_id,
+        summary_date,
+        gidouilles_gained,
+        gidouilles_lost,
+        bonus_gained,
+        bonus_used,
+        warnings_issued,
+        warnings_removed,
+        vip_cards_gained,
+        vip_cards_used
+    ) VALUES (
+        p_student_id,
+        p_class_id,
+        p_summary_date,
+        v_gidouilles_gained,
+        v_gidouilles_lost,
+        v_bonus_gained,
+        v_bonus_used,
+        v_warnings_issued,
+        v_warnings_removed,
+        v_vip_cards_gained,
+        v_vip_cards_used
+    )
+    ON CONFLICT (student_id, class_id, summary_date)
+    DO UPDATE SET
+        gidouilles_gained = EXCLUDED.gidouilles_gained,
+        gidouilles_lost = EXCLUDED.gidouilles_lost,
+        bonus_gained = EXCLUDED.bonus_gained,
+        bonus_used = EXCLUDED.bonus_used,
+        warnings_issued = EXCLUDED.warnings_issued,
+        warnings_removed = EXCLUDED.warnings_removed,
+        vip_cards_gained = EXCLUDED.vip_cards_gained,
+        vip_cards_used = EXCLUDED.vip_cards_used,
+        updated_at = NOW()
+    RETURNING id INTO v_summary_id;
+
+    RETURN v_summary_id;
+END;
+$$;
+
+
+-- ===== 5. Drop the chapter teacher_id trigger and its function =====
+-- The trigger backfilled class_chapters.teacher_id from the class on INSERT;
+-- with the column gone, both are obsolete.
+
+DROP TRIGGER IF EXISTS "set_chapter_teacher_id_trigger" ON "public"."class_chapters";
+DROP FUNCTION IF EXISTS "public"."set_chapter_teacher_id"();
+
+-- ===== 2b. External policies referencing classes-cluster teacher_id =====
+-- These live on OTHER tables but subquery classes.teacher_id ("is the caller the
+-- teacher of this class?"). Mono-teacher: the sole teacher owns every class, so
+-- that predicate becomes public.is_teacher_or_admin() (behaviour-preserving).
+
+DROP POLICY IF EXISTS "Students can read chunks from accessible documents" ON "public"."rag_chunks";
+DROP POLICY IF EXISTS "Students can read system and class documents" ON "public"."rag_documents";
+DROP POLICY IF EXISTS "System can insert VIP cards activity" ON "public"."vip_cards_activity";
+CREATE POLICY "System can insert VIP cards activity" ON "public"."vip_cards_activity" FOR INSERT TO "authenticated" WITH CHECK ((("student_id" = "auth"."uid"()) OR (EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'teacher'::"public"."user_role") AND (EXISTS ( SELECT 1
+           FROM "public"."class_members" "cm"
+          WHERE (("cm"."student_id" = "vip_cards_activity"."student_id") AND ("cm"."class_id" IN ( SELECT "c"."id"
+                   FROM "public"."classes" "c"
+                  WHERE ("public"."is_teacher_or_admin"())))))))))));
+
+DROP POLICY IF EXISTS "Teachers can create assignments for their assessments" ON "public"."assessment_assignments";
+CREATE POLICY "Teachers can create assignments for their assessments" ON "public"."assessment_assignments" FOR INSERT WITH CHECK ((("assigned_by" = "auth"."uid"()) AND "public"."is_assessment_owner"("assessment_id") AND (("class_id" IS NULL) OR (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "assessment_assignments"."class_id") AND ("public"."is_teacher_or_admin"()))))) AND (("student_id" IS NULL) OR (EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "assessment_assignments"."student_id") AND ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "Teachers can create assignments for their riddles" ON "public"."riddle_assignments";
+CREATE POLICY "Teachers can create assignments for their riddles" ON "public"."riddle_assignments" FOR INSERT WITH CHECK ((("assigned_by" = "auth"."uid"()) AND "public"."teacher_owns_riddle"("auth"."uid"(), "riddle_id") AND (("class_id" IS NULL) OR (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "riddle_assignments"."class_id") AND ("public"."is_teacher_or_admin"()))))) AND (("student_id" IS NULL) OR (EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "riddle_assignments"."student_id") AND ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "Teachers can create notifications for their classes" ON "public"."notifications";
+CREATE POLICY "Teachers can create notifications for their classes" ON "public"."notifications" FOR INSERT WITH CHECK (((( SELECT ("profiles"."role")::"text" AS "role"
+   FROM "public"."profiles"
+  WHERE ("profiles"."id" = "auth"."uid"())) = 'teacher'::"text") AND ((("target_type" = 'classes'::"text") AND ("target_class_ids" <@ ( SELECT "array_agg"("classes"."id") AS "array_agg"
+   FROM "public"."classes"
+  WHERE ("public"."is_teacher_or_admin"())))) OR (("target_type" = 'users'::"text") AND ("target_user_ids" <@ ( SELECT "array_agg"(DISTINCT "cm"."student_id") AS "array_agg"
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "Teachers can insert consents for their students" ON "public"."parental_consents";
+CREATE POLICY "Teachers can insert consents for their students" ON "public"."parental_consents" FOR INSERT WITH CHECK ((EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("cm"."class_id" = "c"."id")))
+  WHERE (("cm"."student_id" = "parental_consents"."student_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can insert shared materials" ON "public"."shared_materials";
+CREATE POLICY "Teachers can insert shared materials" ON "public"."shared_materials" FOR INSERT TO "authenticated" WITH CHECK ((("shared_by" = "auth"."uid"()) AND (EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "shared_materials"."class_id") AND ("public"."is_teacher_or_admin"()))))));
+
+DROP POLICY IF EXISTS "Teachers can manage Google Classroom links for their classes" ON "public"."class_google_classroom_links";
+CREATE POLICY "Teachers can manage Google Classroom links for their classes" ON "public"."class_google_classroom_links" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "class_google_classroom_links"."class_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "class_google_classroom_links"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage coursework categories for their classes" ON "public"."coursework_categories";
+CREATE POLICY "Teachers can manage coursework categories for their classes" ON "public"."coursework_categories" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "coursework_categories"."class_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "coursework_categories"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage own class settings" ON "public"."game_class_settings";
+CREATE POLICY "Teachers can manage own class settings" ON "public"."game_class_settings" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "game_class_settings"."class_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "game_class_settings"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage shared coursework for their classes" ON "public"."shared_coursework";
+CREATE POLICY "Teachers can manage shared coursework for their classes" ON "public"."shared_coursework" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "shared_coursework"."class_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "shared_coursework"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage their class counters" ON "public"."whiteboard_export_counters";
+CREATE POLICY "Teachers can manage their class counters" ON "public"."whiteboard_export_counters" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "whiteboard_export_counters"."class_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "whiteboard_export_counters"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can soft delete warnings for their students" ON "public"."student_warnings";
+CREATE POLICY "Teachers can soft delete warnings for their students" ON "public"."student_warnings" FOR UPDATE TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'teacher'::"public"."user_role")))) AND (EXISTS ( SELECT 1
+   FROM "public"."class_members" "cm"
+  WHERE (("cm"."student_id" = "student_warnings"."student_id") AND ("cm"."class_id" IN ( SELECT "c"."id"
+           FROM "public"."classes" "c"
+          WHERE ("public"."is_teacher_or_admin"())))))) AND ("deleted_at" IS NULL))) WITH CHECK ((("deleted_at" IS NOT NULL) AND ("deleted_by" = "auth"."uid"())));
+
+DROP POLICY IF EXISTS "Teachers can update consents for their students" ON "public"."parental_consents";
+CREATE POLICY "Teachers can update consents for their students" ON "public"."parental_consents" FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("cm"."class_id" = "c"."id")))
+  WHERE (("cm"."student_id" = "parental_consents"."student_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can update student rewards in their classes" ON "public"."profiles";
+CREATE POLICY "Teachers can update student rewards in their classes" ON "public"."profiles" FOR UPDATE USING ((("auth"."uid"() = "id") OR (EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "profiles"."id") AND ("public"."is_teacher_or_admin"()))))));
+
+DROP POLICY IF EXISTS "Teachers can validate attempts" ON "public"."riddle_attempts";
+CREATE POLICY "Teachers can validate attempts" ON "public"."riddle_attempts" FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "riddle_attempts"."student_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Users can view messages in their conversations" ON "public"."messages";
+CREATE POLICY "Users can view messages in their conversations" ON "public"."messages" FOR SELECT USING ((("deleted_at" IS NULL) AND ((EXISTS ( SELECT 1
+   FROM "public"."conversation_participants" "cp"
+  WHERE (("cp"."conversation_id" = "messages"."conversation_id") AND ("cp"."user_id" = "auth"."uid"())))) OR ((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = ANY (ARRAY['teacher'::"public"."user_role", 'admin'::"public"."user_role"]))))) AND (EXISTS ( SELECT 1
+   FROM "public"."conversations" "c"
+  WHERE (("c"."id" = "messages"."conversation_id") AND (("c"."is_group" = true) OR (("c"."is_group" = false) AND (EXISTS ( SELECT 1
+           FROM ("public"."conversation_participants" "cp1"
+             JOIN "public"."conversation_participants" "cp2" ON ((("cp1"."conversation_id" = "cp2"."conversation_id") AND ("cp1"."user_id" < "cp2"."user_id"))))
+          WHERE (("cp1"."conversation_id" = "c"."id") AND (EXISTS ( SELECT 1
+                   FROM ("public"."class_members" "cm1"
+                     JOIN "public"."classes" "c1" ON (("c1"."id" = "cm1"."class_id")))
+                  WHERE (("cm1"."student_id" = "cp1"."user_id") AND ("public"."is_teacher_or_admin"())))) AND (EXISTS ( SELECT 1
+                   FROM ("public"."class_members" "cm2"
+                     JOIN "public"."classes" "c2" ON (("c2"."id" = "cm2"."class_id")))
+                  WHERE (("cm2"."student_id" = "cp2"."user_id") AND ("public"."is_teacher_or_admin"()))))))))))))))));
+
+DROP POLICY IF EXISTS "Users can view messages of accessible conversations" ON "public"."tutor_messages";
+CREATE POLICY "Users can view messages of accessible conversations" ON "public"."tutor_messages" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."tutor_conversations" "tc"
+  WHERE (("tc"."id" = "tutor_messages"."conversation_id") AND (("tc"."student_id" = "auth"."uid"()) OR (EXISTS ( SELECT 1
+           FROM "public"."classes" "c"
+          WHERE (("c"."id" = "tc"."class_id") AND ("public"."is_teacher_or_admin"())))) OR (EXISTS ( SELECT 1
+           FROM "public"."profiles"
+          WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'admin'::"public"."user_role")))))))));
+
+DROP POLICY IF EXISTS "Users can view relevant tournaments" ON "public"."minesweeper_tournaments";
+CREATE POLICY "Users can view relevant tournaments" ON "public"."minesweeper_tournaments" FOR SELECT TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'admin'::"public"."user_role")))) OR ("creator_id" = "auth"."uid"()) OR ("scope" = 'global'::"text") OR (("scope" = 'classes'::"text") AND (EXISTS ( SELECT 1
+   FROM ("public"."minesweeper_tournament_classes" "tc"
+     JOIN "public"."class_members" "cm" ON (("cm"."class_id" = "tc"."class_id")))
+  WHERE (("tc"."tournament_id" = "minesweeper_tournaments"."id") AND ("cm"."student_id" = "auth"."uid"()))))) OR (("scope" = 'classes'::"text") AND (EXISTS ( SELECT 1
+   FROM ("public"."minesweeper_tournament_classes" "tc"
+     JOIN "public"."classes" "c" ON (("c"."id" = "tc"."class_id")))
+  WHERE (("tc"."tournament_id" = "minesweeper_tournaments"."id") AND ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "Users can view their conversations" ON "public"."conversations";
+CREATE POLICY "Users can view their conversations" ON "public"."conversations" FOR SELECT USING (((EXISTS ( SELECT 1
+   FROM "public"."conversation_participants"
+  WHERE (("conversation_participants"."conversation_id" = "conversations"."id") AND ("conversation_participants"."user_id" = "auth"."uid"())))) OR ((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = ANY (ARRAY['teacher'::"public"."user_role", 'admin'::"public"."user_role"]))))) AND (("is_group" = true) OR (("is_group" = false) AND (EXISTS ( SELECT 1
+   FROM ("public"."conversation_participants" "cp1"
+     JOIN "public"."conversation_participants" "cp2" ON ((("cp1"."conversation_id" = "cp2"."conversation_id") AND ("cp1"."user_id" < "cp2"."user_id"))))
+  WHERE (("cp1"."conversation_id" = "conversations"."id") AND (( SELECT "count"(*) AS "count"
+           FROM "public"."conversation_participants"
+          WHERE ("conversation_participants"."conversation_id" = "conversations"."id")) = 2) AND (EXISTS ( SELECT 1
+           FROM ("public"."class_members" "cm1"
+             JOIN "public"."classes" "c1" ON (("c1"."id" = "cm1"."class_id")))
+          WHERE (("cm1"."student_id" = "cp1"."user_id") AND ("public"."is_teacher_or_admin"())))) AND (EXISTS ( SELECT 1
+           FROM ("public"."class_members" "cm2"
+             JOIN "public"."classes" "c2" ON (("c2"."id" = "cm2"."class_id")))
+          WHERE (("cm2"."student_id" = "cp2"."user_id") AND ("public"."is_teacher_or_admin"()))))))))))));
+
+DROP POLICY IF EXISTS "Users can view tournament classes" ON "public"."minesweeper_tournament_classes";
+CREATE POLICY "Users can view tournament classes" ON "public"."minesweeper_tournament_classes" FOR SELECT TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'admin'::"public"."user_role")))) OR (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "minesweeper_tournament_classes"."class_id") AND ("public"."is_teacher_or_admin"())))) OR (EXISTS ( SELECT 1
+   FROM "public"."class_members" "cm"
+  WHERE (("cm"."class_id" = "minesweeper_tournament_classes"."class_id") AND ("cm"."student_id" = "auth"."uid"()))))));
+
+DROP POLICY IF EXISTS "anti_fraud_update_teacher_of_student" ON "public"."srs_anti_fraud_flags";
+CREATE POLICY "anti_fraud_update_teacher_of_student" ON "public"."srs_anti_fraud_flags" FOR UPDATE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "srs_anti_fraud_flags"."student_id") AND ("cm"."status" = 'active'::"text") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "srs_anti_fraud_flags"."student_id") AND ("cm"."status" = 'active'::"text") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "marketplace_config_insert_teacher_class" ON "public"."marketplace_config";
+CREATE POLICY "marketplace_config_insert_teacher_class" ON "public"."marketplace_config" FOR INSERT TO "authenticated" WITH CHECK ((("class_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "marketplace_config"."class_id") AND ("public"."is_teacher_or_admin"()))))));
+
+DROP POLICY IF EXISTS "marketplace_config_update_teacher_class" ON "public"."marketplace_config";
+CREATE POLICY "marketplace_config_update_teacher_class" ON "public"."marketplace_config" FOR UPDATE TO "authenticated" USING ((("class_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "marketplace_config"."class_id") AND ("public"."is_teacher_or_admin"())))))) WITH CHECK ((("class_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."classes" "c"
+  WHERE (("c"."id" = "marketplace_config"."class_id") AND ("public"."is_teacher_or_admin"()))))));
+
+DROP POLICY IF EXISTS "python_exercise_assignments_insert" ON "public"."python_exercise_assignments";
+CREATE POLICY "python_exercise_assignments_insert" ON "public"."python_exercise_assignments" FOR INSERT TO "authenticated" WITH CHECK ((("assigned_by" = "auth"."uid"()) AND (EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'teacher'::"public"."user_role")))) AND ((("class_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "python_exercise_assignments"."class_id") AND ("public"."is_teacher_or_admin"()))))) OR (("student_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ("public"."class_members" "cm"
+     JOIN "public"."classes" "c" ON (("c"."id" = "cm"."class_id")))
+  WHERE (("cm"."student_id" = "python_exercise_assignments"."student_id") AND ("public"."is_teacher_or_admin"()))))))));
+
+DROP POLICY IF EXISTS "python_exercise_assignments_select_teacher" ON "public"."python_exercise_assignments";
+CREATE POLICY "python_exercise_assignments_select_teacher" ON "public"."python_exercise_assignments" FOR SELECT TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM "public"."profiles"
+  WHERE (("profiles"."id" = "auth"."uid"()) AND ("profiles"."role" = 'teacher'::"public"."user_role")))) AND (("assigned_by" = "auth"."uid"()) OR (EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "python_exercise_assignments"."class_id") AND ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "skill_attempts_insert_teacher" ON "public"."skill_attempts";
+CREATE POLICY "skill_attempts_insert_teacher" ON "public"."skill_attempts" FOR INSERT TO "authenticated" WITH CHECK ((("source" = 'teacher'::"text") AND (EXISTS ( SELECT 1
+   FROM ("public"."classes" "c"
+     JOIN "public"."class_members" "cm" ON (("cm"."class_id" = "c"."id")))
+  WHERE (("public"."is_teacher_or_admin"()) AND ("cm"."student_id" = "skill_attempts"."student_id")))) AND (("task_id" IS NULL) OR (EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "skill_attempts"."task_id") AND ("public"."is_teacher_or_admin"())))))));
+
+DROP POLICY IF EXISTS "teacher_class_stats" ON "public"."template_usage_stats";
+CREATE POLICY "teacher_class_stats" ON "public"."template_usage_stats" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."classes"
+  WHERE (("classes"."id" = "template_usage_stats"."class_id") AND ("public"."is_teacher_or_admin"())))));
+
+CREATE POLICY "Students can read system and class documents" ON "public"."rag_documents" FOR SELECT TO "authenticated" USING ((("teacher_id" IS NULL) OR (("teacher_id" IN ( SELECT "p"."id" FROM "public"."profiles" "p" WHERE ("p"."role" = 'teacher'::"public"."user_role"))) AND (EXISTS ( SELECT 1 FROM "public"."class_members" "cm" WHERE ("cm"."student_id" = "auth"."uid"()))))));
+
+CREATE POLICY "Students can read chunks from accessible documents" ON "public"."rag_chunks" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1 FROM "public"."rag_documents" "d" WHERE (("d"."id" = "rag_chunks"."document_id") AND (("d"."teacher_id" IS NULL) OR (("d"."teacher_id" IN ( SELECT "p"."id" FROM "public"."profiles" "p" WHERE ("p"."role" = 'teacher'::"public"."user_role"))) AND (EXISTS ( SELECT 1 FROM "public"."class_members" "cm" WHERE ("cm"."student_id" = "auth"."uid"())))))))));
+
+
+-- ===== 2c. External policies referencing denormalized class-cluster teacher_id =====
+-- On chapter sub-tables (class_chapters.teacher_id) and evaluation_task_perimeter
+-- (evaluation_tasks.teacher_id). Same mono-teacher rewrite: -> is_teacher_or_admin().
+
+DROP POLICY IF EXISTS "Teachers can manage checklist items of their chapters" ON "public"."chapter_checklist_items";
+CREATE POLICY "Teachers can manage checklist items of their chapters" ON "public"."chapter_checklist_items" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_checklist_items"."chapter_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_checklist_items"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage documents of their chapters" ON "public"."chapter_documents";
+CREATE POLICY "Teachers can manage documents of their chapters" ON "public"."chapter_documents" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_documents"."chapter_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_documents"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage exercises of their chapters" ON "public"."chapter_exercises";
+CREATE POLICY "Teachers can manage exercises of their chapters" ON "public"."chapter_exercises" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_exercises"."chapter_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_exercises"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can manage quiz questions of their chapters" ON "public"."chapter_quiz_questions";
+CREATE POLICY "Teachers can manage quiz questions of their chapters" ON "public"."chapter_quiz_questions" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_quiz_questions"."chapter_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_quiz_questions"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can create instantiations for their chapters" ON "public"."chapter_template_instantiations";
+CREATE POLICY "Teachers can create instantiations for their chapters" ON "public"."chapter_template_instantiations" FOR INSERT TO "authenticated" WITH CHECK (((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_template_instantiations"."chapter_id") AND ("public"."is_teacher_or_admin"())))) AND "public"."is_teacher_or_admin"()));
+
+DROP POLICY IF EXISTS "Teachers can delete instantiations of their chapters" ON "public"."chapter_template_instantiations";
+CREATE POLICY "Teachers can delete instantiations of their chapters" ON "public"."chapter_template_instantiations" FOR DELETE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_template_instantiations"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can update instantiations of their chapters" ON "public"."chapter_template_instantiations";
+CREATE POLICY "Teachers can update instantiations of their chapters" ON "public"."chapter_template_instantiations" FOR UPDATE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_template_instantiations"."chapter_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_template_instantiations"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can view instantiations of their chapters" ON "public"."chapter_template_instantiations";
+CREATE POLICY "Teachers can view instantiations of their chapters" ON "public"."chapter_template_instantiations" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE (("ch"."id" = "chapter_template_instantiations"."chapter_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "evaluation_task_perimeter_delete_teacher" ON "public"."evaluation_task_perimeter";
+CREATE POLICY "evaluation_task_perimeter_delete_teacher" ON "public"."evaluation_task_perimeter" FOR DELETE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "evaluation_task_perimeter_insert_teacher" ON "public"."evaluation_task_perimeter";
+CREATE POLICY "evaluation_task_perimeter_insert_teacher" ON "public"."evaluation_task_perimeter" FOR INSERT TO "authenticated" WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "evaluation_task_perimeter_select_teacher" ON "public"."evaluation_task_perimeter";
+CREATE POLICY "evaluation_task_perimeter_select_teacher" ON "public"."evaluation_task_perimeter" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "evaluation_task_perimeter_update_teacher" ON "public"."evaluation_task_perimeter";
+CREATE POLICY "evaluation_task_perimeter_update_teacher" ON "public"."evaluation_task_perimeter" FOR UPDATE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."evaluation_tasks" "t"
+  WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"())))));
+
+
+-- ===== 6. Drop teacher_id columns =====
+-- FK constraints referencing these columns are dropped automatically with them.
+
+ALTER TABLE "public"."classes" DROP COLUMN "teacher_id";
+ALTER TABLE "public"."class_chapters" DROP COLUMN "teacher_id";
+ALTER TABLE "public"."class_journal_entries" DROP COLUMN "teacher_id";
+ALTER TABLE "public"."class_schedules" DROP COLUMN "teacher_id";
+ALTER TABLE "public"."game_timeslots" DROP COLUMN "teacher_id";
+ALTER TABLE "public"."evaluation_tasks" DROP COLUMN "teacher_id";
+
+-- ===== 7. Drop dead RPCs =====
+-- get_student_teachers / get_teacher_students had 0 remaining callers once their
+-- two internal callers (get_allowed_recipients, validate_message_recipients) were
+-- inlined in §4, and they referenced the non-existent classes.archived column
+-- (i.e. they were already broken at runtime).
+
+DROP FUNCTION IF EXISTS "public"."get_student_teachers"("uuid");
+DROP FUNCTION IF EXISTS "public"."get_teacher_students"("uuid");
+
+COMMIT;

--- a/tests/helpers/competence-referentiel.helpers.ts
+++ b/tests/helpers/competence-referentiel.helpers.ts
@@ -370,10 +370,11 @@ export async function createEvaluationTask(
 		niveauScolaire?: string;
 	}
 ): Promise<string> {
+	// Mono-teacher: evaluation_tasks.teacher_id was dropped (role-based ownership).
+	void params.teacherId;
 	const { data, error } = await service
 		.from('evaluation_tasks' as never)
 		.insert({
-			teacher_id: params.teacherId,
 			class_id: params.classId ?? null,
 			name: params.name ?? 'Test task',
 			niveau_scolaire: params.niveauScolaire ?? '6e'
@@ -413,7 +414,6 @@ export async function cleanupCompetenceTestData(): Promise<void> {
 	if (!profiles || profiles.length === 0) return;
 
 	const allIds = profiles.map((p) => p.id);
-	const teacherIds = profiles.filter((p) => p.role === 'teacher').map((p) => p.id);
 
 	// Step 2: delete attempts (leaf; ON DELETE CASCADE from profiles already handles it,
 	// but we do it explicitly to avoid trigger side-effects on non-existent cache rows)
@@ -438,29 +438,17 @@ export async function cleanupCompetenceTestData(): Promise<void> {
 			.in('student_id', allIds);
 	}
 
-	// Step 4: evaluation tasks created by test teachers
-	if (teacherIds.length > 0) {
-		// Collect task ids first so we can delete perimeter rows explicitly
-		// (defensive: even though evaluation_task_perimeter.task_id has ON DELETE CASCADE,
-		// we delete explicitly to avoid any trigger side-effects during cascade)
-		const { data: tasks } = await service
-			.from('evaluation_tasks' as never)
-			.select('id')
-			.in('teacher_id', teacherIds);
-		const allTaskIds = ((tasks ?? []) as Array<{ id: string }>).map((t) => t.id);
-
-		if (allTaskIds.length > 0) {
-			await service
-				.from('evaluation_task_perimeter' as never)
-				.delete()
-				.in('task_id', allTaskIds);
-		}
-
-		await service
-			.from('evaluation_tasks' as never)
-			.delete()
-			.in('teacher_id', teacherIds);
-	}
+	// Step 4: evaluation tasks. Mono-teacher dropped evaluation_tasks.teacher_id, so
+	// they no longer scope by teacher; purge all (test DB only — seed.sql has none).
+	// Delete perimeter first (defensive, even though task_id has ON DELETE CASCADE).
+	await service
+		.from('evaluation_task_perimeter' as never)
+		.delete()
+		.not('task_id', 'is', null);
+	await service
+		.from('evaluation_tasks' as never)
+		.delete()
+		.not('id', 'is', null);
 
 	// Step 5: fake templates (domain = 'test') — scoped to test users to avoid
 	// polluting parallel test sessions (B10: filter by created_by)
@@ -472,9 +460,8 @@ export async function cleanupCompetenceTestData(): Promise<void> {
 	if (allIds.length > 0) {
 		await service.from('class_members').delete().in('student_id', allIds);
 	}
-	if (teacherIds.length > 0) {
-		await service.from('classes').delete().in('teacher_id', teacherIds);
-	}
+	// classes no longer carry teacher_id; purge all (test DB only — seed.sql has none).
+	await service.from('classes').delete().not('id', 'is', null);
 
 	// Step 7: profiles + auth users — replica-mode deletion. A client-side
 	// `from('profiles').delete()` (or auth.admin.deleteUser) is silently aborted by

--- a/tests/helpers/database/test-data-factory.ts
+++ b/tests/helpers/database/test-data-factory.ts
@@ -116,10 +116,11 @@ export class ProfileBuilder {
 export class ClassBuilder {
 	private data: Partial<Tables['classes']['Insert']> = {};
 
-	constructor(teacherId: string) {
+	// teacherId kept for call-site compatibility but ignored: the mono-teacher
+	// refactor dropped classes.teacher_id (ownership is role-based now).
+	constructor(_teacherId?: string) {
 		this.data = {
 			id: generateTestId('class'),
-			teacher_id: teacherId,
 			name: 'Test Class',
 			join_code: `TEST${Math.random().toString(36).substring(2, 8).toUpperCase()}`,
 			created_at: new Date().toISOString(),
@@ -414,7 +415,7 @@ export class ErrorLogBuilder {
 // Export factory functions for convenience
 export const TestData = {
 	profile: () => new ProfileBuilder(),
-	class: (teacherId: string) => new ClassBuilder(teacherId),
+	class: (teacherId?: string) => new ClassBuilder(teacherId),
 	exercise: (createdBy: string) => new ExerciseBuilder(createdBy),
 	gameCombat: (organizerId: string, monsterId?: string) =>
 		new GameCombatBuilder(organizerId, monsterId),

--- a/tests/helpers/database/trigger-test-helpers.ts
+++ b/tests/helpers/database/trigger-test-helpers.ts
@@ -164,6 +164,21 @@ export async function cleanupAllTestData(): Promise<void> {
 		console.debug('Cleanup schools:', error);
 	}
 
+	// Mono-teacher: classes/evaluation_tasks no longer FK to profiles via teacher_id,
+	// so they no longer cascade-delete with the test teacher's profile. Purge them
+	// explicitly (test DB only; seed.sql creates no classes/tasks). Cascades clear
+	// class_members, class_chapters, schedules, timeslots, evaluation_task_perimeter.
+	for (const table of ['classes', 'evaluation_tasks']) {
+		try {
+			await serviceClient
+				.from(table as never)
+				.delete()
+				.not('id', 'is', null);
+		} catch (error) {
+			console.debug(`Cleanup ${table}:`, error);
+		}
+	}
+
 	// Clean up auth.users table using direct PostgreSQL client
 	// (Supabase client cannot access auth schema)
 	await deleteTestAuthUsers();
@@ -227,9 +242,10 @@ export async function insertTestClass(params: {
 }): Promise<Database['public']['Tables']['classes']['Row']> {
 	const serviceClient = createServiceRoleClient();
 
+	// Mono-teacher: classes are no longer assigned to a teacher (teacher_id dropped).
+	void params.teacherId;
 	const classData = {
 		id: generateTestId('class'),
-		teacher_id: params.teacherId,
 		name: params.name || 'Test Class',
 		join_code: `TEST${Math.random().toString(36).substring(2, 8).toUpperCase()}`,
 		created_at: new Date().toISOString()

--- a/tests/integration/game-leaderboards.test.ts
+++ b/tests/integration/game-leaderboards.test.ts
@@ -69,12 +69,13 @@ async function createClass(
 	schoolId: string,
 	grade: string | null
 ): Promise<string> {
+	// Mono-teacher: classes are no longer assigned to a teacher (teacher_id dropped).
+	void teacherId;
 	const { data, error } = await svc
 		.from('classes')
 		.insert({
 			name: 'Classe Test',
 			join_code: `LBT${codeCounter++}${Math.random().toString(36).slice(2, 7)}`,
-			teacher_id: teacherId,
 			school_id: schoolId,
 			grade
 		})

--- a/tests/integration/mono-teacher-class-cluster-rls.test.ts
+++ b/tests/integration/mono-teacher-class-cluster-rls.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Mono-teacher — class-cluster RLS after dropping `teacher_id` — Integration Tests
+ * ===============================================================================
+ *
+ * Refactor « professeur unique » : la colonne `teacher_id` a été retirée de
+ * classes, class_chapters, class_journal_entries, class_schedules, game_timeslots
+ * et evaluation_tasks. La propriété passe désormais par le RÔLE
+ * (`public.is_teacher_or_admin()`) au lieu de `teacher_id = auth.uid()`.
+ *
+ * Ces tests épinglent le contrat RLS post-migration, avec de vrais clients
+ * authentifiés (RLS réellement appliqué) :
+ *   - le prof unique ET l'admin gèrent toutes les lignes (CRUD) ;
+ *   - un élève membre LIT les lignes de sa classe (selon les policies élève) ;
+ *   - un élève n'ÉCRIT jamais ;
+ *   - un élève non-membre ne lit pas.
+ *
+ * Migration : 20260620090000_drop_class_teacher_id_mono_teacher.sql
+ * NB : le trigger mono-prof interdit ≥ 2 comptes teacher → un seul teacher par
+ * test ; cleanupAllTestData() entre les tests.
+ *
+ * Run `pnpm db:start` first, then `pnpm test:integration`.
+ *
+ * @module tests/integration/mono-teacher-class-cluster-rls
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
+import {
+	cleanupAllTestData,
+	createServiceRoleClient
+} from '../helpers/database/trigger-test-helpers';
+import { createAuthenticatedClient } from '../helpers/database/supabase-client';
+import { TestData } from '../helpers/database/test-data-factory';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+describe('Mono-teacher class-cluster RLS (no teacher_id) - Integration Tests', () => {
+	let service: SupabaseClient<Database>;
+
+	afterAll(async () => {
+		await cleanupAllTestData();
+	});
+
+	beforeEach(async () => {
+		service = createServiceRoleClient();
+		await cleanupAllTestData();
+	});
+
+	/** Create a class and enrol `studentId` as an active member. */
+	async function classWithMember(studentId: string) {
+		const cls = await TestData.class().create();
+		const { error } = await service
+			.from('class_members')
+			.insert({ class_id: cls.id, student_id: studentId, status: 'active' });
+		expect(error).toBeNull();
+		return cls;
+	}
+
+	// ========================================================================
+	// classes — ownership is now role-based (insert/update/delete/view_own)
+	// ========================================================================
+
+	it('the teacher can create, read, update and delete any class', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const tc = await createAuthenticatedClient(teacher.email);
+
+		const { data: created, error: insErr } = await tc
+			.from('classes')
+			.insert({ name: 'Maths 6e', join_code: `MONO${Math.random().toString(36).slice(2, 7)}` })
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+		expect(created).not.toBeNull();
+
+		const { data: read } = await tc.from('classes').select('id').eq('id', created!.id);
+		expect(read).toHaveLength(1);
+
+		const { error: updErr } = await tc
+			.from('classes')
+			.update({ name: 'Maths 6e B' })
+			.eq('id', created!.id);
+		expect(updErr).toBeNull();
+
+		const { error: delErr } = await tc.from('classes').delete().eq('id', created!.id);
+		expect(delErr).toBeNull();
+		const { data: gone } = await service.from('classes').select('id').eq('id', created!.id);
+		expect(gone).toHaveLength(0);
+	});
+
+	it('the admin can create a class (role-based ownership covers admin)', async () => {
+		const admin = await TestData.profile().withRole('admin').create();
+		// The sole teacher always exists in prod; the class chat-room trigger
+		// attributes the auto-created room to them.
+		await TestData.profile().withRole('teacher').create();
+		const ac = await createAuthenticatedClient(admin.email);
+
+		const { data, error } = await ac
+			.from('classes')
+			.insert({ name: 'Admin class', join_code: `ADM${Math.random().toString(36).slice(2, 7)}` })
+			.select()
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+	});
+
+	it('a student cannot create a class, but reads a class they are a member of', async () => {
+		await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+		const sc = await createAuthenticatedClient(student.email);
+
+		const { error: insErr } = await sc
+			.from('classes')
+			.insert({ name: 'Hack', join_code: `HACK${Math.random().toString(36).slice(2, 7)}` })
+			.select();
+		expect(insErr).not.toBeNull();
+
+		const { data: read } = await sc.from('classes').select('id').eq('id', cls.id);
+		expect(read).toHaveLength(1);
+	});
+
+	it('a non-member student does not see a class', async () => {
+		await TestData.profile().withRole('teacher').create();
+		const outsider = await TestData.profile().withRole('student').create();
+		const cls = await TestData.class().create();
+
+		const sc = await createAuthenticatedClient(outsider.email);
+		const { data } = await sc.from('classes').select('id').eq('id', cls.id);
+		expect(data).toHaveLength(0);
+	});
+
+	// ========================================================================
+	// class_chapters — teacher manages; student reads visible chapters of class
+	// ========================================================================
+
+	it('the teacher manages chapters; a member student reads only visible ones', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data: visible, error: insErr } = await tc
+			.from('class_chapters')
+			.insert({ class_id: cls.id, title: 'Visible', is_visible: true })
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+
+		const { data: hidden } = await tc
+			.from('class_chapters')
+			.insert({ class_id: cls.id, title: 'Hidden', is_visible: false })
+			.select()
+			.single();
+
+		const sc = await createAuthenticatedClient(student.email);
+		const { data: studentSees } = await sc
+			.from('class_chapters')
+			.select('id')
+			.eq('class_id', cls.id);
+		const ids = (studentSees ?? []).map((r) => r.id);
+		expect(ids).toContain(visible!.id);
+		expect(ids).not.toContain(hidden!.id);
+
+		// student cannot write a chapter
+		const { error: hackErr } = await sc
+			.from('class_chapters')
+			.insert({ class_id: cls.id, title: 'Hack', is_visible: true })
+			.select();
+		expect(hackErr).not.toBeNull();
+	});
+
+	// ========================================================================
+	// class_journal_entries — teacher manages; student reads published past
+	// ========================================================================
+
+	it('the teacher manages journal entries; a member student reads only published past ones', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+		const today = new Date().toISOString().slice(0, 10);
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data: published, error: insErr } = await tc
+			.from('class_journal_entries')
+			.insert({ class_id: cls.id, entry_date: today, is_published: true })
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+
+		// Distinct date: (class_id, entry_date) is unique.
+		const { data: draft, error: draftErr } = await tc
+			.from('class_journal_entries')
+			.insert({ class_id: cls.id, entry_date: '2020-01-01', is_published: false })
+			.select()
+			.single();
+		expect(draftErr).toBeNull();
+
+		const sc = await createAuthenticatedClient(student.email);
+		const { data: seen } = await sc
+			.from('class_journal_entries')
+			.select('id')
+			.eq('class_id', cls.id);
+		const ids = (seen ?? []).map((r) => r.id);
+		expect(ids).toContain(published!.id);
+		expect(ids).not.toContain(draft!.id);
+
+		const { error: hackErr } = await sc
+			.from('class_journal_entries')
+			.insert({ class_id: cls.id, entry_date: today, is_published: true })
+			.select();
+		expect(hackErr).not.toBeNull();
+	});
+
+	// ========================================================================
+	// class_schedules — teacher manages; member student reads their class's
+	// ========================================================================
+
+	it('the teacher manages schedules; a member student reads them; a student cannot write', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data: sched, error: insErr } = await tc
+			.from('class_schedules')
+			.insert({ class_id: cls.id, day_of_week: 1, start_time: '08:00', end_time: '09:00' })
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+
+		const sc = await createAuthenticatedClient(student.email);
+		const { data: seen } = await sc.from('class_schedules').select('id').eq('id', sched!.id);
+		expect(seen).toHaveLength(1);
+
+		const { error: hackErr } = await sc
+			.from('class_schedules')
+			.insert({ class_id: cls.id, day_of_week: 2, start_time: '10:00', end_time: '11:00' })
+			.select();
+		expect(hackErr).not.toBeNull();
+	});
+
+	// ========================================================================
+	// game_timeslots — teacher manages; member student reads their class's
+	// ========================================================================
+
+	it('the teacher manages game timeslots; a member student reads them', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data: slot, error: insErr } = await tc
+			.from('game_timeslots')
+			.insert({
+				class_id: cls.id,
+				name: 'Slot',
+				challenge_ids: [],
+				difficulty: 1,
+				starts_at: new Date().toISOString(),
+				ends_at: new Date(Date.now() + 3600_000).toISOString()
+			})
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+
+		const sc = await createAuthenticatedClient(student.email);
+		const { data: seen } = await sc.from('game_timeslots').select('id').eq('id', slot!.id);
+		expect(seen).toHaveLength(1);
+
+		const { error: hackErr } = await sc
+			.from('game_timeslots')
+			.insert({
+				class_id: cls.id,
+				name: 'Hack',
+				challenge_ids: [],
+				difficulty: 1,
+				starts_at: new Date().toISOString(),
+				ends_at: new Date(Date.now() + 3600_000).toISOString()
+			})
+			.select();
+		expect(hackErr).not.toBeNull();
+	});
+
+	// ========================================================================
+	// evaluation_tasks — teacher manages; member student reads class tasks
+	// ========================================================================
+
+	it('the teacher manages evaluation tasks; a member student reads their class tasks; a student cannot write', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data: task, error: insErr } = await tc
+			.from('evaluation_tasks')
+			.insert({ class_id: cls.id, niveau_scolaire: '6e', name: 'Eval 1' })
+			.select()
+			.single();
+		expect(insErr).toBeNull();
+
+		const sc = await createAuthenticatedClient(student.email);
+		const { data: seen } = await sc.from('evaluation_tasks').select('id').eq('id', task!.id);
+		expect(seen).toHaveLength(1);
+
+		const { error: hackErr } = await sc
+			.from('evaluation_tasks')
+			.insert({ class_id: cls.id, niveau_scolaire: '6e', name: 'Hack' })
+			.select();
+		expect(hackErr).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Objectif

Finir le passage **mono-professeur** : retirer la colonne `teacher_id`, désormais redondante, du **cluster classes** (`classes`, `class_chapters`, `class_journal_entries`, `class_schedules`, `game_timeslots`, `evaluation_tasks`). Les classes ne sont plus « assignées à un prof ». La propriété passe de `teacher_id = auth.uid()` au **rôle** via `public.is_teacher_or_admin()`.

**Permissions effectives inchangées** — il y a un seul prof qui possède déjà toutes les classes ; c'est un refactor, pas un élargissement de droits.

## Contenu

- **Migration `20260620090000`** : drop des 6 colonnes + FK + trigger `set_chapter_teacher_id` ; réécriture role-based des policies des 6 tables, de **41 policies externes** (autres tables qui sous-requêtaient `classes.teacher_id`), de 2 policies de lecture élève `rag_*` (réécrites à la main), et de ~40 fonctions `SECURITY DEFINER` ; retrait du param `p_teacher_id` des RPC de classes ; drop des RPC mortes `get_student_teachers` / `get_teacher_students`.
- **Sweep applicatif** (~55 fichiers route/page) qui lisaient encore les colonnes supprimées — la propriété est maintenant assurée par la **RLS + les gardes de rôle** des routes. Les tables **KEEP** (`google_classroom_courses`, `google_integrations`, `rag_documents`, `orphaned_documents`, `teacher_vip_card_overrides`) gardent leur `teacher_id`.
- Pages **côté élève** : résolution du prof unique pour l'affichage (plus d'embed via la FK supprimée).
- **Tests** : nouvelle suite d'intégration RLS pour les 6 tables ; helpers de test adaptés (la suppression du prof ne cascade plus vers les classes) ; mocks unitaires recâblés.

## Vérification

- `pnpm check:incremental` = **0 erreur**.
- Migration appliquée proprement (`db:reset`) ; **0** fonction ne référence une colonne supprimée.
- **`security-auditor` : CLEAN** (aucun Critical/High/Medium — pas d'escalade de privilège, frontières élève intactes, service-role non bypassé).
- `test:server` + intégration **verts** sur DB propre, à l'exception de 2 tests `admin-elevation` (env local : `PUBLIC_SUPABASE_URL` pointe sur la prod) et 1 test `futureDateSchema` (flaky timezone) — **tous pré-existants**, hors-sujet, verts en CI.

## ⚠️ Déploiement (migration DESTRUCTIVE)

`DROP COLUMN` → destructif. **Ne PAS** lancer `db:migrate` avant le déploiement du code. Séquence prévue (séparément, plus tard, accord explicite requis) :

1. Merge + déploiement du code (ne lit plus `teacher_id`).
2. `pnpm maintenance:on`.
3. `pnpm db:migrate` (EU).
4. `pnpm db:types` + commit (régénère `database.ts` depuis la prod) — **avant** ça, `database.ts` est généré depuis le local.
5. `pnpm maintenance:off`.

## Notes audit (Low, à documenter dans `database-schema.md`)

- Insert/delete des `student_warnings` devient admin-inclusif (via `is_class_teacher` → role).
- Filtre `cm.status='active'` retiré dans quelques fonctions VIP (n'élargit que la portée du prof unique).