### PR TITLE
fix(db): add storage chapter-doc policy rewrites to mono-teacher migration

### DIFF
--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -7,30 +7,10 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5"
   }
   public: {
     Tables: {
@@ -16586,9 +16566,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       consent_status: ["pending", "granted", "expired"],
@@ -16640,4 +16617,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/supabase/migrations/20260620090000_drop_class_teacher_id_mono_teacher.sql
+++ b/supabase/migrations/20260620090000_drop_class_teacher_id_mono_teacher.sql
@@ -3566,6 +3566,34 @@ CREATE POLICY "evaluation_task_perimeter_update_teacher" ON "public"."evaluation
   WHERE (("t"."id" = "evaluation_task_perimeter"."task_id") AND ("public"."is_teacher_or_admin"())))));
 
 
+-- ===== 5c. storage.objects chapter-document policies (prod-only) =====
+-- These RLS policies live in the storage schema (created out-of-band via the
+-- Supabase dashboard) and reference class_chapters.teacher_id, so they block the
+-- column drop on prod. They do NOT exist on fresh local DBs, hence DROP ... IF
+-- EXISTS. Rewrite the teacher-ownership predicate to role-based; the
+-- orphaned-documents path branch (keyed on auth.uid()) and is_admin() are kept.
+
+DROP POLICY IF EXISTS "Teachers can read chapter documents" ON "storage"."objects";
+CREATE POLICY "Teachers can read chapter documents" ON "storage"."objects" FOR SELECT TO "authenticated" USING (((bucket_id = 'chapter-documents'::"text") AND ((((string_to_array(name, '/'::"text"))[1] = 'chapters'::"text") AND (EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE ((("ch"."id")::"text" = (string_to_array("objects"."name", '/'::"text"))[2]) AND "public"."is_teacher_or_admin"())))) OR (((string_to_array(name, '/'::"text"))[1] = 'orphaned-documents'::"text") AND ((string_to_array(name, '/'::"text"))[2] = ("auth"."uid"())::"text")) OR "public"."is_admin"())));
+
+DROP POLICY IF EXISTS "Teachers can upload chapter documents" ON "storage"."objects";
+CREATE POLICY "Teachers can upload chapter documents" ON "storage"."objects" FOR INSERT TO "authenticated" WITH CHECK (((bucket_id = 'chapter-documents'::"text") AND ((((string_to_array(name, '/'::"text"))[1] = 'chapters'::"text") AND (EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE ((("ch"."id")::"text" = (string_to_array("objects"."name", '/'::"text"))[2]) AND "public"."is_teacher_or_admin"())))) OR (((string_to_array(name, '/'::"text"))[1] = 'orphaned-documents'::"text") AND "public"."is_admin"()))));
+
+DROP POLICY IF EXISTS "Teachers can update chapter documents" ON "storage"."objects";
+CREATE POLICY "Teachers can update chapter documents" ON "storage"."objects" FOR UPDATE TO "authenticated" USING (((bucket_id = 'chapter-documents'::"text") AND ((string_to_array(name, '/'::"text"))[1] = 'chapters'::"text") AND (EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE ((("ch"."id")::"text" = (string_to_array("objects"."name", '/'::"text"))[2]) AND "public"."is_teacher_or_admin"())))));
+
+DROP POLICY IF EXISTS "Teachers can delete chapter documents" ON "storage"."objects";
+CREATE POLICY "Teachers can delete chapter documents" ON "storage"."objects" FOR DELETE TO "authenticated" USING (((bucket_id = 'chapter-documents'::"text") AND ((((string_to_array(name, '/'::"text"))[1] = 'chapters'::"text") AND (EXISTS ( SELECT 1
+   FROM "public"."class_chapters" "ch"
+  WHERE ((("ch"."id")::"text" = (string_to_array("objects"."name", '/'::"text"))[2]) AND "public"."is_teacher_or_admin"())))) OR (((string_to_array(name, '/'::"text"))[1] = 'orphaned-documents'::"text") AND ((string_to_array(name, '/'::"text"))[2] = ("auth"."uid"())::"text")))));
+
+
 -- ===== 6. Drop teacher_id columns =====
 -- FK constraints referencing these columns are dropped automatically with them.
 


### PR DESCRIPTION
## Contexte

Suite de #42. La migration `20260620090000` a bien été appliquée en prod EU, mais **après un correctif** : 4 policies RLS sur `storage.objects` (bucket `chapter-documents` : read / upload / update / delete) référencent `class_chapters.teacher_id`. Elles ont été créées **hors-baseline** (via le dashboard Supabase), donc absentes du schéma local → `db:reset` local passait, mais le **push prod échouait** au drop de `class_chapters.teacher_id` (SQLSTATE 2BP01).

## Correctif

Ajout, **avant les drops de colonnes**, du `DROP IF EXISTS` + recréation role-based de ces 4 policies (prédicat `ch.teacher_id = auth.uid()` → `public.is_teacher_or_admin()` ; les branches `orphaned-documents` et `is_admin()` sont conservées).

- `DROP ... IF EXISTS` → no-op sur un schéma local frais (les policies n'y existent pas) ; recrée la version role-based partout.
- Vérifié localement (`db:reset` ✅) **et appliqué en prod EU** (`db push` ✅ « Finished »). Prod confirmé migré via `db:types` (plus de `teacher_id` sur les 6 tables).
- Ce commit **remet le fichier de migration en phase avec ce qui a réellement tourné en prod**.

## database.ts

Régénéré depuis la prod (`db:types`, canonique). Le seul delta vs la version générée en `--local` est le **format de génération** (bloc `graphql_public` retiré / métadonnée `__InternalSupabase`), **pas le schéma**. `check:incremental` = 0.

## Note process

La migration de #42 était déjà mergée/appliquée quand le blocage prod est apparu (objets storage hors-baseline, invisibles en local). D'où ce PR de réconciliation plutôt qu'un amend.