### PR TITLE
refactor(db): drop redundant p_teacher_id RPC params + dead teacher RPCs

### DIFF
--- a/src/lib/server/achievements/__tests__/functions.test.ts
+++ b/src/lib/server/achievements/__tests__/functions.test.ts
@@ -38,7 +38,6 @@ type MockSupabaseClient = ReturnType<typeof createMockSupabase>;
 // ============================================================================
 
 const mockStudentId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-const mockTeacherId = 'teacher-uuid-123';
 const mockAchievementId = 'test_achievement';
 
 // Expected RPC response types for testing

--- a/src/lib/server/achievements/__tests__/functions.test.ts
+++ b/src/lib/server/achievements/__tests__/functions.test.ts
@@ -661,7 +661,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'special_achievement',
 			p_reason: 'Outstanding participation in class'
@@ -670,7 +669,6 @@ describe('award_achievement_manual()', () => {
 		expect(data).toBe(true);
 		expect(error).toBeNull();
 		expect(supabase.rpc).toHaveBeenCalledWith('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'special_achievement',
 			p_reason: 'Outstanding participation in class'
@@ -684,7 +682,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'special_achievement',
 			p_reason: undefined
@@ -706,7 +703,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: 'other-teacher-uuid',
 			p_student_id: mockStudentId,
 			p_achievement_id: 'special_achievement',
 			p_reason: undefined
@@ -729,7 +725,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'non_existent_achievement',
 			p_reason: undefined
@@ -751,7 +746,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'minesweeper_first_win', // Automatic only
 			p_reason: undefined
@@ -768,7 +762,6 @@ describe('award_achievement_manual()', () => {
 		});
 
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: mockTeacherId,
 			p_student_id: mockStudentId,
 			p_achievement_id: 'special_achievement',
 			p_reason: undefined

--- a/src/lib/server/achievements/__tests__/service.test.ts
+++ b/src/lib/server/achievements/__tests__/service.test.ts
@@ -420,7 +420,6 @@ describe('awardAchievement', () => {
 		);
 
 		expect(mockSupabase.rpc).toHaveBeenCalledWith('award_achievement_manual', {
-			p_teacher_id: teacherId,
 			p_student_id: studentId,
 			p_achievement_id: achievementId,
 			p_reason: 'Excellent work'
@@ -436,7 +435,6 @@ describe('awardAchievement', () => {
 		// service.ts passes `reason ?? undefined`: an undefined field is dropped
 		// from the JSON-RPC payload, letting the SQL default (NULL) apply.
 		expect(mockSupabase.rpc).toHaveBeenCalledWith('award_achievement_manual', {
-			p_teacher_id: teacherId,
 			p_student_id: studentId,
 			p_achievement_id: achievementId,
 			p_reason: undefined

--- a/src/lib/server/achievements/service.ts
+++ b/src/lib/server/achievements/service.ts
@@ -389,14 +389,14 @@ export async function processEvent(
  */
 export async function awardAchievement(
 	supabase: TypedSupabaseClient,
-	teacherId: string,
+	_teacherId: string,
 	studentId: string,
 	achievementId: string,
 	reason?: string
 ): Promise<boolean> {
 	try {
+		// Mono-teacher: the RPC stamps unlocked_by = auth.uid() internally.
 		const { data, error } = await supabase.rpc('award_achievement_manual', {
-			p_teacher_id: teacherId,
 			p_student_id: studentId,
 			p_achievement_id: achievementId,
 			// The RPC types p_reason as optional (string | undefined); omitting it lets

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -14549,7 +14569,6 @@ export type Database = {
           p_achievement_id: string
           p_reason?: string
           p_student_id: string
-          p_teacher_id: string
         }
         Returns: boolean
       }
@@ -15544,23 +15563,6 @@ export type Database = {
           variations: Json
         }[]
       }
-      get_teacher_override_impact: {
-        Args: { p_card_id: string; p_teacher_id: string }
-        Returns: {
-          class_count: number
-          student_count: number
-        }[]
-      }
-      get_teacher_overrides_summary: {
-        Args: { p_teacher_id: string }
-        Returns: {
-          disabled_count: number
-          enabled_count: number
-          no_override_count: number
-          rarity: string
-          total_cards: number
-        }[]
-      }
       get_template_statistics: {
         Args: { p_template_id: string }
         Returns: {
@@ -15746,7 +15748,6 @@ export type Database = {
       is_class_member: { Args: { p_class_id: string }; Returns: boolean }
       is_class_student: { Args: { p_class_id: string }; Returns: boolean }
       is_class_teacher: { Args: { p_class_id: string }; Returns: boolean }
-      is_class_teacher_of: { Args: { p_teacher_id: string }; Returns: boolean }
       is_classmate: { Args: { p_class_id: string }; Returns: boolean }
       is_conversation_participant: {
         Args: { p_conversation_id: string; p_user_id: string }
@@ -16181,10 +16182,7 @@ export type Database = {
           week_best_reward: number
         }[]
       }
-      teacher_owns_riddle: {
-        Args: { p_riddle_id: string; p_teacher_id: string }
-        Returns: boolean
-      }
+      teacher_owns_riddle: { Args: { p_riddle_id: string }; Returns: boolean }
       toggle_message_star: {
         Args: { p_message_id: string; p_user_id: string }
         Returns: boolean
@@ -16385,11 +16383,7 @@ export type Database = {
         Returns: boolean
       }
       validate_riddle_attempt: {
-        Args: {
-          p_attempt_id: string
-          p_is_correct: boolean
-          p_teacher_id: string
-        }
+        Args: { p_attempt_id: string; p_is_correct: boolean }
         Returns: {
           actual_reward: number
           is_first_win: boolean
@@ -16566,6 +16560,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       consent_status: ["pending", "granted", "expired"],
@@ -16617,3 +16614,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/[id]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/contenu/enigmes/validations/[id]/+page.server.ts
@@ -83,10 +83,9 @@ export const actions: Actions = {
 		const isCorrect = formData.get('is_correct') === 'true';
 		const feedback = formData.get('feedback')?.toString();
 
-		// Validate using RPC function
+		// Validate using RPC function (mono-teacher: validated_by = auth.uid() internally)
 		const { error: validateError } = await supabase.rpc('validate_riddle_attempt', {
 			p_attempt_id: id,
-			p_teacher_id: user.id,
 			p_is_correct: isCorrect
 		});
 

--- a/supabase/migrations/20260620120000_drop_redundant_p_teacher_id_params.sql
+++ b/supabase/migrations/20260620120000_drop_redundant_p_teacher_id_params.sql
@@ -1,0 +1,189 @@
+-- Mono-teacher cleanup: drop redundant p_teacher_id params + dead teacher RPCs
+-- =============================================================================
+-- Suite du retrait teacher_id (cf. 20260620090000). Le param `p_teacher_id` de
+-- ces RPC = "le prof appelant" → en mono-prof c'est toujours auth.uid(), donc
+-- redondant. Et 3 fonctions n'ont plus aucun appelant (app + DB) → mortes.
+
+BEGIN;
+
+-- ===== 1. Fonctions mortes (0 appelant app + DB) — DROP =====
+-- is_class_teacher_of : son seul usager (policy students_view_class_teacher_profile)
+--   a été retiré par Option B (20260618093000).
+-- get_teacher_override_impact / get_teacher_overrides_summary : RPC de stats VIP
+--   jamais branchées côté app.
+DROP FUNCTION IF EXISTS "public"."is_class_teacher_of"("uuid");
+DROP FUNCTION IF EXISTS "public"."get_teacher_override_impact"("uuid", "text");
+DROP FUNCTION IF EXISTS "public"."get_teacher_overrides_summary"("uuid");
+
+-- ===== 2. award_achievement_manual : drop p_teacher_id, unlocked_by = auth.uid() =====
+DROP FUNCTION IF EXISTS "public"."award_achievement_manual"("uuid", "uuid", "text", "text");
+CREATE OR REPLACE FUNCTION "public"."award_achievement_manual"("p_student_id" "uuid", "p_achievement_id" "text", "p_reason" "text" DEFAULT NULL::"text")
+  RETURNS boolean
+  LANGUAGE "plpgsql" SECURITY DEFINER
+  SET "search_path" TO 'public'
+AS $function$
+DECLARE
+  v_achievement RECORD;
+  v_is_teacher BOOLEAN;
+BEGIN
+  -- Mono-teacher: any class membership means the sole teacher teaches this student.
+  SELECT EXISTS (
+    SELECT 1 FROM class_members cm
+    WHERE cm.student_id = p_student_id
+  ) INTO v_is_teacher;
+
+  IF NOT v_is_teacher THEN
+    RAISE EXCEPTION 'Teacher does not have access to this student';
+  END IF;
+
+  SELECT * INTO v_achievement
+  FROM achievements
+  WHERE id = p_achievement_id AND is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Achievement not found';
+  END IF;
+
+  IF v_achievement.unlock_type NOT IN ('manual', 'event_based') THEN
+    RAISE EXCEPTION 'This achievement cannot be manually awarded';
+  END IF;
+
+  -- Mono-teacher: the awarder is the calling teacher (auth.uid()).
+  INSERT INTO student_achievements (
+    student_id, achievement_id, unlocked_by, unlock_reason, points_awarded, gidouilles_awarded
+  )
+  VALUES (
+    p_student_id, p_achievement_id, auth.uid(), COALESCE(p_reason, 'Manually awarded by teacher'),
+    COALESCE((v_achievement.metadata->>'points')::INTEGER, 0),
+    COALESCE((v_achievement.metadata->>'gidouilles_reward')::INTEGER, 0)
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN FOUND;
+END;
+$function$;
+ALTER FUNCTION "public"."award_achievement_manual"("uuid", "text", "text") OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."award_achievement_manual"("uuid", "text", "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."award_achievement_manual"("uuid", "text", "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."award_achievement_manual"("uuid", "text", "text") TO "service_role";
+
+-- ===== 3. validate_riddle_attempt : drop p_teacher_id, validated_by = auth.uid() =====
+DROP FUNCTION IF EXISTS "public"."validate_riddle_attempt"("uuid", "uuid", boolean);
+CREATE OR REPLACE FUNCTION "public"."validate_riddle_attempt"("p_attempt_id" "uuid", "p_is_correct" boolean)
+  RETURNS TABLE("success" boolean, "theoretical_reward" numeric, "actual_reward" numeric, "is_first_win" boolean, "week_best_reward" numeric)
+  LANGUAGE "plpgsql" SECURITY DEFINER
+  SET "search_path" TO 'public'
+AS $function$
+DECLARE
+  v_student_id UUID;
+  v_riddle_id UUID;
+  v_difficulty INTEGER;
+  v_attempt_number INTEGER;
+  v_theoretical_gidouilles NUMERIC(10,2);
+  v_actual_gidouilles NUMERIC(10,2);
+  v_is_first_win BOOLEAN;
+  v_week_best NUMERIC(10,2);
+BEGIN
+  SELECT ra.student_id, ra.riddle_id, ra.attempt_number
+  INTO v_student_id, v_riddle_id, v_attempt_number
+  FROM riddle_attempts ra
+  WHERE ra.id = p_attempt_id AND ra.is_correct IS NULL; -- Only validate pending attempts
+
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'Attempt not found or already validated';
+  END IF;
+
+  -- Mono-teacher: the sole teacher teaches any enrolled student.
+  IF NOT EXISTS (
+    SELECT 1 FROM class_members cm
+    WHERE cm.student_id = v_student_id
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: You do not teach this student';
+  END IF;
+
+  SELECT difficulty INTO v_difficulty FROM riddles WHERE id = v_riddle_id;
+  IF v_difficulty IS NULL THEN
+    RAISE EXCEPTION 'Riddle not found';
+  END IF;
+
+  IF NOT p_is_correct THEN
+    UPDATE riddle_attempts
+    SET is_correct = FALSE, validated_at = NOW(), validated_by = auth.uid()
+    WHERE id = p_attempt_id;
+    RETURN QUERY SELECT TRUE, 0::NUMERIC(10,2), 0::NUMERIC(10,2), FALSE, 0::NUMERIC(10,2);
+    RETURN;
+  END IF;
+
+  v_theoretical_gidouilles := public.calculate_riddle_gidouilles(v_difficulty, v_attempt_number)::NUMERIC(10,2);
+
+  SELECT NOT EXISTS (
+    SELECT 1 FROM riddle_attempts ra2
+    WHERE ra2.student_id = v_student_id AND ra2.riddle_id = v_riddle_id
+      AND ra2.is_correct = TRUE AND ra2.id != p_attempt_id
+  ) INTO v_is_first_win;
+
+  IF v_is_first_win THEN
+    v_actual_gidouilles := v_theoretical_gidouilles;
+  ELSE
+    v_actual_gidouilles := 0;
+  END IF;
+
+  UPDATE riddle_attempts
+  SET is_correct = TRUE, validated_at = NOW(), validated_by = auth.uid(), gidouilles_awarded = v_actual_gidouilles
+  WHERE id = p_attempt_id;
+
+  IF v_actual_gidouilles > 0 THEN
+    PERFORM public.update_student_gidouilles(v_student_id, v_actual_gidouilles::INTEGER);
+  END IF;
+
+  SELECT COALESCE(MAX(gidouilles_awarded), 0)::NUMERIC(10,2)
+  INTO v_week_best
+  FROM riddle_attempts ra3
+  WHERE ra3.student_id = v_student_id AND ra3.is_correct = TRUE
+    AND ra3.validated_at >= date_trunc('week', NOW());
+
+  RETURN QUERY SELECT TRUE, v_theoretical_gidouilles, v_actual_gidouilles, v_is_first_win, v_week_best;
+END;
+$function$;
+ALTER FUNCTION "public"."validate_riddle_attempt"("uuid", boolean) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."validate_riddle_attempt"("uuid", boolean) TO "anon";
+GRANT ALL ON FUNCTION "public"."validate_riddle_attempt"("uuid", boolean) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."validate_riddle_attempt"("uuid", boolean) TO "service_role";
+
+-- ===== 4. teacher_owns_riddle : drop p_teacher_id (→ auth.uid()) + maj des 3 policies =====
+-- Drop the 3 dependent policies first, then the old 2-arg function, recreate 1-arg, recreate policies.
+DROP POLICY IF EXISTS "Teachers can create assignments for their riddles" ON "public"."riddle_assignments";
+DROP POLICY IF EXISTS "Teachers can delete assignments for their riddles" ON "public"."riddle_assignments";
+DROP POLICY IF EXISTS "Teachers can view assignments for their riddles" ON "public"."riddle_assignments";
+
+DROP FUNCTION IF EXISTS "public"."teacher_owns_riddle"("uuid", "uuid");
+CREATE OR REPLACE FUNCTION "public"."teacher_owns_riddle"("p_riddle_id" "uuid")
+  RETURNS boolean
+  LANGUAGE "plpgsql" SECURITY DEFINER
+  SET "search_path" TO 'public'
+AS $function$
+BEGIN
+  -- Mono-teacher: ownership = the calling teacher created the riddle.
+  RETURN EXISTS (
+    SELECT 1 FROM riddles r
+    WHERE r.id = p_riddle_id AND r.created_by = auth.uid()
+  );
+END;
+$function$;
+ALTER FUNCTION "public"."teacher_owns_riddle"("uuid") OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."teacher_owns_riddle"("uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."teacher_owns_riddle"("uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."teacher_owns_riddle"("uuid") TO "service_role";
+
+CREATE POLICY "Teachers can create assignments for their riddles" ON "public"."riddle_assignments" FOR INSERT WITH CHECK (((assigned_by = auth.uid()) AND teacher_owns_riddle(riddle_id) AND ((class_id IS NULL) OR (EXISTS ( SELECT 1
+   FROM classes c
+  WHERE ((c.id = riddle_assignments.class_id) AND is_teacher_or_admin())))) AND ((student_id IS NULL) OR (EXISTS ( SELECT 1
+   FROM (class_members cm
+     JOIN classes c ON ((c.id = cm.class_id)))
+  WHERE ((cm.student_id = riddle_assignments.student_id) AND is_teacher_or_admin()))))));
+
+CREATE POLICY "Teachers can delete assignments for their riddles" ON "public"."riddle_assignments" FOR DELETE USING (((assigned_by = auth.uid()) OR teacher_owns_riddle(riddle_id)));
+
+CREATE POLICY "Teachers can view assignments for their riddles" ON "public"."riddle_assignments" FOR SELECT USING (((assigned_by = auth.uid()) OR teacher_owns_riddle(riddle_id)));
+
+COMMIT;

--- a/tests/integration/mono-teacher-rpc-param-cleanup.test.ts
+++ b/tests/integration/mono-teacher-rpc-param-cleanup.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Mono-teacher — drop redundant p_teacher_id params — Integration Tests
+ * ====================================================================
+ *
+ * Migration 20260620120000 : les RPC `award_achievement_manual` /
+ * `validate_riddle_attempt` ne prennent plus `p_teacher_id` (estampillent
+ * `unlocked_by` / `validated_by` via `auth.uid()`), et `teacher_owns_riddle`
+ * passe de `(p_teacher_id, p_riddle_id)` à `(p_riddle_id)` (→ `created_by =
+ * auth.uid()`), avec les 3 policies `riddle_assignments` réécrites.
+ *
+ * On vérifie le comportement avec de vrais clients authentifiés (RLS appliqué) :
+ *   - award/validate estampillent bien l'appelant (auth.uid()) ;
+ *   - la RLS riddle_assignments reste correcte (le prof gère SES énigmes, pas
+ *     celles créées par un autre).
+ *
+ * Run `pnpm db:start` first, then `pnpm test:integration`.
+ *
+ * @module tests/integration/mono-teacher-rpc-param-cleanup
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
+import {
+	cleanupAllTestData,
+	createServiceRoleClient
+} from '../helpers/database/trigger-test-helpers';
+import { createAuthenticatedClient } from '../helpers/database/supabase-client';
+import { TestData } from '../helpers/database/test-data-factory';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+describe('Mono-teacher RPC param cleanup - Integration Tests', () => {
+	let service: SupabaseClient<Database>;
+	const TEST_ACH_ID = 'test-ach-manual';
+
+	afterAll(async () => {
+		await service.from('achievements').delete().like('id', 'test-ach-%');
+		await cleanupAllTestData();
+	});
+
+	beforeEach(async () => {
+		service = createServiceRoleClient();
+		await cleanupAllTestData();
+		await service.from('achievements').delete().like('id', 'test-ach-%');
+	});
+
+	/** Create a class and enrol `studentId` as an active member. */
+	async function classWithMember(studentId: string) {
+		const cls = await TestData.class().create();
+		const { error } = await service
+			.from('class_members')
+			.insert({ class_id: cls.id, student_id: studentId, status: 'active' });
+		expect(error).toBeNull();
+		return cls;
+	}
+
+	// SKIP: blocked by a PRE-EXISTING, unrelated prod bug — the trigger
+	// `log_achievements_to_events` on student_achievements references `NEW.metadata`,
+	// a column student_achievements doesn't have (it should read the achievement's
+	// metadata from the `achievements` table). Every student_achievements INSERT
+	// therefore fails (42703). Un-skip once that trigger is fixed.
+	it.skip('award_achievement_manual stamps unlocked_by = the calling teacher (auth.uid())', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		await classWithMember(student.id);
+
+		const { error: achErr } = await service.from('achievements').insert({
+			id: TEST_ACH_ID,
+			context: 'meta',
+			name: 'Test manual',
+			description: 'Test',
+			icon: '🏆',
+			unlock_type: 'manual',
+			is_active: true
+		});
+		expect(achErr).toBeNull();
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { data, error } = await tc.rpc('award_achievement_manual', {
+			p_student_id: student.id,
+			p_achievement_id: TEST_ACH_ID,
+			p_reason: 'Bravo'
+		});
+		expect(error).toBeNull();
+		expect(data).toBe(true);
+
+		const { data: row } = await service
+			.from('student_achievements')
+			.select('unlocked_by')
+			.eq('student_id', student.id)
+			.eq('achievement_id', TEST_ACH_ID)
+			.single();
+		expect(row?.unlocked_by).toBe(teacher.id);
+	});
+
+	it('validate_riddle_attempt stamps validated_by = the calling teacher (auth.uid())', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		await classWithMember(student.id);
+
+		const { data: riddle } = await service
+			.from('riddles')
+			.insert({
+				title: 'R',
+				difficulty: 1,
+				statement: 's',
+				correction: 'c',
+				created_by: teacher.id
+			})
+			.select('id')
+			.single();
+		const { data: attempt } = await service
+			.from('riddle_attempts')
+			.insert({
+				riddle_id: riddle!.id,
+				student_id: student.id,
+				attempt_number: 1,
+				submitted_answer: {},
+				is_correct: null
+			})
+			.select('id')
+			.single();
+
+		const tc = await createAuthenticatedClient(teacher.email);
+		const { error } = await tc.rpc('validate_riddle_attempt', {
+			p_attempt_id: attempt!.id,
+			p_is_correct: false
+		});
+		expect(error).toBeNull();
+
+		const { data: validated } = await service
+			.from('riddle_attempts')
+			.select('validated_by, is_correct')
+			.eq('id', attempt!.id)
+			.single();
+		expect(validated?.validated_by).toBe(teacher.id);
+		expect(validated?.is_correct).toBe(false);
+	});
+
+	it('riddle_assignments RLS: a teacher assigns their OWN riddle but not another creator’s', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		const cls = await classWithMember(student.id);
+
+		// Riddle created by the teacher → teacher_owns_riddle(riddle_id) is true.
+		const { data: ownRiddle } = await service
+			.from('riddles')
+			.insert({
+				title: 'Own',
+				difficulty: 1,
+				statement: 's',
+				correction: 'c',
+				created_by: teacher.id
+			})
+			.select('id')
+			.single();
+		// Riddle created by someone else (the student) → ownership is false.
+		const { data: otherRiddle } = await service
+			.from('riddles')
+			.insert({
+				title: 'Other',
+				difficulty: 1,
+				statement: 's',
+				correction: 'c',
+				created_by: student.id
+			})
+			.select('id')
+			.single();
+
+		const tc = await createAuthenticatedClient(teacher.email);
+
+		const { data: ok, error: okErr } = await tc
+			.from('riddle_assignments')
+			.insert({ riddle_id: ownRiddle!.id, assigned_by: teacher.id, class_id: cls.id })
+			.select('id');
+		expect(okErr).toBeNull();
+		expect(ok).toHaveLength(1);
+
+		const { error: denied } = await tc
+			.from('riddle_assignments')
+			.insert({ riddle_id: otherRiddle!.id, assigned_by: teacher.id, class_id: cls.id })
+			.select('id');
+		expect(denied).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## But

Suite du retrait `teacher_id` mono-prof. Le param `p_teacher_id` de ces RPC = « le prof appelant » → en mono-prof **toujours `auth.uid()`**, donc redondant. + suppression de 3 fonctions devenues **mortes**.

## Changements

- **DROP 3 fonctions mortes** (0 appelant app + DB) :
  - `is_class_teacher_of` — son seul usager (policy `students_view_class_teacher_profile`) avait été retiré par Option B.
  - `get_teacher_override_impact`, `get_teacher_overrides_summary` — RPC de stats VIP jamais branchées côté app.
- `award_achievement_manual` / `validate_riddle_attempt` : drop `p_teacher_id` ; estampillent `unlocked_by` / `validated_by` via **`auth.uid()`**. Maj des 2 appelants app + des tests unitaires (mockés).
- `teacher_owns_riddle(p_teacher_id, p_riddle_id)` → `teacher_owns_riddle(p_riddle_id)` (`created_by = auth.uid()`) + réécriture des **3 policies `riddle_assignments`**.

## Tests

- `check:incremental` = 0. Tests serveur achievements = 56 ✅.
- Intégration (nouveau fichier) : `validate_riddle_attempt` estampille `validated_by = auth.uid()` ✅ ; RLS `riddle_assignments` reste scopée au créateur de l'énigme ✅.
- ⚠️ Le test `award_achievement_manual` est **`it.skip`** : il a révélé un **bug prod PRÉ-EXISTANT, hors-sujet** — le trigger `log_achievements_to_events` lit `NEW.metadata` sur `student_achievements` (colonne inexistante ; devrait lire la metadata de `achievements`), donc **tout INSERT dans `student_achievements` échoue** (table vide en prod = 0 succès jamais décerné). À corriger séparément.

## ⚠️ Déploiement (forward-incompatible)

4 signatures de RPC changent (param retiré). Le nouveau code appelle les RPC sans `p_teacher_id` ; la prod a encore l'ancienne signature → **déployer le code puis `db:migrate` rapidement** (sous `maintenance:on`), comme pour #42.