### PR TITLE
fix(db): log_achievements_to_events reads metadata from achievements catalog

### DIFF
--- a/supabase/migrations/20260620130000_fix_log_achievements_metadata.sql
+++ b/supabase/migrations/20260620130000_fix_log_achievements_metadata.sql
@@ -1,0 +1,79 @@
+-- Fix: log_achievements_to_events read metadata from the achievements catalog
+-- =============================================================================
+-- Bug prod : le trigger `log_achievements_to_events` (sur student_achievements)
+-- référençait `NEW.metadata`, mais student_achievements n'a pas de colonne
+-- `metadata`. Tout INSERT échouait (42703) → décerner un succès (manuel OU
+-- automatique) était cassé en prod (table student_achievements vide).
+-- Fix : lire la metadata depuis la table `achievements` (sa vraie source).
+
+CREATE OR REPLACE FUNCTION "public"."log_achievements_to_events"()
+  RETURNS "trigger"
+  LANGUAGE "plpgsql" SECURITY DEFINER
+  SET "search_path" TO 'public'
+AS $function$
+    DECLARE
+        v_achievement_name TEXT;
+        v_achievement_metadata JSONB;
+        v_description TEXT;
+        v_class_id UUID;
+    BEGIN
+        IF EXISTS (
+            SELECT 1 FROM public.reward_events
+            WHERE source_table = 'student_achievements'
+            AND source_id = NEW.id
+        ) THEN
+            RETURN NEW;
+        END IF;
+
+        -- student_achievements has no `metadata` column: read it from the
+        -- achievements catalog (the source of the achievement's metadata).
+        SELECT name, metadata
+        INTO v_achievement_name, v_achievement_metadata
+        FROM public.achievements
+        WHERE id = NEW.achievement_id;
+
+        -- Get student's ACTIVE class
+        SELECT class_id INTO v_class_id
+        FROM public.class_members
+        WHERE student_id = NEW.student_id
+          AND status = 'active'
+        ORDER BY joined_at DESC
+        LIMIT 1;
+
+        v_description := generate_reward_event_description(
+            'achievement'::public.reward_type,
+            'earned'::public.reward_event_type,
+            NULL,
+            v_achievement_name,
+            v_achievement_metadata
+        );
+
+        INSERT INTO public.reward_events (
+            student_id,
+            reward_type,
+            event_type,
+            item_name,
+            description,
+            metadata,
+            source_table,
+            source_id,
+            class_id,
+            created_at
+        ) VALUES (
+            NEW.student_id,
+            'achievement',
+            'earned',
+            v_achievement_name,
+            v_description,
+            COALESCE(v_achievement_metadata, '{}'::jsonb) || jsonb_build_object(
+                'achievement_id', NEW.achievement_id
+            ),
+            'student_achievements',
+            NEW.id,
+            v_class_id,
+            NEW.unlocked_at
+        );
+
+        RETURN NEW;
+    END;
+    $function$;

--- a/tests/integration/achievement-events-trigger.test.ts
+++ b/tests/integration/achievement-events-trigger.test.ts
@@ -1,0 +1,91 @@
+/**
+ * log_achievements_to_events trigger — metadata fix — Integration Tests
+ * ====================================================================
+ *
+ * Regression for migration 20260620130000. The trigger on student_achievements
+ * read `NEW.metadata`, but student_achievements has no such column → every
+ * INSERT failed (42703), so awarding a success (manual OR automatic) was broken
+ * in prod (student_achievements empty). The fix reads the metadata from the
+ * `achievements` catalog instead.
+ *
+ * We exercise the trigger DIRECTLY (service-role INSERT into student_achievements)
+ * so the test is independent of any RPC signature.
+ *
+ * Run `pnpm db:start` first, then `pnpm test:integration`.
+ *
+ * @module tests/integration/achievement-events-trigger
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
+import {
+	cleanupAllTestData,
+	createServiceRoleClient
+} from '../helpers/database/trigger-test-helpers';
+import { TestData } from '../helpers/database/test-data-factory';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+describe('log_achievements_to_events trigger - Integration Tests', () => {
+	let service: SupabaseClient<Database>;
+	const TEST_ACH_ID = 'test-ach-trigger';
+
+	afterAll(async () => {
+		await service.from('achievements').delete().like('id', 'test-ach-%');
+		await cleanupAllTestData();
+	});
+
+	beforeEach(async () => {
+		service = createServiceRoleClient();
+		await cleanupAllTestData();
+		await service.from('achievements').delete().like('id', 'test-ach-%');
+	});
+
+	async function classWithMember(studentId: string) {
+		const cls = await TestData.class().create();
+		const { error } = await service
+			.from('class_members')
+			.insert({ class_id: cls.id, student_id: studentId, status: 'active' });
+		expect(error).toBeNull();
+		return cls;
+	}
+
+	it('inserting a student_achievement succeeds and logs a reward_event from the achievement metadata', async () => {
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const student = await TestData.profile().withRole('student').create();
+		await classWithMember(student.id);
+
+		const { error: achErr } = await service.from('achievements').insert({
+			id: TEST_ACH_ID,
+			context: 'meta',
+			name: 'Trigger test',
+			description: 'D',
+			icon: '🏆',
+			unlock_type: 'manual',
+			is_active: true,
+			metadata: { points: 10 }
+		});
+		expect(achErr).toBeNull();
+
+		// Before the fix this INSERT failed with 42703 (record "new" has no field "metadata").
+		const { data: sa, error: saErr } = await service
+			.from('student_achievements')
+			.insert({ student_id: student.id, achievement_id: TEST_ACH_ID, unlocked_by: teacher.id })
+			.select('id')
+			.single();
+		expect(saErr).toBeNull();
+		expect(sa).not.toBeNull();
+
+		// The trigger logged a reward_event sourcing its metadata from `achievements`.
+		const { data: events } = await service
+			.from('reward_events')
+			.select('metadata, reward_type, event_type, item_name')
+			.eq('source_table', 'student_achievements')
+			.eq('source_id', sa!.id);
+		expect(events).toHaveLength(1);
+		expect(events![0].reward_type).toBe('achievement');
+		expect(events![0].event_type).toBe('earned');
+		const meta = events![0].metadata as Record<string, unknown>;
+		expect(meta.achievement_id).toBe(TEST_ACH_ID);
+		expect(meta.points).toBe(10); // flowed from achievements.metadata, not NEW.metadata
+	});
+});


### PR DESCRIPTION
## Bug

Le trigger `log_achievements_to_events` (sur `student_achievements`) lit `NEW.metadata`, mais **`student_achievements` n'a pas de colonne `metadata`** → tout INSERT échoue (`42703`, « record new has no field metadata »). **Décerner un succès — manuel OU automatique — est donc cassé en prod** (`student_achievements` est vide : 0 ligne jamais insérée).

Découvert via le test award de #46 (qui exposait ce trigger).

## Fix

La metadata voulue est celle de l'**achievement** (catalogue `achievements`), pas de `NEW`. On `SELECT name, metadata` ensemble et on utilise `v_achievement_metadata` pour la description ET le payload `reward_events.metadata`.

## Test

Intégration : exerce le trigger **directement** (INSERT service-role dans `student_achievements`) → l'insert réussit + un `reward_event` est loggé avec `metadata.achievement_id` + la metadata de l'achievement (`points`). Indépendant de toute signature RPC (donc découplé de #46).

## Déploiement

`CREATE OR REPLACE` d'une fonction trigger — **non destructif, non forward-incompatible**. Peut être mergé + migré indépendamment de #46.