### PR TITLE
refactor(student): drop vestigial ClassMembership.teacher_id/teacher_name

### DIFF
--- a/src/lib/types/student-cache.ts
+++ b/src/lib/types/student-cache.ts
@@ -88,7 +88,7 @@ export interface StudentProfile {
  * Usage:
  * ```typescript
  * profile.classes.forEach(membership => {
- *   console.log(`${membership.class_name} - ${membership.teacher_name}`);
+ *   console.log(`${membership.class_name} (joined ${membership.joined_at})`);
  * });
  * ```
  */
@@ -97,10 +97,6 @@ export interface ClassMembership {
 	class_id: string;
 	/** Human-readable class name (e.g., "Mathématiques 6ème A") */
 	class_name: string;
-	/** Full name of the teacher (computed from profile) */
-	teacher_name: string;
-	/** UUID of the teacher */
-	teacher_id: string;
 	/** ISO timestamp of when student joined this class */
 	joined_at: string;
 	/** Whether the class is currently active */

--- a/src/routes/(protected)/dashboard/student/+layout.server.ts
+++ b/src/routes/(protected)/dashboard/student/+layout.server.ts
@@ -45,9 +45,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	}
 
 	try {
-		// Fetch class memberships with class details. Mono-teacher: classes are no
-		// longer linked to a teacher (teacher_id dropped), so the teacher is resolved
-		// once below — every class is taught by the sole teacher.
+		// Fetch class memberships with class details.
 		const { data: memberships, error: membershipError } = await supabase
 			.from('class_members')
 			.select(
@@ -70,13 +68,6 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			// Non-critical - continue with empty classes
 		}
 
-		// Mono-teacher: resolve the sole teacher once for display attribution.
-		const { data: soleTeacher } = await supabase
-			.from('profiles')
-			.select('id, full_name')
-			.eq('role', 'teacher')
-			.maybeSingle();
-
 		// Transform to ClassMembership[]
 		const classes: ClassMembership[] = (memberships || [])
 			.filter((m) => m.classes)
@@ -86,8 +77,6 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 				return {
 					class_id: m.class_id,
 					class_name: classData.name,
-					teacher_name: soleTeacher?.full_name || 'Unknown Teacher',
-					teacher_id: soleTeacher?.id || '',
 					joined_at: m.joined_at,
 					is_active: classData.is_active
 				};

--- a/src/routes/api/student/profile/+server.ts
+++ b/src/routes/api/student/profile/+server.ts
@@ -57,7 +57,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 	try {
 		// Fetch active class memberships with class details.
-		// Mono-teacher: teacher_id was dropped from classes; resolve the sole teacher once below.
 		const { data: memberships, error: membershipError } = await supabase
 			.from('class_members')
 			.select(
@@ -80,13 +79,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 			throw error(500, 'Failed to fetch class memberships');
 		}
 
-		// Resolve the sole teacher once for display attribution.
-		const { data: soleTeacher } = await supabase
-			.from('profiles')
-			.select('id, full_name')
-			.eq('role', 'teacher')
-			.maybeSingle();
-
 		// Transform database response to ClassMembership[]
 		const classes: ClassMembership[] = (memberships || [])
 			.filter((m) => m.classes) // Filter out null classes
@@ -95,8 +87,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 				return {
 					class_id: m.class_id,
 					class_name: classData.name,
-					teacher_name: soleTeacher?.full_name || 'Unknown Teacher',
-					teacher_id: soleTeacher?.id || '',
 					joined_at: m.joined_at,
 					is_active: classData.is_active
 				};


### PR DESCRIPTION
## But

Reste cosmétique du Cluster 2 (§4 de `docs/wip/teacher-id-cluster2-deferred.md`). Le type client `ClassMembership` (cache élève) portait `teacher_id` + `teacher_name` pour chaque classe — un **vestige multi-prof**. En mono-prof, les classes n'ont plus de prof (colonne droppée en Cluster 1), donc les 2 producteurs estampillaient **le prof unique** (toujours le même) sur chaque classe. Et **aucune UI ne lit ces champs** (vérifié : 0 consommateur).

## Changements (client-only, pas de migration)
- `src/lib/types/student-cache.ts` : retire `teacher_id` + `teacher_name` de `ClassMembership` (+ exemple JSDoc).
- `student/+layout.server.ts` & `api/student/profile/+server.ts` : arrêtent de peupler ces champs ; la requête `soleTeacher` devenue **morte** est retirée des deux.

## Laissé exprès
La page `student/cours` a son **propre** `teacherName`/`teacherId` (camelCase) qui, lui, **est affiché** (`cours/+page.svelte:84` → « Professeur : X »). Non touché.

## Vérifs
- `pnpm check:incremental` = 0.
- Aucun test n'asserte sur ces champs (pas de fichier test du producteur).
- Pas de `.svelte` modifié, pas de DB/RLS/auth → revue allégée. **0 changement de comportement.**