### PR TITLE
docs(ref): align docs with the mono-teacher refactor

### DIFF
--- a/docs/guides/export-competences-prof.md
+++ b/docs/guides/export-competences-prof.md
@@ -93,6 +93,6 @@ Marche à suivre côté Sacoche :
 ## Confidentialité
 
 L'export contient des données scolaires nominatives (nom, prénom, classe,
-résultats). Seul l'enseignant de la classe (ou un administrateur) peut générer
-l'export. Le fichier est produit à la volée et **n'est pas stocké** sur le
+résultats). Seul un professeur ou un administrateur peut générer l'export
+(contrôle d'accès role-based — la classe n'est plus rattachée à un prof). Le fichier est produit à la volée et **n'est pas stocké** sur le
 serveur — pensez à le supprimer de votre poste une fois la saisie terminée.

--- a/docs/ref/authentication/data-model.md
+++ b/docs/ref/authentication/data-model.md
@@ -103,13 +103,13 @@ CREATE TYPE user_status AS ENUM ('pending', 'approved', 'rejected');
 RLS active des `001`. Politiques principales (les migrations ulterieures durcissent
 l'auto-update) :
 
-| Politique                                             | Operation | Condition                                                                            |
-| ----------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `Users can view their own profile`                    | SELECT    | `auth.uid() = id`                                                                    |
-| `Users can update own profile`                        | UPDATE    | `auth.uid() = id` **ET** `role` inchange **ET** `status` inchange (`20251208100001`) |
-| `Teachers can view student profiles in their classes` | SELECT    | enseignant de la classe de l'eleve                                                   |
-| `Teachers can view pending users for approval`        | SELECT    | `status = 'pending'` ET `is_teacher_or_admin()` (`20251208100001`)                   |
-| `Teachers and admins can update user status`          | UPDATE    | `auth.uid() != id` ET `is_teacher_or_admin()` (`20251208100001`)                     |
+| Politique                                             | Operation | Condition                                                                                                                                                                 |
+| ----------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Users can view their own profile`                    | SELECT    | `auth.uid() = id`                                                                                                                                                         |
+| `Users can update own profile`                        | UPDATE    | `auth.uid() = id` **ET** `role` inchange **ET** `status` inchange (`20251208100001`)                                                                                      |
+| `Teachers can view student profiles in their classes` | SELECT    | `role = 'student'` ET `is_my_student(id)` — mono-prof : `is_my_student` delegue a `is_teacher_or_admin()`, donc le prof unique / l'admin voit **tous** les profils eleves |
+| `Teachers can view pending users for approval`        | SELECT    | `status = 'pending'` ET `is_teacher_or_admin()` (`20251208100001`)                                                                                                        |
+| `Teachers and admins can update user status`          | UPDATE    | `auth.uid() != id` ET `is_teacher_or_admin()` (`20251208100001`)                                                                                                          |
 
 > **Point de securite cle.** La politique `Users can update own profile` empeche un
 > utilisateur de modifier **son propre `role` ou `status`** : le `WITH CHECK` exige que
@@ -117,6 +117,13 @@ l'auto-update) :
 > `SECURITY DEFINER` `get_user_status(uuid)` pour eviter la recursion RLS). Un eleve ne peut
 > donc pas s'auto-promouvoir `admin` ni s'auto-approuver. La fonction `get_user_status` est
 > definie dans `20251208100001_add_status_rls_policies.sql`.
+
+> **Modele mono-professeur.** Un seul `teacher` (+ un seul `admin`). Les classes ne sont
+> plus assignees a un prof (colonne `teacher_id` supprimee des tables de classes) ; les
+> helpers d'autorisation de classe (`is_class_teacher`, `is_my_student`) **delèguent a
+> `is_teacher_or_admin()`** et sont donc admin-inclusifs. La frontiere sociale = l'**ecole**,
+> la classe = sous-groupe d'organisation. Detail : `docs/architecture/database-schema.md`
+> § « Mono-teacher RLS model ».
 
 ### Trigger `handle_new_user` → `on_auth_user_created`
 

--- a/docs/ref/conformite/registre-traitements.md
+++ b/docs/ref/conformite/registre-traitements.md
@@ -69,17 +69,17 @@ coexister : responsable pour le grand public, sous-traitant pour les établissem
 
 ### T2 — Suivi pédagogique et progression
 
-| Champ                              | Contenu                                                                                                                                                  |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Finalité(s)**                    | Enregistrer les réponses aux exercices, scores, progression, statistiques et historique d'apprentissage ; permettre à l'enseignant de suivre ses élèves. |
-| **Base légale**                    | [À CONFIRMER] — intérêt légitime (art. 6.1.f) ou mission d'intérêt public (art. 6.1.e) selon le cas établissement.                                       |
-| **Personnes concernées**           | Élèves, enseignants.                                                                                                                                     |
-| **Catégories de données**          | Réponses aux questions, scores, niveaux de maîtrise par compétence, historique d'activité, statistiques agrégées (achievements).                         |
-| **Source**                         | Activité de l'élève sur l'application.                                                                                                                   |
-| **Destinataires / sous-traitants** | Supabase (BDD).                                                                                                                                          |
-| **Transferts hors UE**             | Néant (UE/France).                                                                                                                                       |
-| **Durée de conservation**          | 5 ans après la dernière activité, puis anonymisation/suppression.                                                                                        |
-| **Mesures de sécurité**            | RLS (un élève ne voit que ses données, un enseignant que ses classes), chiffrement, journalisation des accès.                                            |
+| Champ                              | Contenu                                                                                                                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Finalité(s)**                    | Enregistrer les réponses aux exercices, scores, progression, statistiques et historique d'apprentissage ; permettre à l'enseignant de suivre ses élèves.                                                     |
+| **Base légale**                    | [À CONFIRMER] — intérêt légitime (art. 6.1.f) ou mission d'intérêt public (art. 6.1.e) selon le cas établissement.                                                                                           |
+| **Personnes concernées**           | Élèves, enseignants.                                                                                                                                                                                         |
+| **Catégories de données**          | Réponses aux questions, scores, niveaux de maîtrise par compétence, historique d'activité, statistiques agrégées (achievements).                                                                             |
+| **Source**                         | Activité de l'élève sur l'application.                                                                                                                                                                       |
+| **Destinataires / sous-traitants** | Supabase (BDD).                                                                                                                                                                                              |
+| **Transferts hors UE**             | Néant (UE/France).                                                                                                                                                                                           |
+| **Durée de conservation**          | 5 ans après la dernière activité, puis anonymisation/suppression.                                                                                                                                            |
+| **Mesures de sécurité**            | RLS (un élève ne voit que ses données ; le professeur unique / l'admin accède aux données des élèves de l'école — modèle mono-professeur, frontière sociale = école), chiffrement, journalisation des accès. |
 
 ### T3 — Gamification et récompenses
 

--- a/docs/ref/srs/anti-fraud.md
+++ b/docs/ref/srs/anti-fraud.md
@@ -120,9 +120,9 @@ Badge count sur l'onglet alimenté par `+page.server.ts` au load + `refreshUnres
 
 Un flag concerne **(élève, capacité)**, pas (élève, capacité, classe). Conséquences :
 
-- Élève dans 2 classes → flag visible par les 2 profs.
-- Résoudre d'un côté → masque l'autre.
-- Cohérence simple, pas de divergence de vue inter-profs.
+- Élève dans 2 classes → un seul flag (pas de doublon par classe).
+- Le flag est le même quelle que soit la classe consultée ; le résoudre le masque partout.
+- Cohérence simple : vue unique (mono-prof), pas de divergence par classe.
 
 ---
 

--- a/docs/ref/srs/anti-fraud.md
+++ b/docs/ref/srs/anti-fraud.md
@@ -81,12 +81,12 @@ CHECK `chk_srs_anti_fraud_resolved_coherent` : garantit `resolved=true ⟺ resol
 
 ### Endpoints
 
-| Méthode | Route                                                      | Auth                            |
-| ------- | ---------------------------------------------------------- | ------------------------------- |
-| POST    | `/api/admin/anti-fraud/run`                                | admin                           |
-| GET     | `/api/teacher/classes/[classId]/anti-fraud/flags`          | teacher (owner classe) ou admin |
-| PATCH   | `/api/teacher/classes/[classId]/anti-fraud/flags/[flagId]` | teacher (owner classe) ou admin |
-| GET     | `/api/teacher/classes/[classId]/anti-fraud/count`          | teacher (owner classe) ou admin |
+| Méthode | Route                                                      | Auth                          |
+| ------- | ---------------------------------------------------------- | ----------------------------- |
+| POST    | `/api/admin/anti-fraud/run`                                | admin                         |
+| GET     | `/api/teacher/classes/[classId]/anti-fraud/flags`          | teacher ou admin (role-based) |
+| PATCH   | `/api/teacher/classes/[classId]/anti-fraud/flags/[flagId]` | teacher ou admin (role-based) |
+| GET     | `/api/teacher/classes/[classId]/anti-fraud/count`          | teacher ou admin (role-based) |
 
 ### UI
 

--- a/docs/ref/teacher-analytics.md
+++ b/docs/ref/teacher-analytics.md
@@ -16,7 +16,7 @@ Le prof accède à une vue unifiée de l'**état d'acquisition** de sa classe su
 | 📘 Connaissances | A (FSRS knowledge)   | `srs_card_stats` + `skill_attempts` + `question_template_skills` | A, B, C, D, E |
 | 🎯 Compétences   | B (compétences math) | `student_competence_level` + `student_observable_state`          | F, G          |
 
-**Sécurité** : seul le `teacher_id` de la classe (ou un admin) peut accéder via la garde `requireTeacherOfClass`.
+**Sécurité** : la garde `requireTeacherOfClass` autorise **tout `teacher` ou `admin`** (role-based via `requireRoles(['teacher','admin'])`), puis vérifie l'existence de la classe (404 sinon). Mono-prof : les classes ne sont plus assignées à un prof — l'autorisation ne dépend d'aucun `teacher_id` de classe.
 
 ---
 
@@ -181,7 +181,7 @@ Analyse critique des items reportés (revue 2026-06-10) : sur 7 candidats, **1 s
 7. Onglet **🎯 Compétences** : vérifier Widget F + G
 8. Clic "Voir" sur une ligne Widget E ou G → modal liste des élèves concernés
 9. Classe vide → message "Aucun élève dans cette classe"
-10. Tentative d'accès via URL d'une classe non-owner → 403
+10. Tentative d'accès par un compte non-prof/non-admin (p.ex. élève) → 403 ; classe inexistante → 404
 
 ---
 


### PR DESCRIPTION
## But

Mettre `docs/ref/` à jour après le refactoring mono-prof (livré + en prod). Corrige les affirmations devenues **fausses** (classe assignée à un prof / isolation multi-prof).

## Méthode
Cartographie via 2 agents Explore + balayage manuel, puis **vérification read-only sur la prod** de chaque correction (conditions RLS réelles, signature `requireTeacherOfClass`). Pas de recopie d'audit.

## Corrections (3 fichiers)
- **`authentication/data-model.md`** : la policy `Teachers can view student profiles` est **role-based** (`role='student' AND is_my_student(id)`, et `is_my_student` → `is_teacher_or_admin()` → admin-inclusif), pas une propriété par classe. + courte **note « Modèle mono-professeur »** renvoyant à `database-schema.md`.
- **`teacher-analytics.md`** : `requireTeacherOfClass` = `requireRoles(['teacher','admin'])` + existence de la classe (404), pas un check `teacher_id` de classe ; étape e2e « classe non-owner » corrigée.
- **`conformite/registre-traitements.md`** (T2) : la mesure RLS = le prof unique / l'admin accède aux données de **tous** les élèves de l'école (frontière sociale = école), plus « un enseignant que ses classes ».

## Vérifié non-périmé (laissé tel quel)
- `vips/economy.md` : décrit l'économie + cartes **globalement** désactivées (`is_enabled`), jamais le système d'override par prof (déjà supprimé #48) → rien à changer.
- `srs/*` : « deck assigné » = assignation de deck ; « prof connaît ses élèves » = vrai en mono-prof.
- `teacher_id` sur `google_integrations`/`google_classroom_courses`/`rag_documents`/`orphaned_documents` = clés/audit légitimes (gardées exprès).
- `*/progress/*` : docs historiques, non touchés.