### PR TITLE
docs(comments): fix stale "teacher owns the class" code comments (mono-teacher)

### DIFF
--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
@@ -48,7 +48,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		throw error(400, 'Format de date invalide');
 	}
 
-	// Verify teacher owns this class
+	// Verify the class exists (mono-teacher: RLS scopes access to teacher/admin)
 	const { data: classData, error: classError } = await locals.supabase
 		.from('classes')
 		.select('id, name, grade')

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
@@ -243,12 +243,12 @@ export const actions: Actions = {
 	 * SECURITY:
 	 * - Verifies user is authenticated
 	 * - Validates day_of_week is 0-4 (Sunday-Thursday)
-	 * - Confirms teacher owns the class before creating entry
+	 * - Requires the teacher role (mono-teacher: classes have no per-teacher owner; RLS scopes the write)
 	 *
 	 * PROCESS:
 	 * 1. Extract form data (class_id, day_of_week, times, optional fields)
 	 * 2. Validate required fields and day range
-	 * 3. Verify class ownership
+	 * 3. Verify teacher/admin role (RLS scopes the write)
 	 * 4. Insert new schedule entry into database
 	 */
 	createScheduleEntry: async ({ request, locals: { safeGetSession, supabase } }) => {
@@ -437,12 +437,12 @@ export const actions: Actions = {
 	 *
 	 * SECURITY:
 	 * - Verifies user is authenticated teacher
-	 * - Validates class belongs to teacher
-	 * - Validates course belongs to teacher (if provided)
+	 * - Requires the teacher role (mono-teacher: classes have no per-teacher owner)
+	 * - Validates course belongs to teacher (if provided) — google_classroom_courses.teacher_id
 	 *
 	 * PROCESS:
 	 * 1. Extract and validate classId and courseId from form data
-	 * 2. Verify class ownership
+	 * 2. Verify teacher/admin role (RLS scopes the write)
 	 * 3. Verify course ownership (if courseId provided)
 	 * 4. Update class with google_classroom_course_id
 	 */

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.svelte
@@ -30,7 +30,8 @@
 
 	SECURITY:
 	- Only teachers can access this page
-	- All CRUD operations verify teacher owns the class
+	- All CRUD operations require the teacher/admin role; RLS scopes the writes
+	  (mono-teacher: classes have no per-teacher owner)
 	- Server-side validation on all mutations
 -->
 

--- a/src/routes/api/classes/[classId]/gidouilles/+server.ts
+++ b/src/routes/api/classes/[classId]/gidouilles/+server.ts
@@ -15,7 +15,7 @@ import { requireRole } from '$lib/server/middleware/auth';
  * SECURITY:
  * - Verifies user is authenticated
  * - Verifies user is a teacher
- * - Verifies teacher owns the class
+ * - Mono-teacher: classes have no per-teacher owner; RLS scopes the read
  *
  * RETURNS:
  * Array of { student_id, gidouilles, bonus, vip_cards } objects

--- a/src/routes/api/classes/[classId]/students/+server.ts
+++ b/src/routes/api/classes/[classId]/students/+server.ts
@@ -15,7 +15,7 @@ import { requireRole } from '$lib/server/middleware/auth';
  * SECURITY:
  * - Verifies user is authenticated
  * - Verifies user is a teacher
- * - Verifies teacher owns the class
+ * - Mono-teacher: classes have no per-teacher owner; RLS scopes the read
  *
  * RETURNS:
  * Object with students array: { students: [...] }

--- a/src/routes/api/google/courses/[courseId]/+server.ts
+++ b/src/routes/api/google/courses/[courseId]/+server.ts
@@ -220,7 +220,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 
 		// Fetch ALL sharing data in one query
 		// Note: shared_coursework uses 'shared_by' column, not 'teacher_id'
-		// But we filter by class ownership via RLS, so we don't need explicit filter here
+		// But RLS scopes access (mono-teacher: teacher/admin), so we don't need explicit filter here
 		const { data: allSharedData, error: sharedError } = await locals.supabase
 			.from('shared_coursework')
 			.select(

--- a/src/routes/api/google/courses/[courseId]/share/+server.ts
+++ b/src/routes/api/google/courses/[courseId]/share/+server.ts
@@ -25,7 +25,7 @@
  * Security:
  * - Teacher role required
  * - Verify coursework belongs to teacher
- * - Verify class belongs to teacher
+ * - Verify the class is accessible (mono-teacher: RLS scopes to teacher/admin)
  * - All inputs validated with Zod
  */
 
@@ -109,7 +109,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 				throw error(400, 'Category not found');
 			}
 
-			// Verify the category's class belongs to the teacher
+			// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 			const { data: categoryClass, error: categoryClassError } = await locals.supabase
 				.from('classes')
 				.select('id')
@@ -232,7 +232,7 @@ export const DELETE: RequestHandler = async ({ locals, url }) => {
 				throw error(403, 'Coursework does not belong to you');
 			}
 
-			// Verify class belongs to teacher (for security)
+			// Verify the class is accessible (mono-teacher: RLS-scoped)
 			const { data: classData, error: classError } = await locals.supabase
 				.from('classes')
 				.select('id')
@@ -304,7 +304,7 @@ export const DELETE: RequestHandler = async ({ locals, url }) => {
 				throw error(403, 'Material does not belong to you');
 			}
 
-			// Verify class belongs to teacher (for security)
+			// Verify the class is accessible (mono-teacher: RLS-scoped)
 			const { data: classData, error: classError } = await locals.supabase
 				.from('classes')
 				.select('id')

--- a/src/routes/api/google/shared-coursework/+server.ts
+++ b/src/routes/api/google/shared-coursework/+server.ts
@@ -36,8 +36,8 @@
  * Security:
  * - Teacher role required
  * - Verify coursework ownership via RLS + explicit checks
- * - Verify class ownership
- * - Verify category belongs to teacher's classes
+ * - Verify the class is accessible (mono-teacher: RLS scopes to teacher/admin)
+ * - Verify category is accessible via the teacher's/admin's classes
  * - All inputs validated with Zod
  * - Array size limits to prevent DoS
  */
@@ -388,7 +388,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				throw error(400, 'Category not found');
 			}
 
-			// Verify the category's class belongs to the teacher
+			// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 			const { data: categoryClass, error: categoryClassError } = await locals.supabase
 				.from('classes')
 				.select('id')

--- a/src/routes/api/google/shared-coursework/[id]/+server.ts
+++ b/src/routes/api/google/shared-coursework/[id]/+server.ts
@@ -24,8 +24,8 @@
  *
  * Security:
  * - Teacher role required
- * - Verify record ownership via class ownership
- * - Verify category belongs to teacher's classes (if updated)
+ * - Verify record access via RLS (mono-teacher: teacher/admin)
+ * - Verify category is accessible via the teacher's/admin's classes (if updated)
  * - All inputs validated with Zod
  */
 
@@ -106,7 +106,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 				throw error(400, 'Category not found');
 			}
 
-			// Verify the category's class belongs to the teacher
+			// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 			const { data: categoryClass, error: categoryClassError } = await locals.supabase
 				.from('classes')
 				.select('id')

--- a/src/routes/api/google/shared-materials/+server.ts
+++ b/src/routes/api/google/shared-materials/+server.ts
@@ -44,8 +44,8 @@
  * Security:
  * - Teacher role required
  * - Verify material ownership via RLS + explicit checks
- * - Verify class ownership
- * - Verify category/topic belongs to teacher's classes
+ * - Verify the class is accessible (mono-teacher: RLS scopes to teacher/admin)
+ * - Verify category/topic is accessible via the teacher's/admin's classes
  * - All inputs validated with Zod
  * - Array size limits to prevent DoS
  */
@@ -92,7 +92,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
 		// Build base query with JOINs
 		// Note: Schema uses 'description_override' not 'custom_description'
-		// No need to filter by teacher - RLS policies handle this via class ownership
+		// No need to filter by teacher - RLS policies scope access (mono-teacher: teacher/admin)
 		let query = locals.supabase.from('shared_materials').select(
 			`
 				id,
@@ -350,7 +350,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			throw error(400, 'Category not found');
 		}
 
-		// Verify the category's class belongs to the teacher
+		// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 		const { data: categoryClass, error: categoryClassError } = await locals.supabase
 			.from('classes')
 			.select('id')
@@ -554,7 +554,7 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
 				throw error(400, 'Category not found');
 			}
 
-			// Verify the category's class belongs to the teacher
+			// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 			const { data: categoryClass, error: categoryClassError } = await locals.supabase
 				.from('classes')
 				.select('id')

--- a/src/routes/api/google/shared-materials/[id]/+server.ts
+++ b/src/routes/api/google/shared-materials/[id]/+server.ts
@@ -24,8 +24,8 @@
  *
  * Security:
  * - Teacher role required
- * - Verify record ownership via RLS (class belongs to teacher)
- * - Verify category/topic belongs to teacher's classes/courses
+ * - Verify record access via RLS (mono-teacher: teacher/admin)
+ * - Verify category/topic is accessible via the teacher's/admin's classes/courses
  * - All inputs validated with Zod
  */
 
@@ -53,7 +53,7 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
 
 	const sharedMaterialId = idValidation.data;
 
-	// Verify record exists and belongs to teacher (via RLS - class ownership)
+	// Verify record exists (via RLS - mono-teacher: scoped to teacher/admin)
 	// Note: RLS policy ensures only teacher's shared materials are accessible
 	const { data: existingRecord, error: fetchError } = await locals.supabase
 		.from('shared_materials')
@@ -151,7 +151,7 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 			throw error(400, 'Category not found');
 		}
 
-		// Verify the category's class belongs to the teacher
+		// Verify the category's class is accessible (mono-teacher: RLS-scoped)
 		const { data: categoryClass, error: categoryClassError } = await locals.supabase
 			.from('classes')
 			.select('id')

--- a/src/routes/api/marketplace/admin/activity/+server.ts
+++ b/src/routes/api/marketplace/admin/activity/+server.ts
@@ -71,7 +71,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		const classIds = teacherClasses?.map((c: { id: string }) => c.id) || [];
 
 		if (class_id) {
-			// Verify teacher owns this class
+			// Verify the requested class is accessible (mono-teacher: RLS returns the teacher's/admin's classes)
 			if (!classIds.includes(class_id)) {
 				throw error(403, 'Accès non autorisé à cette classe');
 			}

--- a/src/routes/api/marketplace/admin/analytics/+server.ts
+++ b/src/routes/api/marketplace/admin/analytics/+server.ts
@@ -67,7 +67,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		const classIds = teacherClasses?.map((c: { id: string }) => c.id) || [];
 
 		if (class_id) {
-			// Verify teacher owns this class
+			// Verify the requested class is accessible (mono-teacher: RLS returns the teacher's/admin's classes)
 			if (!classIds.includes(class_id)) {
 				throw error(403, 'Accès non autorisé à cette classe');
 			}

--- a/src/routes/api/python-notebooks/[id]/share/+server.ts
+++ b/src/routes/api/python-notebooks/[id]/share/+server.ts
@@ -26,7 +26,7 @@ const shareNotebookSchema = z.object({
  * POST /api/python-notebooks/[id]/share
  * Share notebook with a class
  * Teachers only
- * Must be the notebook author and teacher of the class
+ * Must be the notebook author; teacher/admin role required (mono-teacher)
  */
 export const POST: RequestHandler = async ({ locals, params, request }) => {
 	const { user } = await requireRole(locals, 'teacher');

--- a/src/routes/api/teacher/categories/[classId]/+server.ts
+++ b/src/routes/api/teacher/categories/[classId]/+server.ts
@@ -7,13 +7,13 @@
  *
  * Flow:
  * 1. Verify user is a teacher
- * 2. Verify class belongs to teacher
+ * 2. Verify the class is accessible (mono-teacher: RLS scopes to teacher/admin)
  * 3. Fetch categories for class
  * 4. Return categories ordered by display_order
  *
  * Security:
  * - Teacher role required
- * - Verify class ownership
+ * - Class access scoped by RLS (mono-teacher: teacher/admin)
  */
 
 import { json, error } from '@sveltejs/kit';
@@ -24,7 +24,7 @@ import { uuidSchema } from '$lib/server/validation';
 /**
  * Fetch categories for a specific class
  *
- * Security: Teacher role required, class ownership verified
+ * Security: Teacher role required; class access scoped by RLS (mono-teacher)
  *
  * Returns categories ordered by display_order
  */

--- a/src/routes/api/teacher/competences/export/+server.ts
+++ b/src/routes/api/teacher/competences/export/+server.ts
@@ -14,7 +14,8 @@
  *   - last_obs       ('true' to add a derniere_observation column — longue only)
  *   - period_label   (optional, used only in the filename)
  *
- * AuthZ: teacher (or admin) owning the class — `requireTeacherOfClass`.
+ * AuthZ: teacher or admin (role-based) — `requireTeacherOfClass`. Mono-teacher:
+ * classes are not owned by a teacher; the role gate + RLS scope the access.
  */
 
 import { error } from '@sveltejs/kit';
@@ -67,7 +68,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 	}
 	const q = parsed.data;
 
-	// AuthN + AuthZ + ownership (teacher of the class, or admin).
+	// AuthN + AuthZ (teacher or admin, role-based; class existence checked).
 	const { user, classRow } = await requireTeacherOfClass(locals, q.class_id);
 
 	const { competences, rows } = await loadClassCompetenceExport(

--- a/src/routes/api/whiteboard/export-to-classroom/+server.ts
+++ b/src/routes/api/whiteboard/export-to-classroom/+server.ts
@@ -17,7 +17,7 @@
  *
  * Security:
  * - Teacher role required
- * - Class ownership verified
+ * - Class access scoped by RLS (mono-teacher: teacher/admin)
  * - PDF content validated (magic bytes)
  * - Google integration with drive.file scope required
  */


### PR DESCRIPTION
## But

Suite au signalement (commentaire `competences/export:17`), **balayage complet de `src/`** : les commentaires de code qui affirmaient encore une **propriété de classe par prof** (`teacher_id` droppé → accès role-based + RLS `is_teacher_or_admin`). Sur la demande « corrige », je n'ai pas traité qu'une ligne — j'ai tout balayé.

## Corrigé (17 fichiers, **commentaires uniquement**)
« Verifies/Confirms teacher owns the/this class », « teacher of the class », « class belongs to teacher », « the category's class belongs to the teacher », « Verify class ownership », « Class ownership verified » → reformulés en « role-based / RLS-scoped (mono-teacher) ».

Couvre : `teacher/classes/+page.{svelte,server.ts}`, `classes/[classId]/{gidouilles,students}`, `python-notebooks/[id]/share`, `teacher/competences/export`, `teacher/categories/[classId]`, `cahier-texte/[classId]/[date]`, `marketplace/admin/{activity,analytics}`, `whiteboard/export-to-classroom`, et le cluster `google/{courses,shared-materials,shared-coursework}`.

## Laissé exprès (justifié)
- **Messages d'erreur 500** `'Failed to verify class ownership'` — **user-facing + assertés par les tests** (changer = casser les tests). Comportement inchangé.
- « coursework/material **belongs to teacher** » — ownership du **record** (un seul prof) = correct, pas du class-ownership.
- `google_classroom_courses.teacher_id` (clé d'owner légitime, gardée).
- `bulk-share:88` déjà correct (« teacher_id dropped, no per-class ownership »).

## Vérifs
Gardes réelles vérifiées (toutes `requireRole('teacher')` / `requireTeacherOfClass` = role-based). `pnpm check:incremental` = 0. Aucun changement de logique. Verified read-only en prod : `is_teacher_of_class`/`is_teacher_of_student` existent mais délèguent à `is_teacher_or_admin()`.