### PR TITLE
docs(comments): fix remaining class-cluster ownership comments (mono-teacher)

### DIFF
--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -155,7 +155,7 @@ export async function updateJournalEntry(
 	if (input.homeworkDueDate !== undefined) updateData.homework_due_date = input.homeworkDueDate;
 	if (input.isPublished !== undefined) updateData.is_published = input.isPublished;
 
-	// Update (RLS policy ensures teacher owns the entry)
+	// Update (RLS scopes access to teacher/admin; mono-teacher: entries have no per-teacher owner)
 	const { data: entry, error } = await supabase
 		.from('class_journal_entries')
 		.update(updateData)

--- a/src/lib/server/vip-card-actions.ts
+++ b/src/lib/server/vip-card-actions.ts
@@ -45,7 +45,7 @@
  * ```
  *
  * SECURITY:
- * - All functions verify teacher owns the student's class via RPC functions
+ * - All functions verify the teacher/admin teaches the student via RPC functions (role-based, mono-teacher)
  * - Uses SECURITY DEFINER RPC functions for database operations
  */
 

--- a/src/lib/server/warnings.ts
+++ b/src/lib/server/warnings.ts
@@ -19,7 +19,7 @@
  * ```
  *
  * PATTERNS:
- * - All functions verify teacher ownership via RLS
+ * - All functions scope access via RLS (teacher/admin; mono-teacher, no per-class owner)
  * - Warning types: C (Comportement), M (Matériel), R (Retard), T (Travail)
  * - Score calculation: 20 - total_warnings (max 20, min 0)
  */

--- a/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/classes/+page.server.ts
@@ -8,7 +8,7 @@
  * - Load teacher's classes with student counts
  * - Load schedule entries for each class
  * - Create, update, and delete schedule entries
- * - Security: Verify teacher ownership before modifications
+ * - Security: teacher/admin role + RLS scope modifications (mono-teacher: no per-class owner)
  *
  * ROUTES:
  * - Load: GET /dashboard/teacher/classes
@@ -314,12 +314,12 @@ export const actions: Actions = {
 	 * SECURITY:
 	 * - Verifies user is authenticated
 	 * - Validates day_of_week is 0-4 (Sunday-Thursday)
-	 * - Confirms teacher owns the schedule entry before updating
+	 * - Requires the teacher role; RLS scopes the write (mono-teacher: no per-teacher owner)
 	 *
 	 * PROCESS:
 	 * 1. Extract form data (id, day_of_week, times, optional fields)
 	 * 2. Validate required fields and day range
-	 * 3. Verify schedule entry ownership
+	 * 3. Verify teacher/admin role (RLS scopes the write)
 	 * 4. Update schedule entry in database
 	 */
 	updateScheduleEntry: async ({ request, locals: { safeGetSession, supabase } }) => {
@@ -386,11 +386,11 @@ export const actions: Actions = {
 	 *
 	 * SECURITY:
 	 * - Verifies user is authenticated
-	 * - Confirms teacher owns the schedule entry before deletion
+	 * - Requires the teacher role; RLS scopes the write (mono-teacher: no per-teacher owner)
 	 *
 	 * PROCESS:
 	 * 1. Extract schedule entry ID from form data
-	 * 2. Verify schedule entry ownership
+	 * 2. Verify teacher/admin role (RLS scopes the write)
 	 * 3. Delete entry from database (cascades automatically)
 	 */
 	deleteScheduleEntry: async ({ request, locals: { safeGetSession, supabase } }) => {

--- a/src/routes/(protected)/dashboard/teacher/classes/[classId]/analytics/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/classes/[classId]/analytics/+page.server.ts
@@ -1,5 +1,5 @@
 /**
- * Analytics page — load class header + verify ownership.
+ * Analytics page — load class header + verify access (role-based: teacher/admin).
  *
  * Les widgets fetchent leurs données via les endpoints `/api/teacher/...`
  * en client-side (lazy). On charge ici juste le nom de la classe pour le header.

--- a/src/routes/api/classes/[classId]/warnings/+server.ts
+++ b/src/routes/api/classes/[classId]/warnings/+server.ts
@@ -4,7 +4,7 @@
  *
  * Security:
  * - Requires authentication
- * - Teacher ownership verified via helper function (RLS)
+ * - Access scoped via RLS helper (teacher/admin; mono-teacher, no per-class owner)
  * - Input validated (classId, period_id query param)
  *
  * Query params:

--- a/src/routes/api/whiteboard/export-to-classroom/+server.ts
+++ b/src/routes/api/whiteboard/export-to-classroom/+server.ts
@@ -7,7 +7,7 @@
  *
  * Simplified Flow:
  * 1. Validate inputs (classId, date, pdfBase64)
- * 2. Get class and verify ownership + google_classroom_course_id
+ * 2. Get class (RLS-scoped: teacher/admin) + google_classroom_course_id
  * 3. Find "Notes de cours" topic for the course
  * 4. Get next export counter from DB (atomic increment)
  * 5. Generate title (French date) and filename
@@ -89,7 +89,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const { pdfBase64, classId, date } = validation.data;
 
 	try {
-		// Step 1: Get class and verify ownership + google_classroom_course_id
+		// Step 1: Get class (RLS-scoped: teacher/admin) + google_classroom_course_id
 		const { data: classData, error: classError } = await locals.supabase
 			.from('classes')
 			.select(


### PR DESCRIPTION
## But

Follow-up demandé : balayer les phrasings d'ownership que mes passes précédentes (#51) avaient ratés (« verify ownership » nu, « schedule entry ownership », « owns the entry »…).

## Corrigé (7 fichiers, **commentaires only**)
Commentaires affirmant une propriété **par prof** d'une ressource du **cluster classes** (tables ayant perdu `teacher_id` : `classes`, `class_schedules`, `class_journal_entries`, `game_timeslots`) → reformulés **role-based + RLS** (`is_teacher_or_admin`).

`journal.ts`, `vip-card-actions.ts`, `warnings.ts`, `classes/[classId]/warnings`, `classes/+page.server.ts` (schedule entries), `classes/[classId]/analytics`, `whiteboard/export-to-classroom`.

## Laissé EXPRÈS (vérifié owner propre en prod)
« teacher owns the **assessment / worksheet / riddle / exercise** » → **légitime** : ces tables ont leur **propre** colonne owner (`created_by` / `author_id` / `owner_id`), non touchée par le refactor mono-prof. Et « Verify class **exists** » = existence, pas ownership.

## Vérifs
`pnpm check:incremental` = 0. Aucune logique touchée. Owner columns confirmées read-only en prod.