### PR TITLE
feat(curriculum): suivi du programme — référentiel, cahier de texte, avancement

### DIFF
--- a/docs/wip/referentiel/6e-programme-curriculum.md
+++ b/docs/wip/referentiel/6e-programme-curriculum.md
@@ -1,0 +1,187 @@
+# Programme de suivi 6ᵉ — Thème → Item → Point (à relire)
+
+> **But** : source de vérité pour le **seed** du référentiel de programme (table `curriculum_*`), grade `'6'`. **Distinct** du référentiel d'évaluation.
+> **Source** : BO cycle 3 (réforme) — blocs « Connaissances et capacités attendues » de la **6ᵉ** (`/Users/david/Downloads/programme-de-math-matiques-pour-le-cycle-3-439827 (1).pdf`), croisés avec l'ossature éval 6ᵉ en base.
+> **Tag `kind`** : `[C]` = connaissance · `[SF]` = savoir-faire (modifiable dans l'app).
+> L'**ordre** des thèmes / items / points = `display_order`. Les « Automatismes » du BO (réactivations CM) ne sont pas des points séparés.
+>
+> **Statut** : proposition Phase 0, **en attente de relecture David** avant le seed. 6 thèmes · 20 items · ~95 points.
+
+---
+
+## 1. Nombres et calculs
+
+### 1.1 Nombres entiers et décimaux
+
+- [C] Connaître et utiliser la valeur des chiffres selon leur rang dans l'écriture d'un nombre
+- [C] Connaître les liens entre les unités de numération (unité, dizaine… dixième, centième, millième)
+- [C] Connaître des grands nombres entiers
+- [SF] Reconnaître un nombre décimal
+- [SF] Associer et utiliser différentes écritures d'un nombre décimal (virgule, fraction, nombre mixte, pourcentage)
+- [SF] Placer un nombre décimal sur une demi-droite graduée et l'y repérer
+- [SF] Comparer deux nombres décimaux
+- [SF] Ordonner une liste de nombres décimaux
+- [SF] Encadrer un nombre décimal par deux décimaux, intercaler
+- [SF] Donner la valeur arrondie d'un décimal (unité, dixième, centième)
+- [SF] Déterminer la valeur arrondie de certains nombres non décimaux
+
+### 1.2 Calcul sur les nombres décimaux
+
+- [SF] Additionner et soustraire des nombres décimaux
+- [SF] Multiplier un nombre entier ou décimal par 0,1, 0,01 et 0,001
+- [C] Connaître le lien avec la division par 10, 100, 1000
+- [C] Comprendre le sens de la multiplication de deux nombres décimaux
+- [SF] Calculer le produit de deux nombres décimaux
+- [SF] Contrôler les résultats à l'aide d'ordres de grandeur
+- [SF] Résoudre des problèmes mettant en jeu des multiplications de décimaux
+- [SF] Diviser un nombre décimal par un nombre entier non nul inférieur à 10
+- [SF] Résoudre des problèmes mettant en jeu des divisions décimales
+- [SF] Effectuer la division euclidienne d'un entier par un entier inférieur à 100
+- [SF] Résoudre des problèmes mettant en jeu des divisions euclidiennes
+
+### 1.3 Fractions
+
+- [SF] Relier une fraction au résultat exact de la division de son numérateur par son dénominateur
+- [C] Comprendre et connaître la définition du quotient d'un entier a par un entier b non nul
+- [SF] Compléter des égalités à trous multiplicatives
+- [SF] Placer une fraction sur une demi-droite graduée (cas simples)
+- [SF] Graduer un segment de longueur donnée
+- [C] Savoir que la fraction a/b peut représenter un entier, un décimal non entier ou un nombre non décimal
+- [SF] Utiliser une multiplication pour appliquer une fraction à un nombre entier
+- [SF] Établir des égalités de fractions
+- [SF] Comparer et encadrer des fractions
+- [SF] Ordonner une liste de nombres écrits sous forme de fractions ou de nombres mixtes
+- [SF] Additionner et soustraire des fractions
+- [SF] Multiplier une fraction par un nombre entier
+- [SF] Résoudre des problèmes mettant en jeu des fractions
+- [SF] Inventer des problèmes mettant en jeu des fractions
+
+### 1.4 Pourcentages
+
+- [C] Connaître la définition d'un pourcentage
+- [C] Comprendre le sens d'un pourcentage
+- [SF] Calculer une proportion (rapport partie/tout) et l'exprimer en pourcentage (cas simples)
+- [SF] Appliquer un pourcentage à une grandeur ou à un nombre
+
+### 1.5 Algèbre (pensée algébrique)
+
+- [SF] Utiliser des modèles pré-algébriques pour résoudre des problèmes algébriques
+- [SF] Identifier la structure d'un motif évolutif en repérant une régularité
+
+---
+
+## 2. Grandeurs et mesures
+
+### 2.1 Longueurs et périmètres
+
+- [C] Savoir que le périmètre du disque est proportionnel à son diamètre
+- [C] Connaître la formule du périmètre d'un disque
+- [SF] Calculer le périmètre d'un disque
+- [SF] Calculer des périmètres de figures composées
+- [SF] Résoudre des problèmes impliquant des longueurs
+
+### 2.2 Aires
+
+- [SF] Effectuer des conversions d'aire
+- [C] Connaître la formule de l'aire d'un carré ou d'un rectangle
+- [SF] Calculer l'aire d'un carré ou d'un rectangle
+
+### 2.3 Volumes
+
+- [C] Connaître l'unité centimètre cube
+- [SF] Comparer des volumes
+- [SF] Déterminer un volume
+
+### 2.4 Durées et repérage dans le temps
+
+- [SF] Effectuer des calculs sur des horaires et des durées
+- [SF] Résoudre des problèmes impliquant des horaires et des durées
+- [SF] Convertir des durées
+
+---
+
+## 3. Espace et géométrie
+
+### 3.1 Distances, cercles et disques
+
+- [C] Connaître et utiliser la définition de la distance entre deux points
+- [C] Connaître et utiliser la définition du milieu d'un segment
+- [C] Connaître les définitions d'un cercle, d'un disque, d'un rayon, d'un diamètre, d'une corde
+- [C] Comprendre la définition d'un cercle et celle d'un disque comme ensembles de points
+- [SF] Résoudre des problèmes mettant en jeu des distances à un point
+
+### 3.2 Médiatrice d'un segment
+
+- [C] Connaître la définition de la médiatrice d'un segment
+- [SF] Comprendre et utiliser la propriété caractéristique de la médiatrice
+- [SF] Résoudre des problèmes en s'appuyant sur la propriété caractéristique de la médiatrice
+
+### 3.3 Angles
+
+- [C] Connaître et utiliser les angles, le lexique et les notations (droit, plat, plein, nul, aigu, obtus, opposés par le sommet, adjacents, supplémentaires)
+- [SF] Mesurer un angle
+- [SF] Construire un angle de mesure donnée
+
+### 3.4 Bissectrice d'un angle saillant
+
+- [C] Connaître la définition de la bissectrice d'un angle saillant
+- [SF] Utiliser la bissectrice pour effectuer des constructions et résoudre des problèmes
+
+### 3.5 Triangles
+
+- [SF] Construire des triangles
+- [SF] Connaître et utiliser les propriétés angulaires des triangles particuliers (rectangle, isocèle, équilatéral)
+- [C] Connaître la valeur de la somme des mesures des angles d'un triangle
+- [SF] Utiliser la somme des angles d'un triangle pour calculer un angle, construire, résoudre des problèmes
+- [C] Savoir que les médiatrices d'un triangle sont concourantes
+- [SF] Connaître et construire le cercle circonscrit à un triangle
+
+### 3.6 Symétrie axiale
+
+- [C] Connaître la définition du symétrique d'un point par rapport à une droite
+- [SF] Connaître et utiliser les propriétés de la symétrie axiale pour effectuer des constructions
+
+### 3.7 Vision dans l'espace
+
+- [C] Reconnaître les solides usuels (cube, pavé, cylindre, cône, boule, pyramide, prisme droit)
+- [SF] Voir dans l'espace des assemblages de cubes (passer entre l'objet 3D et ses représentations 2D, dénombrer)
+
+---
+
+## 4. Organisation, gestion de données et probabilités
+
+### 4.1 Organisation et gestion de données
+
+- [SF] Planifier une enquête et recueillir des données
+- [SF] Réaliser des mesures et les consigner dans un tableau
+- [SF] Construire un tableau simple pour présenter des données
+- [SF] Faire un choix en filtrant les données d'un tableau selon un critère
+
+### 4.2 Probabilités
+
+- [C] Savoir que la probabilité d'un évènement est un nombre compris entre 0 et 1
+- [SF] Calculer des probabilités dans des situations simples d'équiprobabilité
+- [SF] Comparer les résultats d'une expérience aléatoire répétée à une probabilité calculée
+
+---
+
+## 5. Proportionnalité
+
+### 5.1 Proportionnalité et échelles
+
+- [C] Connaître la définition de la proportionnalité et la mettre en lien avec des expressions de la vie courante
+- [SF] Identifier si une situation relève du modèle de la proportionnalité
+- [SF] Résoudre un problème de proportionnalité en choisissant une procédure adaptée (linéarité, retour à l'unité)
+- [SF] Représenter une situation de proportionnalité à l'aide d'un tableau ou de notations symboliques
+- [SF] S'initier à la résolution de problèmes d'échelles
+
+---
+
+## 6. Initiation à la pensée informatique
+
+### 6.1 Programmer
+
+- [C] Identifier une instruction ou une séquence d'instructions
+- [SF] Produire et exécuter une séquence d'instructions
+- [SF] Répéter à la main une séquence d'instructions pour accomplir une tâche imposée
+- [SF] Programmer la construction d'un chemin simple

--- a/docs/wip/suivi-programme-progress.md
+++ b/docs/wip/suivi-programme-progress.md
@@ -198,11 +198,28 @@ journal_entry_points              -- signal de couverture (manuel + auto matéri
 - **6 endpoints** `src/routes/api/teacher/curriculum/{themes,items,points}[/[id]]/+server.ts` — GET/POST/PATCH/DELETE, `requireRoles(['teacher','admin'])` + RLS.
 - Tests : `curriculum-api.test.ts` **22/22** (201/400/404/409/401/403, tri, cascade, archive). + `curriculum-tracking-rls.test.ts` **12/12**. **`check:incremental` = 0 erreur.**
 
-**Brique 2 — Alimentation (à faire) :**
+**Brique 2 — Alimentation : ✅ FAIT & VERT**
 
-- Endpoints tagging exercices (`exercise_curriculum_points`).
-- Endpoints cahier de texte : `journal_entry_activities` (3 types) + `journal_entry_points` (couverture auto matérialisée depuis les activités taguées + coche manuelle, dé-coche).
-- Tests endpoints + RLS/contraintes (`exercise_curriculum_points`, `journal_entry_*` : `kind_shape`, `source`, unique).
+- Helper `src/lib/server/curriculum-coverage.ts` : `reconcileAutoCoverage(entryId)` — set-reconcile idempotent (auto = union des points tagués sur les exercices référencés ; ne touche pas les rows `manual`).
+- Validation Zod étendue (tagging, `createActivitySchema` discriminé sur `kind` + `superRefine` course, coverage).
+- **4 endpoints** : `exercise-tags` (GET/POST/DELETE), `activities` (GET/POST + reconcile si exercise), `activities/[id]` (DELETE + reconcile), `coverage` (GET/POST manuel/DELETE).
+- Tests : `curriculum-coverage.test.ts` **18/18** (tagging idempotent, 3 types d'activité, **réconciliation auto add/remove**, couverture manuelle, RLS 42501 student, CHECK `kind_shape`/`source`). **`check:incremental` = 0 erreur.**
+
+**Sémantique couverture (V1, actée dans le code) :** auto = matérialisé/réconcilié depuis les activités exercice ; manual = coché par le prof. `unique(entry_id, point_id)`. **Coche manuelle d'un point déjà `auto` → promotion en `manual`** (survit à la réconciliation — corrige une perte de donnée silencieuse repérée en revue).
+
+**Revue (code-reviewer + security-auditor) — aucun bloquant / aucune faille critique-élevée.** Corrigés : promotion auto→manual (#1) ; `22P02` (UUID malformé) → 400 dans le mapper ; `textbookRefSchema.strict()` ; `to authenticated` sur les 6 policies RLS.
+
+**Limites V1 assumées (documentées) :**
+
+- `reconcileAutoCoverage` = read-then-write en 3 requêtes (pas transactionnel) → risque de course **négligeable en mono-prof** ; à passer en fonction Postgres si besoin de concurrence.
+- **Tagging d'un exercice pris en compte « à la prochaine activité »** : tagger/dé-tagger un exercice ne re-réconcilie pas les entrées de cahier de texte qui le référencent déjà (workflow attendu : taguer avant d'utiliser). À arbitrer avec le PO si on veut un re-reconcile cross-entrées.
+- Décocher manuellement un point **auto** encore adossé à un exercice → ré-ajouté à la prochaine réconciliation (pas de suppression persistante).
+- Messages d'erreur 500 : les endpoints de la brique 1 renvoient encore `dbErr.message` (aligné sur le pattern codebase existant, ~15 occurrences ailleurs) ; brique 2 + cas mappés = message générique. Nettoyage global possible plus tard.
+
+**Phase 1 = données + API + tests : COMPLÈTE (52 tests verts).** Restent, hors Phase 1 :
+
+- Revue : `code-reviewer` + `security-auditor` (RLS/API) avant PR/merge.
+- Phase 2 (seed d'un grade — en attente §10 Q1/Q2), Phases 3-5 (UI édition / heatmap / intégration cahier de texte).
 
 ---
 

--- a/docs/wip/suivi-programme-progress.md
+++ b/docs/wip/suivi-programme-progress.md
@@ -175,7 +175,7 @@ journal_entry_points              -- signal de couverture (manuel + auto matéri
 
 ## 11. Phase 1 — progression (crash-recovery)
 
-> Branche : **`feat/suivi-programme`**. **Non commité** (en attente d'accord).
+> Branche : **`feat/suivi-programme`** — 3 commits (briques 1 & 2 + nettoyage types). **Migration POUSSÉE EN PROD le 2026-06-21** (`db:migrate` par David, vérifiée : 6 tables, RLS activée). `database.ts` régénéré (`db:types`) → tables typées, `as never` retirés du code (types `Tables<'…'>`). **Branche non mergée / code non déployé.**
 
 **Fait & vérifié (local Supabase) :**
 
@@ -216,17 +216,18 @@ journal_entry_points              -- signal de couverture (manuel + auto matéri
 - Décocher manuellement un point **auto** encore adossé à un exercice → ré-ajouté à la prochaine réconciliation (pas de suppression persistante).
 - Messages d'erreur 500 : les endpoints de la brique 1 renvoient encore `dbErr.message` (aligné sur le pattern codebase existant, ~15 occurrences ailleurs) ; brique 2 + cas mappés = message générique. Nettoyage global possible plus tard.
 
-**Phase 1 = données + API + tests : COMPLÈTE (52 tests verts).** Restent, hors Phase 1 :
+**Phase 1 = données + API + tests : COMPLÈTE (53 tests verts).** Revue code+sécurité passée (aucun bloquant). Migration en prod, `database.ts` régénéré, types nettoyés. Restent, hors Phase 1 :
 
-- Revue : `code-reviewer` + `security-auditor` (RLS/API) avant PR/merge.
-- Phase 2 (seed d'un grade — en attente §10 Q1/Q2), Phases 3-5 (UI édition / heatmap / intégration cahier de texte).
+- **Merge de la branche + déploiement du code** (la migration additive est déjà en prod, aucun code `main` ne s'en sert → pas de casse en attendant).
+- **Phase 2 (seed 6ᵉ) : ✅ FAIT & VÉRIFIÉ** — migration `20260621160000_seed_curriculum_6e.sql` : 6 thèmes · 20 items · **95 points** (BO cycle 3, « Connaissances et capacités attendues » 6ᵉ), tag `kind` connaissance/savoir-faire. Source de vérité : `docs/wip/referentiel/6e-programme-curriculum.md`. Appliquée en local (`db:reset`), comptes vérifiés (42/14/23/7/5/4), 53 tests verts. **Non poussée en prod.**
+- Phases 3-5 (UI édition / heatmap / intégration cahier de texte).
 
 ---
 
 ## 10. Questions ouvertes (à trancher avec David)
 
-1. **Grade de démarrage** : quel(s) niveau(x) enseignes-tu, et lequel pré-remplit-on en premier ? (6ᵉ ?)
-2. **Source du pré-remplissage** : ta **progression perso 2016** (« echelles descriptives connaissance 6 2016.pdf », tableau ~15 items × colonnes, intitulés simples) ? le **BO** ? l'arbre **éval 6ᵉ existant** (6 thèmes / 18 items) comme ossature ? Une combinaison ?
+1. ~~Grade de démarrage~~ — **ACTÉ : 6ᵉ.**
+2. ~~Source du pré-remplissage~~ — **ACTÉ : BO cycle 3** (PDF officiel) + ossature éval 6ᵉ en référence. Seed livré (Phase 2).
 3. **Référence manuel** : structurée (`manuel`, `page`, `numéro`) ou simple texte libre (label) ? Proposition : `jsonb` souple (label obligatoire, le reste optionnel).
 4. **`kind` sur le Point** (connaissance / savoir-faire) : utile ou superflu vu le grain fin ? Proposition : champ **optionnel** (null par défaut).
 5. ~~Vocabulaire~~ — **ACTÉ** (2026-06-21) : `Thème → Item → Point`, niveau 3 neutre + champ `kind` optionnel (cf. §3).

--- a/docs/wip/suivi-programme-progress.md
+++ b/docs/wip/suivi-programme-progress.md
@@ -1,0 +1,220 @@
+# Suivi du programme & cahier de texte — Spec Phase 0 (TDD)
+
+> **Statut** : Phase 0 — spécification, **en attente de validation David**. Aucun code écrit.
+> **Créé le** : 2026-06-21
+> **Feature** : référentiel de programme (distinct de l'évaluation) + suivi de couverture alimenté par le cahier de texte.
+
+---
+
+## 1. Objectif
+
+Permettre au prof de **suivre l'avancement dans le programme officiel par classe** : voir où on en est, quels points n'ont **jamais** été travaillés (les trous), et combien de fois chaque point a été travaillé (heatmap). L'alimentation se fait depuis le **cahier de texte** (`class_journal_entries`, déjà implémenté), via les activités proposées.
+
+**Distinction fondamentale (2 axes de suivi)** :
+
+| Axe                                    | Question                                                                               | Existant ?                                                                                               |
+| -------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Acquisition élève**                  | « tel élève **maîtrise**-t-il l'objectif X ? »                                         | ✅ existe (référentiel `skills`/`skill_objectives`, routes `objectifs`/`competences`/`evaluation-tasks`) |
+| **Couverture programme** (ce chantier) | « la classe a-t-elle **déjà travaillé** le point X cette année, et combien de fois ? » | ❌ à construire                                                                                          |
+
+---
+
+## 2. Décisions actées (David, 2026-06-21)
+
+1. **Référentiel de programme NOUVEAU et distinct** du référentiel d'évaluation (`skills`/`skill_objectives`). Nouvelles tables, propre nomenclature. _(Lien optionnel point ↔ objectif possible plus tard, pas maintenant.)_
+2. **3 niveaux, grain fin** : `Thème → Item → Point`. Ex. **Calcul → Fractions → « Additionner deux fractions »**. Le **Point** est le grain de suivi (assez précis pour repérer les trous).
+3. **Couverture = compteur** (pas booléen) : nombre de fois qu'un point a été travaillé, **par classe**, sur l'année scolaire → **heatmap** (intensité de couleur ∝ nombre ; vide = jamais vu ⚠️).
+4. **Alimentation hybride** : activités taguées → couverture auto **+** coche manuelle.
+5. **Création hybride** : un grade **pré-rempli** comme point de départ, puis **éditable par le prof dans l'app** (CRUD thèmes/items/points), une arborescence **par grade**, réutilisée sur toutes les classes du même grade.
+6. **Nomenclature actée** : `Thème → Item → Point` (cf. §3). Niveau 3 « Point » **neutre** (connaissance OU savoir-faire via `kind`), pour ne pas réutiliser « Objectif »/« Capacité » (éval) ni « Domaine » (banni dans le réf. d'éval).
+
+---
+
+## 3. Vocabulaire (ACTÉ 2026-06-21)
+
+- **Thème** (niveau 1) — ex. « Calcul », « Espace et géométrie ». _(« thème », pas « domaine ».)_
+- **Item** (niveau 2) — ex. « Fractions », « Symétrie axiale ».
+- **Point** (niveau 3, grain de suivi) — ex. « Additionner deux fractions ».
+- **Couverture** — nombre de fois qu'un point a été travaillé dans une classe sur l'année.
+- ⚠️ Ne pas réutiliser « objectif » / « capacité » / « observable » (réservés au référentiel d'évaluation, pour éviter la confusion).
+
+**Justification (sourcée)** : « Thème » est identique dans le réf. d'éval _et_ le système de questions → gardé. « Item » est déjà employé comme synonyme d'« objectif » dans le doc d'éval (`skills-referentiel-design.md:126`). « Point » reste neutre car « Capacité » (éval) impose _exactement 4, ordonnées par difficulté_ — ce que le niveau 3 du programme n'a pas. « Domaine »/« Sous-domaine » (système de questions) écartés car « Domaine » est un **terme banni** côté éval (`:109`).
+
+---
+
+## 4. Modèle de données (proposition — à valider)
+
+> Convention mono-prof : **pas de `teacher_id`**, ownership par rôle via `is_teacher_or_admin()` (cohérent avec le cluster classes après le retrait `teacher_id`). Grade = code canonique (`'6'`, pas `'6e'`) → réconcilier avec `niveau_scolaire` du référentiel d'éval.
+
+### 4.1 Arborescence du programme (par grade, éditable)
+
+```
+curriculum_themes
+  id uuid pk · grade text · name text · display_order int · timestamps
+curriculum_items
+  id uuid pk · theme_id fk→themes (cascade) · name text · display_order int · timestamps
+curriculum_points
+  id uuid pk · item_id fk→items (cascade) · name text · display_order int
+  · kind text null  -- optionnel: 'connaissance' | 'savoir-faire' | null
+  · timestamps
+```
+
+### 4.2 Tagging des activités du système d'exercices
+
+```
+exercise_curriculum_points
+  exercise_id fk→exercises · point_id fk→curriculum_points · pk(exercise_id, point_id)
+```
+
+Un exercice du système porte 0..n points. Référencer cet exercice dans une entrée de cahier de texte ⇒ ses points sont marqués **auto**.
+
+### 4.3 Alimentation depuis le cahier de texte
+
+`class_journal_entries` existe déjà (id, class_id, entry_date, lesson_content, homework_content, …). On ajoute :
+
+```
+journal_entry_activities          -- les 3 types d'activité d'une entrée
+  id uuid pk · entry_id fk→class_journal_entries (cascade)
+  · kind text  -- 'exercise' | 'textbook' | 'course'
+  · exercise_id fk→exercises null          -- si kind='exercise'
+  · chapter_id  fk→class_chapters null      -- si kind='course' (point de cours = chapitre)
+  · textbook_ref jsonb null                 -- si kind='textbook' { manuel?, page?, numero?, label }
+  · label text null
+  · display_order int
+
+journal_entry_points              -- signal de couverture (manuel + auto matérialisé)
+  id uuid pk · entry_id fk→class_journal_entries (cascade)
+  · point_id fk→curriculum_points
+  · source text  -- 'auto' (dérivé d'une activité taguée) | 'manual' (coché par le prof)
+  · unique(entry_id, point_id)
+```
+
+**Couverture d'un point pour une classe** = `count(journal_entry_points jep JOIN class_journal_entries e) WHERE e.class_id = :class AND jep.point_id = :point AND e.entry_date dans l'année scolaire courante`.
+
+> **Choix à trancher (Phase 1)** : matérialiser les points `auto` dans `journal_entry_points` au moment de l'enregistrement (heatmap = simple `count`, supporte la dé-sélection manuelle, snapshot stable) **vs** dériver à la lecture (`manual ∪ points-des-activités`). Proposition : **matérialiser** pour la simplicité de la heatmap et la maîtrise prof (il peut décocher un point auto).
+
+---
+
+## 5. Couverture & heatmap
+
+- **Périmètre temporel** : année scolaire courante (proposition : champ « début d'année » au niveau prof/réglages, défaut 1er septembre). Les compteurs ne mélangent pas deux années.
+- **Agrégation (rollup)** : compteur au **Point**, sommé/agrégé à l'**Item** puis au **Thème**. Vue d'avancement à 3 niveaux dépliables.
+- **Échelle de couleur (proposition)** : 0 = « jamais vu » (état distinct, mis en avant) · 1 = clair · 2–3 = moyen · 4+ = foncé. Seuils ajustables.
+- **% d'avancement** (proposition) : part des points d'un item/thème touchés au moins 1 fois (≠ intensité). Affiché à côté de la heatmap.
+
+---
+
+## 6. Comportements (TDD — cas nominal / limite / erreur)
+
+### 6.1 Édition du programme (CRUD arborescence)
+
+- **Nominal** : le prof crée un thème pour la 6ᵉ → il apparaît dans l'arborescence de la 6ᵉ, `display_order` à la fin. Idem item (sous un thème), point (sous un item).
+- **Nominal** : renommer / réordonner (drag) un nœud persiste l'ordre.
+- **Limite** : supprimer un thème avec items/points → cascade (avec confirmation UI). Supprimer un point déjà couvert → **interdit ou archivage** (à trancher : on ne veut pas perdre l'historique de couverture). Proposition : **soft-archive** (`archived_at`) plutôt que delete dur si le point a des `journal_entry_points`.
+- **Erreur** : nom vide / > N caractères → 400 (Zod). Grade hors codes canoniques → 400.
+- **Sécurité** : seul `is_teacher_or_admin()` peut éditer (RLS). Élève : aucun accès en écriture (lecture éventuelle hors V1).
+
+### 6.2 Pré-remplissage (seed) d'un grade
+
+- **Nominal** : un grade pré-rempli (ex. 6ᵉ) apparaît avec ses thèmes/items/points dès l'ouverture, puis modifiable.
+- **Limite** : le seed ne s'applique qu'une fois (idempotent) ; éditer après seed n'est pas écrasé par un re-seed.
+
+### 6.3 Tagging d'un exercice du système
+
+- **Nominal** : associer un exercice à 1..n points → relation créée.
+- **Limite** : exercice déjà tagué sur le même point → idempotent (pas de doublon).
+- **Erreur** : point/exercice inexistant → 400/404.
+
+### 6.4 Alimentation depuis une entrée de cahier de texte
+
+- **Nominal (auto)** : entrée qui référence un exercice tagué (points P1,P2) → `journal_entry_points` (P1,P2, source='auto'). La couverture de P1,P2 pour la classe **+1**.
+- **Nominal (manuel)** : le prof coche P3 sur l'entrée (réf. manuel ou point de cours libre) → `journal_entry_points` (P3, source='manual'). Couverture +1.
+- **Limite** : même point couvert 2 fois par la même entrée (1 auto via exo + 1 manuel) → **compté une fois par entrée** (`unique(entry_id, point_id)` ; `manual` l'emporte sur `auto` ou priorité à définir).
+- **Limite** : le prof décoche un point `auto` → retiré de la couverture pour cette entrée.
+- **Limite** : supprimer l'entrée → cascade, couverture recalculée (−1).
+- **Limite** : changer la `class_id`/date d'une entrée → la couverture suit la bonne classe/année.
+- **Erreur** : référencer un exercice/chapitre/point inexistant → 400.
+
+### 6.5 Vue d'avancement (heatmap)
+
+- **Nominal** : pour une classe, l'arborescence affiche chaque point avec son compteur et sa couleur ; items/thèmes agrègent.
+- **Limite** : classe sans aucune entrée → tout à 0 / « jamais vu ».
+- **Limite** : points archivés → exclus de la heatmap active (consultables à part).
+
+---
+
+## 7. UI (pages — proposition)
+
+1. **Édition du programme** (`teacher/programme` ou `teacher/curriculum`) : sélecteur de grade + arborescence éditable (thèmes/items/points, drag-order, CRUD).
+2. **Avancement par classe** (heatmap) : `teacher/classes/[classId]/programme` (ou onglet) — arborescence dépliable colorée, % par item/thème, filtre « points non vus ».
+3. **Intégration cahier de texte** : dans l'éditeur d'entrée (`teacher/cahier-texte/[classId]/[date]`), bloc « Programme travaillé » : (a) activités (exo système / réf manuel / point de cours) ; (b) points auto-déduits + coche manuelle.
+
+> Composants UI : **MySelect / MyCheckbox** obligatoires ; runes only ; `svelte-autofixer` sur chaque `.svelte`.
+
+---
+
+## 8. Phasage (proposition)
+
+- **Phase 1 — Données & API** : migrations (4.1–4.3), types `database-helpers`, validation Zod, endpoints CRUD programme + tagging + alimentation. Tests d'intégration (RLS `is_teacher_or_admin()`, triggers couverture). **Tests d'abord.**
+- **Phase 2 — Seed d'un grade** : pré-remplissage du grade choisi (cf. §10).
+- **Phase 3 — UI édition programme** (CRUD).
+- **Phase 4 — UI heatmap avancement** (rollup, couleurs, filtre trous).
+- **Phase 5 — Intégration cahier de texte** (bloc « Programme travaillé », auto + manuel).
+- Revue : `code-reviewer` + `security-auditor` (RLS/API) à chaque phase touchant données/auth.
+
+---
+
+## 9. Hors périmètre V1 (proposé)
+
+- Accès **élève** à la couverture/programme (lecture).
+- Lien point ↔ objectif d'évaluation (croisement « travaillé » × « acquis »).
+- Tagging massif des 103 exercices existants (on tague au fil de l'eau / par lots ensuite).
+- Multi-grades complets (on démarre par 1 grade pré-rempli).
+
+---
+
+## 11. Phase 1 — progression (crash-recovery)
+
+> Branche : **`feat/suivi-programme`**. **Non commité** (en attente d'accord).
+
+**Fait & vérifié (local Supabase) :**
+
+- **Migration** `supabase/migrations/20260621100000_curriculum_tracking.sql` — les 6 tables (§4) + RLS mono-prof (`is_teacher_or_admin()`, pattern `class_chapters`) + CHECK + UNIQUE + index + triggers `updated_at`. **Appliquée via `db:reset` sans erreur.**
+- **Tests** `tests/integration/curriculum-tracking-rls.test.ts` — **12/12 verts** : RLS (teacher OK / student refusé 42501 / student SELECT filtré / admin OK), CHECK (grade canonique, nom non vide, `kind`), UNIQUE (`grade,name` / `item_id,name`), cascade thème→items→points.
+
+**Décisions gravées dans le schéma :**
+
+- Valeurs : `kind` ∈ {`connaissance`, `savoir_faire`} (nullable) · `source` ∈ {`auto`, `manual`} · activité `kind` ∈ {`exercise`, `textbook`, `course`}.
+- **Grade = code canonique** (`'6'`, pas `'6e'`) — réconciliation avec `niveau_scolaire` du réf. d'éval **à faire au moment du seed** (Phase 2).
+- **Soft-archive** des points via `archived_at` (pas de delete dur si couverture existante — à appliquer côté API).
+- UNIQUE `(grade,name)` / `(theme_id,name)` / `(item_id,name)` → 409 côté API.
+- `textbook_ref` = `jsonb` souple `{ manuel?, page?, numero?, label }`.
+
+**Brique 1 — Arborescence (Thème/Item/Point) : ✅ FAIT & VERT**
+
+- Types manuels standalone dans `database-helpers.ts` (`CurriculumTheme/Item/Point`, `JournalEntryActivity/Point`, `ExerciseCurriculumPoint`, unions `kind`/`source`/`activityKind`, `TextbookRef`). ⚠️ À remplacer par `Tables<'…'>` après push prod + `db:types`.
+- Zod : `src/lib/server/validation/curriculum.ts` (create/update themes/items/points + query schemas).
+- Helper serveur : `src/lib/server/curriculum.ts` (mapping erreurs PG→HTTP, colonnes).
+- **6 endpoints** `src/routes/api/teacher/curriculum/{themes,items,points}[/[id]]/+server.ts` — GET/POST/PATCH/DELETE, `requireRoles(['teacher','admin'])` + RLS.
+- Tests : `curriculum-api.test.ts` **22/22** (201/400/404/409/401/403, tri, cascade, archive). + `curriculum-tracking-rls.test.ts` **12/12**. **`check:incremental` = 0 erreur.**
+
+**Brique 2 — Alimentation (à faire) :**
+
+- Endpoints tagging exercices (`exercise_curriculum_points`).
+- Endpoints cahier de texte : `journal_entry_activities` (3 types) + `journal_entry_points` (couverture auto matérialisée depuis les activités taguées + coche manuelle, dé-coche).
+- Tests endpoints + RLS/contraintes (`exercise_curriculum_points`, `journal_entry_*` : `kind_shape`, `source`, unique).
+
+---
+
+## 10. Questions ouvertes (à trancher avec David)
+
+1. **Grade de démarrage** : quel(s) niveau(x) enseignes-tu, et lequel pré-remplit-on en premier ? (6ᵉ ?)
+2. **Source du pré-remplissage** : ta **progression perso 2016** (« echelles descriptives connaissance 6 2016.pdf », tableau ~15 items × colonnes, intitulés simples) ? le **BO** ? l'arbre **éval 6ᵉ existant** (6 thèmes / 18 items) comme ossature ? Une combinaison ?
+3. **Référence manuel** : structurée (`manuel`, `page`, `numéro`) ou simple texte libre (label) ? Proposition : `jsonb` souple (label obligatoire, le reste optionnel).
+4. **`kind` sur le Point** (connaissance / savoir-faire) : utile ou superflu vu le grain fin ? Proposition : champ **optionnel** (null par défaut).
+5. ~~Vocabulaire~~ — **ACTÉ** (2026-06-21) : `Thème → Item → Point`, niveau 3 neutre + champ `kind` optionnel (cf. §3).
+6. **Matérialisation vs dérivation** de la couverture auto (cf. §4.3) : ok pour matérialiser ?
+
+```
+
+```

--- a/src/lib/config/dashboard-nav.ts
+++ b/src/lib/config/dashboard-nav.ts
@@ -23,6 +23,7 @@ import {
 	Book,
 	Layers,
 	ListTodo,
+	Gauge,
 	Code,
 	ShieldAlert,
 	Package,
@@ -118,6 +119,7 @@ export function getNavLinks(
 				icon: BookOpen
 			},
 			{ href: '/dashboard/teacher/programme', label: 'Programme', icon: ListTodo },
+			{ href: '/dashboard/teacher/avancement', label: 'Avancement', icon: Gauge },
 			{ href: '/dashboard/teacher/contenu', label: 'Mes contenus', icon: Layers },
 			{
 				href: '/dashboard/teacher/evaluation-tasks',

--- a/src/lib/config/dashboard-nav.ts
+++ b/src/lib/config/dashboard-nav.ts
@@ -117,6 +117,7 @@ export function getNavLinks(
 				label: 'Cahier de textes',
 				icon: BookOpen
 			},
+			{ href: '/dashboard/teacher/programme', label: 'Programme', icon: ListTodo },
 			{ href: '/dashboard/teacher/contenu', label: 'Mes contenus', icon: Layers },
 			{
 				href: '/dashboard/teacher/evaluation-tasks',

--- a/src/lib/server/curriculum-coverage.ts
+++ b/src/lib/server/curriculum-coverage.ts
@@ -1,0 +1,77 @@
+/**
+ * Coverage reconciliation — materializes the AUTO curriculum coverage of a
+ * cahier de texte entry from its tagged exercise activities.
+ *
+ * Idempotent set-reconcile: the desired auto set = union of the curriculum
+ * points tagged on the exercises referenced by the entry's 'exercise'
+ * activities. We delete stale `source='auto'` rows and insert missing ones,
+ * never touching `source='manual'` rows (the teacher's explicit choices).
+ *
+ * Called after any exercise activity is added to / removed from an entry.
+ */
+
+type Sb = App.Locals['supabase'];
+
+export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Promise<void> {
+	// 1. exercises referenced by this entry's 'exercise' activities
+	const { data: acts, error: actErr } = await supabase
+		.from('journal_entry_activities' as never)
+		.select('exercise_id')
+		.eq('entry_id', entryId)
+		.eq('kind', 'exercise');
+	if (actErr) throw new Error(`reconcileAutoCoverage activities: ${actErr.message}`);
+
+	const exerciseIds = [
+		...new Set(
+			((acts ?? []) as { exercise_id: string | null }[])
+				.map((a) => a.exercise_id)
+				.filter((id): id is string => id !== null)
+		)
+	];
+
+	// 2. desired auto points = union of those exercises' curriculum tags
+	let desired: string[] = [];
+	if (exerciseIds.length > 0) {
+		const { data: tags, error: tagErr } = await supabase
+			.from('exercise_curriculum_points' as never)
+			.select('point_id')
+			.in('exercise_id', exerciseIds);
+		if (tagErr) throw new Error(`reconcileAutoCoverage tags: ${tagErr.message}`);
+		desired = [...new Set(((tags ?? []) as { point_id: string }[]).map((t) => t.point_id))];
+	}
+
+	// 3. existing coverage rows for the entry
+	const { data: existing, error: exErr } = await supabase
+		.from('journal_entry_points' as never)
+		.select('point_id, source')
+		.eq('entry_id', entryId);
+	if (exErr) throw new Error(`reconcileAutoCoverage existing: ${exErr.message}`);
+
+	const rows = (existing ?? []) as { point_id: string; source: string }[];
+	const existingPoints = new Set(rows.map((r) => r.point_id));
+
+	// 4. delete stale auto rows (source='auto' and no longer desired)
+	const staleAuto = rows
+		.filter((r) => r.source === 'auto' && !desired.includes(r.point_id))
+		.map((r) => r.point_id);
+	if (staleAuto.length > 0) {
+		const { error } = await supabase
+			.from('journal_entry_points' as never)
+			.delete()
+			.eq('entry_id', entryId)
+			.eq('source', 'auto')
+			.in('point_id', staleAuto);
+		if (error) throw new Error(`reconcileAutoCoverage delete: ${error.message}`);
+	}
+
+	// 5. insert missing desired auto rows (no row at all yet — manual rows win)
+	const toInsert = desired
+		.filter((pid) => !existingPoints.has(pid))
+		.map((pid) => ({ entry_id: entryId, point_id: pid, source: 'auto' }));
+	if (toInsert.length > 0) {
+		const { error } = await supabase
+			.from('journal_entry_points' as never)
+			.upsert(toInsert as never, { onConflict: 'entry_id,point_id', ignoreDuplicates: true });
+		if (error) throw new Error(`reconcileAutoCoverage insert: ${error.message}`);
+	}
+}

--- a/src/lib/server/curriculum-coverage.ts
+++ b/src/lib/server/curriculum-coverage.ts
@@ -15,7 +15,7 @@ type Sb = App.Locals['supabase'];
 export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Promise<void> {
 	// 1. exercises referenced by this entry's 'exercise' activities
 	const { data: acts, error: actErr } = await supabase
-		.from('journal_entry_activities' as never)
+		.from('journal_entry_activities')
 		.select('exercise_id')
 		.eq('entry_id', entryId)
 		.eq('kind', 'exercise');
@@ -33,7 +33,7 @@ export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Prom
 	let desired: string[] = [];
 	if (exerciseIds.length > 0) {
 		const { data: tags, error: tagErr } = await supabase
-			.from('exercise_curriculum_points' as never)
+			.from('exercise_curriculum_points')
 			.select('point_id')
 			.in('exercise_id', exerciseIds);
 		if (tagErr) throw new Error(`reconcileAutoCoverage tags: ${tagErr.message}`);
@@ -42,7 +42,7 @@ export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Prom
 
 	// 3. existing coverage rows for the entry
 	const { data: existing, error: exErr } = await supabase
-		.from('journal_entry_points' as never)
+		.from('journal_entry_points')
 		.select('point_id, source')
 		.eq('entry_id', entryId);
 	if (exErr) throw new Error(`reconcileAutoCoverage existing: ${exErr.message}`);
@@ -56,7 +56,7 @@ export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Prom
 		.map((r) => r.point_id);
 	if (staleAuto.length > 0) {
 		const { error } = await supabase
-			.from('journal_entry_points' as never)
+			.from('journal_entry_points')
 			.delete()
 			.eq('entry_id', entryId)
 			.eq('source', 'auto')
@@ -70,8 +70,8 @@ export async function reconcileAutoCoverage(supabase: Sb, entryId: string): Prom
 		.map((pid) => ({ entry_id: entryId, point_id: pid, source: 'auto' }));
 	if (toInsert.length > 0) {
 		const { error } = await supabase
-			.from('journal_entry_points' as never)
-			.upsert(toInsert as never, { onConflict: 'entry_id,point_id', ignoreDuplicates: true });
+			.from('journal_entry_points')
+			.upsert(toInsert, { onConflict: 'entry_id,point_id', ignoreDuplicates: true });
 		if (error) throw new Error(`reconcileAutoCoverage insert: ${error.message}`);
 	}
 }

--- a/src/lib/server/curriculum.ts
+++ b/src/lib/server/curriculum.ts
@@ -2,9 +2,8 @@
  * Server helpers — Curriculum tracking (suivi du programme).
  *
  * Centralizes the Postgres-error → HTTP-status mapping shared by the
- * curriculum CRUD endpoints. The curriculum_* tables are not yet in the
- * generated database.ts, so endpoints use `.from('table' as never)` and cast
- * results to the helper types in `$lib/types/database-helpers`.
+ * curriculum CRUD endpoints. Result rows are narrowed to the helper types in
+ * `$lib/types/database-helpers` (constrained columns: grade/kind/source).
  */
 
 import { json } from '@sveltejs/kit';

--- a/src/lib/server/curriculum.ts
+++ b/src/lib/server/curriculum.ts
@@ -35,6 +35,8 @@ export function curriculumDbError(err: DbErrorLike, uniqueMsg = 'Doublon'): Resp
 			return json({ error: 'Valeur invalide' }, { status: 400 });
 		case '23503': // foreign_key_violation (e.g. unknown theme_id/item_id)
 			return json({ error: 'Référence introuvable' }, { status: 400 });
+		case '22P02': // invalid_text_representation (e.g. malformed UUID path param)
+			return json({ error: 'Identifiant invalide' }, { status: 400 });
 		default:
 			return null;
 	}

--- a/src/lib/server/curriculum.ts
+++ b/src/lib/server/curriculum.ts
@@ -7,6 +7,7 @@
  */
 
 import { json } from '@sveltejs/kit';
+import type { CurriculumTheme, CurriculumItem, CurriculumPoint } from '$lib/types/database-helpers';
 
 /** Minimal shape of a PostgREST/Postgres error (code is what we branch on). */
 export interface DbErrorLike {
@@ -39,4 +40,56 @@ export function curriculumDbError(err: DbErrorLike, uniqueMsg = 'Doublon'): Resp
 		default:
 			return null;
 	}
+}
+
+/** A theme with its items, each with its points (nested tree). */
+export type CurriculumTreeTheme = CurriculumTheme & {
+	items: (CurriculumItem & { points: CurriculumPoint[] })[];
+};
+
+/**
+ * Load the full Thème → Item → Point tree for a grade (ordered by display_order
+ * then name at each level). Shared by the programme editor and the
+ * cahier-de-texte coverage block.
+ */
+export async function getCurriculumTree(
+	supabase: App.Locals['supabase'],
+	grade: string
+): Promise<CurriculumTreeTheme[]> {
+	const { data: themes } = await supabase
+		.from('curriculum_themes')
+		.select(THEME_COLS)
+		.eq('grade', grade)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+	const themeList = (themes ?? []) as CurriculumTheme[];
+	const themeIds = themeList.map((t) => t.id);
+	if (themeIds.length === 0) return [];
+
+	const { data: items } = await supabase
+		.from('curriculum_items')
+		.select(ITEM_COLS)
+		.in('theme_id', themeIds)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+	const itemList = (items ?? []) as CurriculumItem[];
+	const itemIds = itemList.map((i) => i.id);
+
+	let pointList: CurriculumPoint[] = [];
+	if (itemIds.length > 0) {
+		const { data: points } = await supabase
+			.from('curriculum_points')
+			.select(POINT_COLS)
+			.in('item_id', itemIds)
+			.order('display_order', { ascending: true })
+			.order('name', { ascending: true });
+		pointList = (points ?? []) as CurriculumPoint[];
+	}
+
+	return themeList.map((theme) => ({
+		...theme,
+		items: itemList
+			.filter((i) => i.theme_id === theme.id)
+			.map((item) => ({ ...item, points: pointList.filter((p) => p.item_id === item.id) }))
+	}));
 }

--- a/src/lib/server/curriculum.ts
+++ b/src/lib/server/curriculum.ts
@@ -1,0 +1,41 @@
+/**
+ * Server helpers — Curriculum tracking (suivi du programme).
+ *
+ * Centralizes the Postgres-error → HTTP-status mapping shared by the
+ * curriculum CRUD endpoints. The curriculum_* tables are not yet in the
+ * generated database.ts, so endpoints use `.from('table' as never)` and cast
+ * results to the helper types in `$lib/types/database-helpers`.
+ */
+
+import { json } from '@sveltejs/kit';
+
+/** Minimal shape of a PostgREST/Postgres error (code is what we branch on). */
+export interface DbErrorLike {
+	code?: string | null;
+	message?: string;
+}
+
+/** Column lists (single source of truth for SELECT projections). */
+export const THEME_COLS = 'id, grade, name, display_order, created_at, updated_at';
+export const ITEM_COLS = 'id, theme_id, name, display_order, created_at, updated_at';
+export const POINT_COLS =
+	'id, item_id, name, display_order, kind, archived_at, created_at, updated_at';
+
+/**
+ * Map a known Postgres error code to an HTTP JSON Response.
+ * Returns `null` when the error is not one we translate (caller → 500).
+ */
+export function curriculumDbError(err: DbErrorLike, uniqueMsg = 'Doublon'): Response | null {
+	switch (err.code) {
+		case '23505': // unique_violation
+			return json({ error: uniqueMsg }, { status: 409 });
+		case '42501': // insufficient_privilege (RLS)
+			return json({ error: 'Accès refusé' }, { status: 403 });
+		case '23514': // check_violation
+			return json({ error: 'Valeur invalide' }, { status: 400 });
+		case '23503': // foreign_key_violation (e.g. unknown theme_id/item_id)
+			return json({ error: 'Référence introuvable' }, { status: 400 });
+		default:
+			return null;
+	}
+}

--- a/src/lib/server/validation/curriculum.ts
+++ b/src/lib/server/validation/curriculum.ts
@@ -1,0 +1,117 @@
+/**
+ * Zod validation — Curriculum tracking (suivi du programme)
+ * =========================================================
+ *
+ * Referential tree: Thème → Item → Point. All inputs validated here.
+ * Mirrors the DB constraints in migration 20260621100000_curriculum_tracking.sql.
+ */
+
+import { z } from 'zod';
+import { gradeCodeSchema } from './grades';
+
+// ---------------------------------------------------------------------------
+// Shared field schemas
+// ---------------------------------------------------------------------------
+
+const nameSchema = z
+	.string()
+	.trim()
+	.min(1, 'Le nom ne peut pas être vide')
+	.max(200, 'Le nom ne peut pas dépasser 200 caractères');
+
+const displayOrderSchema = z.number().int().min(0).max(100000);
+
+const pointKindSchema = z.enum(['connaissance', 'savoir_faire']);
+
+// ---------------------------------------------------------------------------
+// Thème (level 1)
+// ---------------------------------------------------------------------------
+
+export const createThemeSchema = z.object({
+	grade: gradeCodeSchema,
+	name: nameSchema,
+	display_order: displayOrderSchema.optional()
+});
+
+export const updateThemeSchema = z
+	.object({
+		name: nameSchema.optional(),
+		display_order: displayOrderSchema.optional()
+	})
+	.refine((d) => d.name !== undefined || d.display_order !== undefined, {
+		message: 'Au moins un champ à mettre à jour'
+	});
+
+// ---------------------------------------------------------------------------
+// Item (level 2)
+// ---------------------------------------------------------------------------
+
+export const createItemSchema = z.object({
+	theme_id: z.string().uuid(),
+	name: nameSchema,
+	display_order: displayOrderSchema.optional()
+});
+
+export const updateItemSchema = z
+	.object({
+		name: nameSchema.optional(),
+		display_order: displayOrderSchema.optional()
+	})
+	.refine((d) => d.name !== undefined || d.display_order !== undefined, {
+		message: 'Au moins un champ à mettre à jour'
+	});
+
+// ---------------------------------------------------------------------------
+// Point (level 3, tracking grain)
+// ---------------------------------------------------------------------------
+
+export const createPointSchema = z.object({
+	item_id: z.string().uuid(),
+	name: nameSchema,
+	display_order: displayOrderSchema.optional(),
+	kind: pointKindSchema.nullable().optional()
+});
+
+export const updatePointSchema = z
+	.object({
+		name: nameSchema.optional(),
+		display_order: displayOrderSchema.optional(),
+		kind: pointKindSchema.nullable().optional(),
+		// soft-archive toggle: true → set archived_at = now(), false → clear
+		archived: z.boolean().optional()
+	})
+	.refine(
+		(d) =>
+			d.name !== undefined ||
+			d.display_order !== undefined ||
+			d.kind !== undefined ||
+			d.archived !== undefined,
+		{ message: 'Au moins un champ à mettre à jour' }
+	);
+
+// ---------------------------------------------------------------------------
+// Query-param schemas (GET filters)
+// ---------------------------------------------------------------------------
+
+export const themeListQuerySchema = z.object({
+	grade: gradeCodeSchema
+});
+
+export const itemListQuerySchema = z.object({
+	theme_id: z.string().uuid()
+});
+
+export const pointListQuerySchema = z.object({
+	item_id: z.string().uuid()
+});
+
+// ---------------------------------------------------------------------------
+// Inferred input types
+// ---------------------------------------------------------------------------
+
+export type CreateThemeInput = z.infer<typeof createThemeSchema>;
+export type UpdateThemeInput = z.infer<typeof updateThemeSchema>;
+export type CreateItemInput = z.infer<typeof createItemSchema>;
+export type UpdateItemInput = z.infer<typeof updateItemSchema>;
+export type CreatePointInput = z.infer<typeof createPointSchema>;
+export type UpdatePointInput = z.infer<typeof updatePointSchema>;

--- a/src/lib/server/validation/curriculum.ts
+++ b/src/lib/server/validation/curriculum.ts
@@ -115,3 +115,84 @@ export type CreateItemInput = z.infer<typeof createItemSchema>;
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;
 export type CreatePointInput = z.infer<typeof createPointSchema>;
 export type UpdatePointInput = z.infer<typeof updatePointSchema>;
+
+// ---------------------------------------------------------------------------
+// Brique 2 — Tagging des exercices & alimentation (cahier de texte)
+// ---------------------------------------------------------------------------
+
+const uuidSchema = z.string().uuid();
+
+/** Tag / untag a system exercise with a curriculum point. */
+export const exerciseTagSchema = z.object({
+	exercise_id: uuidSchema,
+	point_id: uuidSchema
+});
+
+export const exerciseTagListQuerySchema = z.object({
+	exercise_id: uuidSchema
+});
+
+/** Free-form textbook reference (manuel scolaire). */
+const textbookRefSchema = z
+	.object({
+		label: z.string().trim().min(1, 'Référence requise').max(200),
+		manuel: z.string().trim().max(200).optional(),
+		page: z.string().trim().max(50).optional(),
+		numero: z.string().trim().max(50).optional()
+	})
+	.strict();
+
+/** Add an activity to a cahier de texte entry (3 kinds). */
+export const createActivitySchema = z
+	.discriminatedUnion('kind', [
+		z.object({
+			entry_id: uuidSchema,
+			kind: z.literal('exercise'),
+			exercise_id: uuidSchema,
+			display_order: displayOrderSchema.optional()
+		}),
+		z.object({
+			entry_id: uuidSchema,
+			kind: z.literal('course'),
+			chapter_id: uuidSchema.optional(),
+			label: z.string().trim().min(1).max(200).optional(),
+			display_order: displayOrderSchema.optional()
+		}),
+		z.object({
+			entry_id: uuidSchema,
+			kind: z.literal('textbook'),
+			textbook_ref: textbookRefSchema,
+			display_order: displayOrderSchema.optional()
+		})
+	])
+	.superRefine((d, ctx) => {
+		if (d.kind === 'course' && d.chapter_id === undefined && d.label === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'Un point de cours requiert un chapitre ou un libellé'
+			});
+		}
+	});
+
+export const activityListQuerySchema = z.object({
+	entry_id: uuidSchema
+});
+
+/** Manually add / remove a curriculum point on an entry (coverage). */
+export const coveragePointSchema = z.object({
+	entry_id: uuidSchema,
+	point_id: uuidSchema
+});
+
+export const coverageListQuerySchema = z.object({
+	entry_id: uuidSchema
+});
+
+export const coveragePointQuerySchema = z.object({
+	entry_id: uuidSchema,
+	point_id: uuidSchema
+});
+
+export type ExerciseTagInput = z.infer<typeof exerciseTagSchema>;
+export type CreateActivityInput = z.infer<typeof createActivitySchema>;
+export type CoveragePointInput = z.infer<typeof coveragePointSchema>;

--- a/src/lib/types/database-helpers.ts
+++ b/src/lib/types/database-helpers.ts
@@ -575,10 +575,9 @@ export type {
 // Référentiel de programme (Thème → Item → Point), DISTINCT du référentiel
 // d'évaluation (skills/objectives). Couverture alimentée par le cahier de texte.
 //
-// NOTE: standalone types — les tables `curriculum_*` / `journal_entry_*` /
-// `exercise_curriculum_points` ne sont pas encore dans le `database.ts` généré
-// (migration 20260621100000 non poussée en prod). Après le push prod +
-// `pnpm db:types`, remplacer ces interfaces par `Tables<'curriculum_themes'>` etc.
+// Rows dérivées du `database.ts` généré ; on resserre seulement les colonnes
+// contraintes que le générateur expose en `string`/`Json` (grade, kind, source,
+// textbook_ref) vers leurs unions/formes réelles.
 
 /** A curriculum point can be a knowledge item or a know-how (neutral by default). */
 export type CurriculumPointKind = 'connaissance' | 'savoir_faire';
@@ -598,62 +597,26 @@ export interface TextbookRef {
 }
 
 /** Level 1 — Thème (per grade). e.g. "Calcul". */
-export interface CurriculumTheme {
-	id: string;
-	grade: GradeCode;
-	name: string;
-	display_order: number;
-	created_at: string;
-	updated_at: string;
-}
+export type CurriculumTheme = Omit<Tables<'curriculum_themes'>, 'grade'> & { grade: GradeCode };
 
 /** Level 2 — Item (under a Thème). e.g. "Fractions". */
-export interface CurriculumItem {
-	id: string;
-	theme_id: string;
-	name: string;
-	display_order: number;
-	created_at: string;
-	updated_at: string;
-}
+export type CurriculumItem = Tables<'curriculum_items'>;
 
 /** Level 3 — Point (tracking grain). e.g. "Additionner deux fractions". */
-export interface CurriculumPoint {
-	id: string;
-	item_id: string;
-	name: string;
-	display_order: number;
+export type CurriculumPoint = Omit<Tables<'curriculum_points'>, 'kind'> & {
 	kind: CurriculumPointKind | null;
-	archived_at: string | null;
-	created_at: string;
-	updated_at: string;
-}
+};
 
 /** Tags a system exercise with a curriculum point it covers. */
-export interface ExerciseCurriculumPoint {
-	exercise_id: string;
-	point_id: string;
-	created_at: string;
-}
+export type ExerciseCurriculumPoint = Tables<'exercise_curriculum_points'>;
 
 /** An activity attached to a journal entry (system exercise / textbook / course point). */
-export interface JournalEntryActivity {
-	id: string;
-	entry_id: string;
-	kind: JournalActivityKind;
-	exercise_id: string | null;
-	chapter_id: string | null;
-	textbook_ref: TextbookRef | null;
-	label: string | null;
-	display_order: number;
-	created_at: string;
-}
+export type JournalEntryActivity = Omit<
+	Tables<'journal_entry_activities'>,
+	'kind' | 'textbook_ref'
+> & { kind: JournalActivityKind; textbook_ref: TextbookRef | null };
 
 /** Coverage signal: a curriculum point worked on in a journal entry. */
-export interface JournalEntryPoint {
-	id: string;
-	entry_id: string;
-	point_id: string;
+export type JournalEntryPoint = Omit<Tables<'journal_entry_points'>, 'source'> & {
 	source: CoverageSource;
-	created_at: string;
-}
+};

--- a/src/lib/types/database-helpers.ts
+++ b/src/lib/types/database-helpers.ts
@@ -65,6 +65,7 @@
 
 import type { Database, Tables } from './database';
 import type { QuestionTemplate } from '$lib/questions/types';
+import type { GradeCode } from '$lib/types/grades';
 
 // ============================================================================
 // Table Row Type Aliases
@@ -566,3 +567,93 @@ export type {
 	ValidatedObservables,
 	PhaseBlocage
 };
+
+// ============================================================================
+// CURRICULUM TRACKING (suivi du programme — Phase 1)
+// ============================================================================
+//
+// Référentiel de programme (Thème → Item → Point), DISTINCT du référentiel
+// d'évaluation (skills/objectives). Couverture alimentée par le cahier de texte.
+//
+// NOTE: standalone types — les tables `curriculum_*` / `journal_entry_*` /
+// `exercise_curriculum_points` ne sont pas encore dans le `database.ts` généré
+// (migration 20260621100000 non poussée en prod). Après le push prod +
+// `pnpm db:types`, remplacer ces interfaces par `Tables<'curriculum_themes'>` etc.
+
+/** A curriculum point can be a knowledge item or a know-how (neutral by default). */
+export type CurriculumPointKind = 'connaissance' | 'savoir_faire';
+
+/** How a journal entry came to cover a point. */
+export type CoverageSource = 'auto' | 'manual';
+
+/** The kind of activity attached to a cahier de texte entry. */
+export type JournalActivityKind = 'exercise' | 'textbook' | 'course';
+
+/** Free-form textbook reference (manuel scolaire). `label` is required. */
+export interface TextbookRef {
+	label: string;
+	manuel?: string;
+	page?: string;
+	numero?: string;
+}
+
+/** Level 1 — Thème (per grade). e.g. "Calcul". */
+export interface CurriculumTheme {
+	id: string;
+	grade: GradeCode;
+	name: string;
+	display_order: number;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Level 2 — Item (under a Thème). e.g. "Fractions". */
+export interface CurriculumItem {
+	id: string;
+	theme_id: string;
+	name: string;
+	display_order: number;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Level 3 — Point (tracking grain). e.g. "Additionner deux fractions". */
+export interface CurriculumPoint {
+	id: string;
+	item_id: string;
+	name: string;
+	display_order: number;
+	kind: CurriculumPointKind | null;
+	archived_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Tags a system exercise with a curriculum point it covers. */
+export interface ExerciseCurriculumPoint {
+	exercise_id: string;
+	point_id: string;
+	created_at: string;
+}
+
+/** An activity attached to a journal entry (system exercise / textbook / course point). */
+export interface JournalEntryActivity {
+	id: string;
+	entry_id: string;
+	kind: JournalActivityKind;
+	exercise_id: string | null;
+	chapter_id: string | null;
+	textbook_ref: TextbookRef | null;
+	label: string | null;
+	display_order: number;
+	created_at: string;
+}
+
+/** Coverage signal: a curriculum point worked on in a journal entry. */
+export interface JournalEntryPoint {
+	id: string;
+	entry_id: string;
+	point_id: string;
+	source: CoverageSource;
+	created_at: string;
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -2100,6 +2100,109 @@ export type Database = {
           },
         ]
       }
+      curriculum_items: {
+        Row: {
+          created_at: string
+          display_order: number
+          id: string
+          name: string
+          theme_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          display_order?: number
+          id?: string
+          name: string
+          theme_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          display_order?: number
+          id?: string
+          name?: string
+          theme_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "curriculum_items_theme_id_fkey"
+            columns: ["theme_id"]
+            isOneToOne: false
+            referencedRelation: "curriculum_themes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      curriculum_points: {
+        Row: {
+          archived_at: string | null
+          created_at: string
+          display_order: number
+          id: string
+          item_id: string
+          kind: string | null
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          archived_at?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          item_id: string
+          kind?: string | null
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          archived_at?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          item_id?: string
+          kind?: string | null
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "curriculum_points_item_id_fkey"
+            columns: ["item_id"]
+            isOneToOne: false
+            referencedRelation: "curriculum_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      curriculum_themes: {
+        Row: {
+          created_at: string
+          display_order: number
+          grade: string
+          id: string
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          display_order?: number
+          grade: string
+          id?: string
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          display_order?: number
+          grade?: string
+          id?: string
+          name?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       daily_game_rewards: {
         Row: {
           actual_reward: number
@@ -2769,6 +2872,39 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "riddle_progress"
             referencedColumns: ["student_id"]
+          },
+        ]
+      }
+      exercise_curriculum_points: {
+        Row: {
+          created_at: string
+          exercise_id: string
+          point_id: string
+        }
+        Insert: {
+          created_at?: string
+          exercise_id: string
+          point_id: string
+        }
+        Update: {
+          created_at?: string
+          exercise_id?: string
+          point_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_curriculum_points_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "exercise_curriculum_points_point_id_fkey"
+            columns: ["point_id"]
+            isOneToOne: false
+            referencedRelation: "curriculum_points"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -4582,6 +4718,103 @@ export type Database = {
             isOneToOne: true
             referencedRelation: "riddle_progress"
             referencedColumns: ["student_id"]
+          },
+        ]
+      }
+      journal_entry_activities: {
+        Row: {
+          chapter_id: string | null
+          created_at: string
+          display_order: number
+          entry_id: string
+          exercise_id: string | null
+          id: string
+          kind: string
+          label: string | null
+          textbook_ref: Json | null
+        }
+        Insert: {
+          chapter_id?: string | null
+          created_at?: string
+          display_order?: number
+          entry_id: string
+          exercise_id?: string | null
+          id?: string
+          kind: string
+          label?: string | null
+          textbook_ref?: Json | null
+        }
+        Update: {
+          chapter_id?: string | null
+          created_at?: string
+          display_order?: number
+          entry_id?: string
+          exercise_id?: string | null
+          id?: string
+          kind?: string
+          label?: string | null
+          textbook_ref?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "journal_entry_activities_chapter_id_fkey"
+            columns: ["chapter_id"]
+            isOneToOne: false
+            referencedRelation: "class_chapters"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "journal_entry_activities_entry_id_fkey"
+            columns: ["entry_id"]
+            isOneToOne: false
+            referencedRelation: "class_journal_entries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "journal_entry_activities_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      journal_entry_points: {
+        Row: {
+          created_at: string
+          entry_id: string
+          id: string
+          point_id: string
+          source: string
+        }
+        Insert: {
+          created_at?: string
+          entry_id: string
+          id?: string
+          point_id: string
+          source?: string
+        }
+        Update: {
+          created_at?: string
+          entry_id?: string
+          id?: string
+          point_id?: string
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "journal_entry_points_entry_id_fkey"
+            columns: ["entry_id"]
+            isOneToOne: false
+            referencedRelation: "class_journal_entries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "journal_entry_points_point_id_fkey"
+            columns: ["point_id"]
+            isOneToOne: false
+            referencedRelation: "curriculum_points"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/src/routes/(protected)/dashboard/teacher/avancement/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/avancement/+page.server.ts
@@ -1,0 +1,64 @@
+/**
+ * Teacher — Avancement du programme (coverage heatmap) — server load.
+ *
+ * For a class, shows how many times each curriculum point was worked on during
+ * the current school year (count from journal_entry_points), rolled up to items
+ * and themes. Read-only.
+ */
+
+import type { PageServerLoad } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { getCurriculumTree, type CurriculumTreeTheme } from '$lib/server/curriculum';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const { data: classesRaw } = await locals.supabase
+		.from('classes')
+		.select('id, name, grade')
+		.order('name', { ascending: true });
+	const classes = (classesRaw ?? []) as { id: string; name: string; grade: string | null }[];
+
+	const requested = url.searchParams.get('class');
+	const selected = classes.find((c) => c.id === requested) ?? classes[0] ?? null;
+
+	// Current school year window: 1 Sept → 1 Sept.
+	const now = new Date();
+	const startYear = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
+	const yearStart = `${startYear}-09-01`;
+	const yearEnd = `${startYear + 1}-09-01`;
+
+	let tree: CurriculumTreeTheme[] = [];
+	const counts: Record<string, number> = {};
+
+	if (selected?.grade) {
+		tree = await getCurriculumTree(locals.supabase, selected.grade);
+
+		const { data: entries } = await locals.supabase
+			.from('class_journal_entries')
+			.select('id')
+			.eq('class_id', selected.id)
+			.gte('entry_date', yearStart)
+			.lt('entry_date', yearEnd);
+		const entryIds = (entries ?? []).map((e) => e.id);
+
+		if (entryIds.length > 0) {
+			const { data: cov } = await locals.supabase
+				.from('journal_entry_points')
+				.select('point_id')
+				.in('entry_id', entryIds);
+			for (const row of cov ?? []) {
+				counts[row.point_id] = (counts[row.point_id] ?? 0) + 1;
+			}
+		}
+	}
+
+	return {
+		classOptions: classes.map((c) => ({ value: c.id, label: c.name })),
+		selectedClassId: selected?.id ?? '',
+		selectedGrade: selected?.grade ?? null,
+		schoolYearLabel: `${startYear}–${startYear + 1}`,
+		tree,
+		counts
+	};
+};

--- a/src/routes/(protected)/dashboard/teacher/avancement/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/avancement/+page.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	/**
+	 * Teacher — Avancement du programme (coverage heatmap).
+	 *
+	 * Read-only view: for a class, how many times each curriculum point was worked
+	 * on this school year, rolled up to items and themes. Colour = intensity.
+	 */
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import * as Card from '$lib/components/ui/card';
+	import MySelect from '$lib/components/MySelect.svelte';
+	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
+	import { Gauge, ChevronRight, ChevronDown } from '@lucide/svelte';
+	import type { PageData } from './$types';
+
+	type Theme = PageData['tree'][number];
+	type Item = Theme['items'][number];
+
+	let { data }: { data: PageData } = $props();
+
+	let openThemes = $state<Record<string, boolean>>({});
+	let openItems = $state<Record<string, boolean>>({});
+	let onlyUncovered = $state(false);
+
+	function changeClass(value: string | string[]) {
+		if (typeof value !== 'string') return;
+		// Query-only navigation (reloads the server load).
+		const url = new URL(page.url);
+		url.searchParams.set('class', value);
+		goto(url, { keepFocus: true, noScroll: true });
+	}
+
+	function count(pointId: string): number {
+		return data.counts[pointId] ?? 0;
+	}
+
+	/** Colour bucket: 0 = never seen (highlighted), then light → dark. */
+	function cellClass(c: number): string {
+		if (c === 0) return 'bg-red-50 text-red-700 ring-1 ring-inset ring-red-200';
+		if (c === 1) return 'bg-emerald-100 text-emerald-900';
+		if (c <= 3) return 'bg-emerald-300 text-emerald-950';
+		return 'bg-emerald-500 text-white';
+	}
+
+	function itemStats(item: Item): { vus: number; total: number } {
+		const total = item.points.length;
+		const vus = item.points.filter((p) => count(p.id) > 0).length;
+		return { vus, total };
+	}
+
+	function themeStats(theme: Theme): { vus: number; total: number } {
+		let vus = 0;
+		let total = 0;
+		for (const item of theme.items) {
+			const s = itemStats(item);
+			vus += s.vus;
+			total += s.total;
+		}
+		return { vus, total };
+	}
+
+	function pct(vus: number, total: number): number {
+		return total > 0 ? Math.round((vus / total) * 100) : 0;
+	}
+
+	function uncoveredPoints(item: Item) {
+		return item.points.filter((p) => count(p.id) === 0);
+	}
+
+	function themeHasUncovered(theme: Theme): boolean {
+		return theme.items.some((item) => uncoveredPoints(item).length > 0);
+	}
+</script>
+
+<svelte:head><title>Avancement du programme | UbuMaths</title></svelte:head>
+
+<div class="container mx-auto max-w-4xl space-y-6 p-4">
+	<!-- Header -->
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div class="flex items-center gap-3">
+			<div class="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10">
+				<Gauge class="h-6 w-6 text-primary" />
+			</div>
+			<div>
+				<h1 class="text-2xl font-bold tracking-tight">Avancement du programme</h1>
+				<p class="text-sm text-muted-foreground">Année scolaire {data.schoolYearLabel}</p>
+			</div>
+		</div>
+		{#if data.classOptions.length > 0}
+			<MySelect
+				type="single"
+				value={data.selectedClassId}
+				items={data.classOptions}
+				onValueChange={changeClass}
+				placeholder="Classe…"
+				triggerClass="w-48"
+			/>
+		{/if}
+	</div>
+
+	{#if data.classOptions.length === 0}
+		<div class="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+			Aucune classe.
+		</div>
+	{:else if data.tree.length === 0}
+		<div class="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+			Aucun programme défini pour le niveau de cette classe.
+			<a class="underline" href={resolve('/dashboard/teacher/programme')}>Le créer dans Programme</a
+			>.
+		</div>
+	{:else}
+		<!-- Legend + filter -->
+		<div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-card p-3">
+			<div class="flex flex-wrap items-center gap-3 text-xs">
+				<span class="text-muted-foreground">Travaillé :</span>
+				<span class="rounded px-2 py-0.5 {cellClass(0)}">jamais</span>
+				<span class="rounded px-2 py-0.5 {cellClass(1)}">1×</span>
+				<span class="rounded px-2 py-0.5 {cellClass(2)}">2–3×</span>
+				<span class="rounded px-2 py-0.5 {cellClass(4)}">4×+</span>
+			</div>
+			<MyCheckbox bind:checked={onlyUncovered} label="Seulement les points non vus" />
+		</div>
+
+		<!-- Heatmap tree -->
+		<div class="space-y-2">
+			{#each data.tree as theme (theme.id)}
+				{@const ts = themeStats(theme)}
+				{#if !onlyUncovered || themeHasUncovered(theme)}
+					<div class="rounded-lg border bg-card">
+						<button
+							class="flex w-full items-center gap-2 p-2 text-left"
+							onclick={() => (openThemes[theme.id] = !openThemes[theme.id])}
+						>
+							{#if onlyUncovered || openThemes[theme.id]}
+								<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{:else}
+								<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{/if}
+							<span class="flex-1 font-semibold">{theme.name}</span>
+							<span class="text-xs text-muted-foreground">
+								{ts.vus}/{ts.total} · {pct(ts.vus, ts.total)}%
+							</span>
+						</button>
+
+						{#if onlyUncovered || openThemes[theme.id]}
+							<div class="space-y-1 border-t p-2 pl-4">
+								{#each theme.items as item (item.id)}
+									{@const is = itemStats(item)}
+									{#if !onlyUncovered || uncoveredPoints(item).length > 0}
+										<div class="rounded-md border">
+											<button
+												class="flex w-full items-center gap-2 p-2 text-left text-sm"
+												onclick={() => (openItems[item.id] = !openItems[item.id])}
+											>
+												{#if onlyUncovered || openItems[item.id]}
+													<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+												{:else}
+													<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+												{/if}
+												<span class="flex-1 font-medium">{item.name}</span>
+												<span class="text-xs text-muted-foreground">{is.vus}/{is.total}</span>
+											</button>
+
+											{#if onlyUncovered || openItems[item.id]}
+												<div class="space-y-0.5 border-t p-2 pl-4">
+													{#each onlyUncovered ? uncoveredPoints(item) : item.points as point (point.id)}
+														{@const c = count(point.id)}
+														<div class="flex items-center gap-2 py-0.5 text-sm">
+															<span
+																class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded px-1.5 text-xs font-medium {cellClass(
+																	c
+																)}"
+															>
+																{c}
+															</span>
+															<span class:text-muted-foreground={c === 0}>{point.name}</span>
+														</div>
+													{/each}
+												</div>
+											{/if}
+										</div>
+									{/if}
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/routes/(protected)/dashboard/teacher/avancement/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/avancement/+page.svelte
@@ -8,7 +8,6 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
-	import * as Card from '$lib/components/ui/card';
 	import MySelect from '$lib/components/MySelect.svelte';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { Gauge, ChevronRight, ChevronDown } from '@lucide/svelte';

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
@@ -94,12 +94,44 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		: [];
 
 	let coveredPoints: { point_id: string; source: string }[] = [];
+	let activities: {
+		id: string;
+		kind: string;
+		exercise_id: string | null;
+		chapter_id: string | null;
+		textbook_ref: unknown;
+		label: string | null;
+		display_order: number;
+	}[] = [];
 	if (entry) {
 		const { data: cov } = await locals.supabase
 			.from('journal_entry_points')
 			.select('point_id, source')
 			.eq('entry_id', entry.id);
 		coveredPoints = (cov ?? []) as { point_id: string; source: string }[];
+
+		const { data: acts } = await locals.supabase
+			.from('journal_entry_activities')
+			.select('id, kind, exercise_id, chapter_id, textbook_ref, label, display_order')
+			.eq('entry_id', entry.id)
+			.order('display_order', { ascending: true })
+			.order('created_at', { ascending: true });
+		activities = (acts ?? []) as typeof activities;
+	}
+
+	// Exercises selectable for this class's grade (for the activity picker).
+	let exerciseOptions: { value: string; label: string }[] = [];
+	if (classData.grade) {
+		const { data: exs } = await locals.supabase
+			.from('exercises')
+			.select('id, title, slug, topic')
+			.contains('grades', [classData.grade])
+			.order('title', { ascending: true })
+			.limit(500);
+		exerciseOptions = (exs ?? []).map((e) => ({
+			value: e.id,
+			label: e.title || e.topic || e.slug || 'Exercice sans titre'
+		}));
 	}
 
 	return {
@@ -107,7 +139,9 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		entry,
 		entryDate: date,
 		curriculumTree,
-		coveredPoints
+		coveredPoints,
+		activities,
+		exerciseOptions
 	};
 };
 

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.server.ts
@@ -14,6 +14,7 @@ import {
 	validateCreateJournalEntry,
 	validateUpdateJournalEntry
 } from '$lib/server/validation/journal';
+import { getCurriculumTree } from '$lib/server/curriculum';
 import { z } from 'zod';
 
 // UUID validation schema
@@ -87,10 +88,26 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 			}
 		: null;
 
+	// Programme travaillé — curriculum tree (class grade) + this entry's coverage.
+	const curriculumTree = classData.grade
+		? await getCurriculumTree(locals.supabase, classData.grade)
+		: [];
+
+	let coveredPoints: { point_id: string; source: string }[] = [];
+	if (entry) {
+		const { data: cov } = await locals.supabase
+			.from('journal_entry_points')
+			.select('point_id, source')
+			.eq('entry_id', entry.id);
+		coveredPoints = (cov ?? []) as { point_id: string; source: string }[];
+	}
+
 	return {
 		classData,
 		entry,
-		entryDate: date
+		entryDate: date,
+		curriculumTree,
+		coveredPoints
 	};
 };
 

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
@@ -12,6 +12,7 @@
 
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
@@ -31,7 +32,10 @@
 		ClipboardList,
 		Globe,
 		EyeOff,
-		Calendar
+		Calendar,
+		ListTodo,
+		ChevronRight,
+		ChevronDown
 	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 
@@ -56,6 +60,66 @@
 
 	// Delete confirmation dialog
 	let showDeleteDialog = $state(false);
+
+	// --- Programme travaillé (coverage) --------------------------------------
+	const initialCovered: Record<string, string> = {};
+	for (const c of initialData.coveredPoints) initialCovered[c.point_id] = c.source;
+	let coveredSource = $state<Record<string, string>>(initialCovered);
+	let openProgThemes = $state<Record<string, boolean>>({});
+	let openProgItems = $state<Record<string, boolean>>({});
+	let coveredCount = $derived(Object.keys(coveredSource).length);
+
+	function isCovered(pointId: string): boolean {
+		return coveredSource[pointId] !== undefined;
+	}
+
+	async function covApi(url: string, method: string, body?: unknown): Promise<boolean> {
+		try {
+			const res = await fetch(url, {
+				method,
+				headers: body ? { 'Content-Type': 'application/json' } : undefined,
+				body: body ? JSON.stringify(body) : undefined
+			});
+			if (!res.ok) {
+				const j = await res.json().catch(() => ({}));
+				toaster.error(j?.error ?? 'Une erreur est survenue');
+				return false;
+			}
+			return true;
+		} catch {
+			toaster.error('Erreur réseau');
+			return false;
+		}
+	}
+
+	/** Optimistically toggle a curriculum point's coverage for this entry. */
+	async function togglePoint(point: { id: string }) {
+		const entryId = data.entry?.id;
+		if (!entryId) return;
+
+		if (isCovered(point.id)) {
+			const prev = coveredSource[point.id];
+			const next = { ...coveredSource };
+			delete next[point.id];
+			coveredSource = next;
+			const ok = await covApi(
+				`/api/teacher/curriculum/coverage?entry_id=${entryId}&point_id=${point.id}`,
+				'DELETE'
+			);
+			if (!ok) coveredSource = { ...coveredSource, [point.id]: prev };
+		} else {
+			coveredSource = { ...coveredSource, [point.id]: 'manual' };
+			const ok = await covApi('/api/teacher/curriculum/coverage', 'POST', {
+				entry_id: entryId,
+				point_id: point.id
+			});
+			if (!ok) {
+				const next = { ...coveredSource };
+				delete next[point.id];
+				coveredSource = next;
+			}
+		}
+	}
 
 	// Derived values
 	let isEditing = $derived(!!data.entry);
@@ -331,6 +395,92 @@
 			</div>
 		</div>
 	</form>
+
+	<!-- Programme travaillé (coverage) -->
+	{#if isEditing}
+		<div class="mt-6">
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="flex items-center gap-2">
+						<ListTodo class="h-5 w-5 text-primary" />
+						Programme travaillé
+					</Card.Title>
+					<Card.Description>
+						Cochez les points du programme abordés pendant cette séance.
+						{#if coveredCount > 0}
+							<span class="font-medium text-foreground">
+								{coveredCount} point{coveredCount > 1 ? 's' : ''} coché{coveredCount > 1
+									? 's'
+									: ''}.
+							</span>
+						{/if}
+					</Card.Description>
+				</Card.Header>
+				<Card.Content>
+					{#if data.curriculumTree.length === 0}
+						<p class="text-sm text-muted-foreground">
+							Aucun programme défini pour le niveau de cette classe.
+							<a class="underline" href={resolve('/dashboard/teacher/programme')}
+								>Le créer dans Programme</a
+							>.
+						</p>
+					{:else}
+						<div class="space-y-1">
+							{#each data.curriculumTree as theme (theme.id)}
+								<div class="rounded-md border">
+									<button
+										class="flex w-full items-center gap-2 p-2 text-left font-medium"
+										onclick={() => (openProgThemes[theme.id] = !openProgThemes[theme.id])}
+									>
+										{#if openProgThemes[theme.id]}
+											<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+										{:else}
+											<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+										{/if}
+										{theme.name}
+									</button>
+									{#if openProgThemes[theme.id]}
+										<div class="space-y-1 border-t p-2 pl-4">
+											{#each theme.items as item (item.id)}
+												<div>
+													<button
+														class="flex w-full items-center gap-2 py-1 text-left text-sm"
+														onclick={() => (openProgItems[item.id] = !openProgItems[item.id])}
+													>
+														{#if openProgItems[item.id]}
+															<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+														{:else}
+															<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+														{/if}
+														<span class="font-medium">{item.name}</span>
+														<span class="text-xs text-muted-foreground">
+															({item.points.filter((p) => isCovered(p.id)).length}/{item.points
+																.length})
+														</span>
+													</button>
+													{#if openProgItems[item.id]}
+														<div class="space-y-1 py-1 pl-6">
+															{#each item.points as point (point.id)}
+																<MyCheckbox
+																	checked={isCovered(point.id)}
+																	label={point.name}
+																	onchange={() => togglePoint(point)}
+																/>
+															{/each}
+														</div>
+													{/if}
+												</div>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		</div>
+	{/if}
 
 	<!-- Hidden delete form -->
 	{#if isEditing}

--- a/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/cahier-texte/[classId]/[date]/+page.svelte
@@ -20,6 +20,8 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Separator } from '$lib/components/ui/separator';
 	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
+	import MySelect from '$lib/components/MySelect.svelte';
+	import { Badge } from '$lib/components/ui/badge';
 	import RichTextEditor from '$lib/components/rich-text/RichTextEditor.svelte';
 	import ConfirmDialog from '$lib/components/ui/confirm-dialog/ConfirmDialog.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
@@ -35,7 +37,8 @@
 		Calendar,
 		ListTodo,
 		ChevronRight,
-		ChevronDown
+		ChevronDown,
+		Plus
 	} from '@lucide/svelte';
 	import type { PageData, ActionData } from './$types';
 
@@ -118,6 +121,104 @@
 				delete next[point.id];
 				coveredSource = next;
 			}
+		}
+	}
+
+	// --- Activités (5b) -------------------------------------------------------
+	let activities = $state(initialData.activities);
+	let selectedExercise = $state('');
+	let tbLabel = $state('');
+	let courseLabel = $state('');
+
+	function exerciseLabel(id: string | null): string {
+		if (!id) return 'Exercice';
+		return data.exerciseOptions.find((o) => o.value === id)?.label ?? 'Exercice';
+	}
+
+	function activityLabel(a: PageData['activities'][number]): string {
+		if (a.kind === 'exercise') return exerciseLabel(a.exercise_id);
+		if (a.kind === 'textbook')
+			return (a.textbook_ref as { label?: string } | null)?.label ?? 'Référence manuel';
+		return a.label ?? 'Point de cours';
+	}
+
+	function kindShort(kind: string): string {
+		if (kind === 'exercise') return 'Exo';
+		if (kind === 'textbook') return 'Manuel';
+		return 'Cours';
+	}
+
+	async function refreshActivities() {
+		const entryId = data.entry?.id;
+		if (!entryId) return;
+		const res = await fetch(`/api/teacher/curriculum/activities?entry_id=${entryId}`);
+		if (res.ok) activities = (await res.json()).activities ?? [];
+	}
+
+	async function refreshCoverage() {
+		const entryId = data.entry?.id;
+		if (!entryId) return;
+		const res = await fetch(`/api/teacher/curriculum/coverage?entry_id=${entryId}`);
+		if (!res.ok) return;
+		const next: Record<string, string> = {};
+		for (const c of (await res.json()).coverage ?? []) next[c.point_id] = c.source;
+		coveredSource = next;
+	}
+
+	async function addExercise() {
+		const entryId = data.entry?.id;
+		if (!entryId || !selectedExercise) return;
+		const ok = await covApi('/api/teacher/curriculum/activities', 'POST', {
+			entry_id: entryId,
+			kind: 'exercise',
+			exercise_id: selectedExercise
+		});
+		if (ok) {
+			selectedExercise = '';
+			toaster.success('Exercice ajouté');
+			await refreshActivities();
+			await refreshCoverage();
+		}
+	}
+
+	async function addTextbook() {
+		const entryId = data.entry?.id;
+		const label = tbLabel.trim();
+		if (!entryId || !label) return;
+		const ok = await covApi('/api/teacher/curriculum/activities', 'POST', {
+			entry_id: entryId,
+			kind: 'textbook',
+			textbook_ref: { label }
+		});
+		if (ok) {
+			tbLabel = '';
+			toaster.success('Référence ajoutée');
+			await refreshActivities();
+		}
+	}
+
+	async function addCourse() {
+		const entryId = data.entry?.id;
+		const label = courseLabel.trim();
+		if (!entryId || !label) return;
+		const ok = await covApi('/api/teacher/curriculum/activities', 'POST', {
+			entry_id: entryId,
+			kind: 'course',
+			label
+		});
+		if (ok) {
+			courseLabel = '';
+			toaster.success('Point de cours ajouté');
+			await refreshActivities();
+		}
+	}
+
+	async function deleteActivity(a: PageData['activities'][number]) {
+		const ok = await covApi(`/api/teacher/curriculum/activities/${a.id}`, 'DELETE');
+		if (ok) {
+			toaster.success('Activité retirée');
+			await refreshActivities();
+			if (a.kind === 'exercise') await refreshCoverage();
 		}
 	}
 
@@ -417,6 +518,71 @@
 					</Card.Description>
 				</Card.Header>
 				<Card.Content>
+					<!-- Activités de la séance -->
+					<div class="mb-4 space-y-3">
+						<p class="text-sm font-medium">Activités</p>
+						{#if activities.length > 0}
+							<ul class="space-y-1">
+								{#each activities as a (a.id)}
+									<li class="flex items-center gap-2 text-sm">
+										<Badge variant="secondary" class="shrink-0">{kindShort(a.kind)}</Badge>
+										<span class="flex-1 truncate">{activityLabel(a)}</span>
+										<Button variant="ghost" size="sm" onclick={() => deleteActivity(a)}>
+											<Trash2 class="h-4 w-4 text-destructive" />
+										</Button>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+						<div class="space-y-2">
+							{#if data.exerciseOptions.length > 0}
+								<div class="flex gap-2">
+									<MySelect
+										type="single"
+										bind:value={selectedExercise}
+										items={data.exerciseOptions}
+										placeholder="Exercice du système…"
+										triggerClass="flex-1"
+									/>
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={!selectedExercise}
+										onclick={addExercise}
+									>
+										<Plus class="h-4 w-4" />
+									</Button>
+								</div>
+							{/if}
+							<div class="flex gap-2">
+								<Input
+									bind:value={tbLabel}
+									placeholder="Référence manuel (ex. Sésamath p.42 n°12)"
+								/>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={!tbLabel.trim()}
+									onclick={addTextbook}
+								>
+									<Plus class="h-4 w-4" />
+								</Button>
+							</div>
+							<div class="flex gap-2">
+								<Input bind:value={courseLabel} placeholder="Point de cours abordé…" />
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={!courseLabel.trim()}
+									onclick={addCourse}
+								>
+									<Plus class="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					</div>
+					<Separator class="mb-4" />
+
 					{#if data.curriculumTree.length === 0}
 						<p class="text-sm text-muted-foreground">
 							Aucun programme défini pour le niveau de cette classe.
@@ -463,7 +629,9 @@
 															{#each item.points as point (point.id)}
 																<MyCheckbox
 																	checked={isCovered(point.id)}
-																	label={point.name}
+																	label={coveredSource[point.id] === 'auto'
+																		? `${point.name} (auto)`
+																		: point.name}
 																	onchange={() => togglePoint(point)}
 																/>
 															{/each}

--- a/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { error, redirect } from '@sveltejs/kit';
 import { getExercise } from '$lib/server/exercises';
+import { getCurriculumTree, type CurriculumTreeTheme } from '$lib/server/curriculum';
 
 /**
  * Load exercise for editing and view assignments
@@ -34,8 +35,24 @@ export const load: PageServerLoad = async ({ locals, params, fetch }) => {
 		assignmentCount = assignments.length;
 	}
 
+	// Curriculum trees for the exercise's grades + its existing tags (for tagging UI)
+	const grades = (result.data.grades ?? []) as string[];
+	const curriculumByGrade: { grade: string; tree: CurriculumTreeTheme[] }[] = [];
+	for (const g of grades) {
+		const tree = await getCurriculumTree(locals.supabase, g);
+		if (tree.length > 0) curriculumByGrade.push({ grade: g, tree });
+	}
+
+	const { data: tagRows } = await locals.supabase
+		.from('exercise_curriculum_points')
+		.select('point_id')
+		.eq('exercise_id', id);
+	const taggedPointIds = (tagRows ?? []).map((r) => r.point_id);
+
 	return {
 		exercise: result.data,
-		assignmentCount
+		assignmentCount,
+		curriculumByGrade,
+		taggedPointIds
 	};
 };

--- a/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/contenu/exercices/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { browser } from '$app/environment';
 	import ExerciseForm from '$lib/components/exercises/ExerciseForm.svelte';
 	import MySelect from '$lib/components/MySelect.svelte';
+	import MyCheckbox from '$lib/components/MyCheckbox.svelte';
 	import { toaster } from '$lib/stores/toaster.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -23,7 +24,10 @@
 		Clock,
 		Globe,
 		Download,
-		Loader2
+		Loader2,
+		ListTodo,
+		ChevronRight,
+		ChevronDown
 	} from '@lucide/svelte';
 	import { generateExerciseTypst } from '$lib/exercises/typst/exercise-typst-generator';
 	import { getTypstService, PRIORITY } from '$lib/typst/service';
@@ -83,6 +87,63 @@
 	// PDF download state
 	let isPdfLoading = $state(false);
 	let showPdfDialog = $state(false);
+
+	// --- Points de programme (tagging) ---------------------------------------
+	// svelte-ignore state_referenced_locally
+	const initialTaggedIds = data.taggedPointIds;
+	const initialTags: Record<string, boolean> = {};
+	for (const pid of initialTaggedIds) initialTags[pid] = true;
+	let taggedSet = $state<Record<string, boolean>>(initialTags);
+	let openTagThemes = $state<Record<string, boolean>>({});
+	let openTagItems = $state<Record<string, boolean>>({});
+
+	function isTagged(pointId: string): boolean {
+		return taggedSet[pointId] === true;
+	}
+
+	async function tagApi(url: string, method: string, body?: unknown): Promise<boolean> {
+		try {
+			const res = await fetch(url, {
+				method,
+				headers: body ? { 'Content-Type': 'application/json' } : undefined,
+				body: body ? JSON.stringify(body) : undefined
+			});
+			if (!res.ok) {
+				const j = await res.json().catch(() => ({}));
+				toaster.error(j?.error ?? 'Une erreur est survenue');
+				return false;
+			}
+			return true;
+		} catch {
+			toaster.error('Erreur réseau');
+			return false;
+		}
+	}
+
+	async function toggleTag(pointId: string) {
+		const exId = data.exercise.id;
+		if (isTagged(pointId)) {
+			const next = { ...taggedSet };
+			delete next[pointId];
+			taggedSet = next;
+			const ok = await tagApi(
+				`/api/teacher/curriculum/exercise-tags?exercise_id=${exId}&point_id=${pointId}`,
+				'DELETE'
+			);
+			if (!ok) taggedSet = { ...taggedSet, [pointId]: true };
+		} else {
+			taggedSet = { ...taggedSet, [pointId]: true };
+			const ok = await tagApi('/api/teacher/curriculum/exercise-tags', 'POST', {
+				exercise_id: exId,
+				point_id: pointId
+			});
+			if (!ok) {
+				const next = { ...taggedSet };
+				delete next[pointId];
+				taggedSet = next;
+			}
+		}
+	}
 
 	// Expiration options for token creation
 	const expirationOptions = [
@@ -518,6 +579,76 @@
 		{initialVariation}
 		onvariationchange={handleVariationChange}
 	/>
+
+	<!-- Points de programme (tagging → couverture auto dans le cahier de texte) -->
+	{#if data.curriculumByGrade.length > 0}
+		<Card.Root class="mt-6">
+			<Card.Header>
+				<Card.Title class="flex items-center gap-2">
+					<ListTodo class="h-5 w-5 text-primary" />
+					Points de programme
+				</Card.Title>
+				<Card.Description>
+					Tague les points du programme couverts par cet exercice. Quand il est référencé dans une
+					entrée de cahier de texte, ces points sont cochés automatiquement.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				{#each data.curriculumByGrade as { grade, tree } (grade)}
+					{#if data.curriculumByGrade.length > 1}
+						<p class="text-sm font-semibold text-muted-foreground">Niveau {grade}</p>
+					{/if}
+					<div class="space-y-1">
+						{#each tree as theme (theme.id)}
+							<div class="rounded-md border">
+								<button
+									class="flex w-full items-center gap-2 p-2 text-left text-sm font-medium"
+									onclick={() => (openTagThemes[theme.id] = !openTagThemes[theme.id])}
+								>
+									{#if openTagThemes[theme.id]}
+										<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+									{:else}
+										<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+									{/if}
+									{theme.name}
+								</button>
+								{#if openTagThemes[theme.id]}
+									<div class="space-y-1 border-t p-2 pl-4">
+										{#each theme.items as item (item.id)}
+											<div>
+												<button
+													class="flex w-full items-center gap-2 py-1 text-left text-sm"
+													onclick={() => (openTagItems[item.id] = !openTagItems[item.id])}
+												>
+													{#if openTagItems[item.id]}
+														<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+													{:else}
+														<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+													{/if}
+													<span class="font-medium">{item.name}</span>
+												</button>
+												{#if openTagItems[item.id]}
+													<div class="space-y-1 py-1 pl-6">
+														{#each item.points as point (point.id)}
+															<MyCheckbox
+																checked={isTagged(point.id)}
+																label={point.name}
+																onchange={() => toggleTag(point.id)}
+															/>
+														{/each}
+													</div>
+												{/if}
+											</div>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/each}
+			</Card.Content>
+		</Card.Root>
+	{/if}
 </div>
 
 <!-- JSON Debug Dialog -->

--- a/src/routes/(protected)/dashboard/teacher/programme/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/programme/+page.server.ts
@@ -8,9 +8,8 @@
 import type { PageServerLoad } from './$types';
 import { requireRoles } from '$lib/server/middleware/auth';
 import { gradeCodeSchema } from '$lib/server/validation/grades';
-import { THEME_COLS, ITEM_COLS, POINT_COLS } from '$lib/server/curriculum';
+import { getCurriculumTree } from '$lib/server/curriculum';
 import { GRADE_CODES, GRADES } from '$lib/types/grades';
-import type { CurriculumTheme, CurriculumItem, CurriculumPoint } from '$lib/types/database-helpers';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
@@ -18,49 +17,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const rawGrade = url.searchParams.get('grade') ?? '6';
 	const grade = gradeCodeSchema.safeParse(rawGrade).success ? rawGrade : '6';
 
-	const { data: themes } = await locals.supabase
-		.from('curriculum_themes')
-		.select(THEME_COLS)
-		.eq('grade', grade)
-		.order('display_order', { ascending: true })
-		.order('name', { ascending: true });
-
-	const themeList = (themes ?? []) as CurriculumTheme[];
-	const themeIds = themeList.map((t) => t.id);
-
-	let itemList: CurriculumItem[] = [];
-	let pointList: CurriculumPoint[] = [];
-
-	if (themeIds.length > 0) {
-		const { data: items } = await locals.supabase
-			.from('curriculum_items')
-			.select(ITEM_COLS)
-			.in('theme_id', themeIds)
-			.order('display_order', { ascending: true })
-			.order('name', { ascending: true });
-		itemList = (items ?? []) as CurriculumItem[];
-
-		const itemIds = itemList.map((i) => i.id);
-		if (itemIds.length > 0) {
-			const { data: points } = await locals.supabase
-				.from('curriculum_points')
-				.select(POINT_COLS)
-				.in('item_id', itemIds)
-				.order('display_order', { ascending: true })
-				.order('name', { ascending: true });
-			pointList = (points ?? []) as CurriculumPoint[];
-		}
-	}
-
-	const tree = themeList.map((theme) => ({
-		...theme,
-		items: itemList
-			.filter((i) => i.theme_id === theme.id)
-			.map((item) => ({
-				...item,
-				points: pointList.filter((p) => p.item_id === item.id)
-			}))
-	}));
+	const tree = await getCurriculumTree(locals.supabase, grade);
 
 	return {
 		grade,

--- a/src/routes/(protected)/dashboard/teacher/programme/+page.server.ts
+++ b/src/routes/(protected)/dashboard/teacher/programme/+page.server.ts
@@ -1,0 +1,70 @@
+/**
+ * Teacher — Programme (curriculum tree editor) — server load.
+ *
+ * Loads the Thème → Item → Point tree for the selected grade (?grade=, default
+ * '6'). Mutations happen client-side via the /api/teacher/curriculum endpoints.
+ */
+
+import type { PageServerLoad } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { gradeCodeSchema } from '$lib/server/validation/grades';
+import { THEME_COLS, ITEM_COLS, POINT_COLS } from '$lib/server/curriculum';
+import { GRADE_CODES, GRADES } from '$lib/types/grades';
+import type { CurriculumTheme, CurriculumItem, CurriculumPoint } from '$lib/types/database-helpers';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const rawGrade = url.searchParams.get('grade') ?? '6';
+	const grade = gradeCodeSchema.safeParse(rawGrade).success ? rawGrade : '6';
+
+	const { data: themes } = await locals.supabase
+		.from('curriculum_themes')
+		.select(THEME_COLS)
+		.eq('grade', grade)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+
+	const themeList = (themes ?? []) as CurriculumTheme[];
+	const themeIds = themeList.map((t) => t.id);
+
+	let itemList: CurriculumItem[] = [];
+	let pointList: CurriculumPoint[] = [];
+
+	if (themeIds.length > 0) {
+		const { data: items } = await locals.supabase
+			.from('curriculum_items')
+			.select(ITEM_COLS)
+			.in('theme_id', themeIds)
+			.order('display_order', { ascending: true })
+			.order('name', { ascending: true });
+		itemList = (items ?? []) as CurriculumItem[];
+
+		const itemIds = itemList.map((i) => i.id);
+		if (itemIds.length > 0) {
+			const { data: points } = await locals.supabase
+				.from('curriculum_points')
+				.select(POINT_COLS)
+				.in('item_id', itemIds)
+				.order('display_order', { ascending: true })
+				.order('name', { ascending: true });
+			pointList = (points ?? []) as CurriculumPoint[];
+		}
+	}
+
+	const tree = themeList.map((theme) => ({
+		...theme,
+		items: itemList
+			.filter((i) => i.theme_id === theme.id)
+			.map((item) => ({
+				...item,
+				points: pointList.filter((p) => p.item_id === item.id)
+			}))
+	}));
+
+	return {
+		grade,
+		gradeOptions: GRADE_CODES.map((code) => ({ value: code, label: GRADES[code].shortName })),
+		tree
+	};
+};

--- a/src/routes/(protected)/dashboard/teacher/programme/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/programme/+page.svelte
@@ -1,0 +1,457 @@
+<script lang="ts">
+	/**
+	 * Teacher — Programme (curriculum tree editor).
+	 *
+	 * Editable Thème → Item → Point tree for a grade. Mutations go through the
+	 * /api/teacher/curriculum endpoints; the page reloads via invalidateAll().
+	 */
+	import { goto, invalidateAll } from '$app/navigation';
+	import { page } from '$app/state';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import MySelect from '$lib/components/MySelect.svelte';
+	import { toaster } from '$lib/stores/toaster.svelte';
+	import {
+		Plus,
+		Pencil,
+		Trash2,
+		ChevronRight,
+		ChevronDown,
+		ArrowUp,
+		ArrowDown,
+		ListTodo
+	} from '@lucide/svelte';
+	import type { PageData } from './$types';
+
+	type Level = 'theme' | 'item' | 'point';
+	type DialogKind = 'none' | 'connaissance' | 'savoir_faire';
+
+	let { data }: { data: PageData } = $props();
+
+	// --- expansion (keyed by id; $state proxy → reactive) ---------------------
+	let openThemes = $state<Record<string, boolean>>({});
+	let openItems = $state<Record<string, boolean>>({});
+
+	// --- dialog state ---------------------------------------------------------
+	let dialogOpen = $state(false);
+	let dialogMode = $state<'create' | 'edit'>('create');
+	let dialogLevel = $state<Level>('theme');
+	let dialogName = $state('');
+	let dialogKind = $state<DialogKind>('none');
+	/** Edit: id of the node. Create: id of the parent ('' for a theme). */
+	let dialogTargetId = $state('');
+	let busy = $state(false);
+
+	const kindItems = [
+		{ value: 'none', label: '— non précisé' },
+		{ value: 'connaissance', label: 'Connaissance' },
+		{ value: 'savoir_faire', label: 'Savoir-faire' }
+	];
+
+	const dialogTitle = $derived.by(() => {
+		const noun = dialogLevel === 'theme' ? 'thème' : dialogLevel === 'item' ? 'item' : 'point';
+		if (dialogMode === 'create') return `Nouveau ${noun}`;
+		return `Modifier le ${noun}`;
+	});
+
+	function basePath(level: Level): string {
+		return level === 'theme' ? 'themes' : level === 'item' ? 'items' : 'points';
+	}
+
+	function kindLabel(kind: string | null): string | null {
+		if (kind === 'connaissance') return 'connaissance';
+		if (kind === 'savoir_faire') return 'savoir-faire';
+		return null;
+	}
+
+	function pointCount(theme: PageData['tree'][number]): number {
+		return theme.items.reduce((sum, i) => sum + i.points.length, 0);
+	}
+
+	// --- API helper -----------------------------------------------------------
+	async function api(url: string, method: string, body?: unknown): Promise<boolean> {
+		busy = true;
+		try {
+			const res = await fetch(url, {
+				method,
+				headers: body ? { 'Content-Type': 'application/json' } : undefined,
+				body: body ? JSON.stringify(body) : undefined
+			});
+			const json = await res.json().catch(() => ({}));
+			if (!res.ok) {
+				toaster.error(json?.error ?? 'Une erreur est survenue');
+				return false;
+			}
+			return true;
+		} catch {
+			toaster.error('Erreur réseau');
+			return false;
+		} finally {
+			busy = false;
+		}
+	}
+
+	// --- grade ----------------------------------------------------------------
+	function changeGrade(value: string | string[]) {
+		if (typeof value !== 'string') return;
+		// Query-only navigation on the same route → reloads the server load.
+		// (resolve() can't carry a query string; this mirrors the existing goto('?') usage.)
+		const url = new URL(page.url);
+		url.searchParams.set('grade', value);
+		goto(url, { keepFocus: true, noScroll: true });
+	}
+
+	// --- dialog openers -------------------------------------------------------
+	function openCreate(level: Level, parentId = '') {
+		dialogMode = 'create';
+		dialogLevel = level;
+		dialogTargetId = parentId;
+		dialogName = '';
+		dialogKind = 'none';
+		dialogOpen = true;
+	}
+
+	function openEdit(level: Level, node: { id: string; name: string; kind?: string | null }) {
+		dialogMode = 'edit';
+		dialogLevel = level;
+		dialogTargetId = node.id;
+		dialogName = node.name;
+		dialogKind = (node.kind as DialogKind) ?? 'none';
+		dialogOpen = true;
+	}
+
+	// --- submit (create / edit) ----------------------------------------------
+	async function submitDialog() {
+		const name = dialogName.trim();
+		if (!name) {
+			toaster.error('Le nom ne peut pas être vide');
+			return;
+		}
+		const kind = dialogKind === 'none' ? null : dialogKind;
+		let ok = false;
+
+		if (dialogMode === 'create') {
+			if (dialogLevel === 'theme') {
+				ok = await api('/api/teacher/curriculum/themes', 'POST', { grade: data.grade, name });
+			} else if (dialogLevel === 'item') {
+				ok = await api('/api/teacher/curriculum/items', 'POST', {
+					theme_id: dialogTargetId,
+					name
+				});
+				if (ok) openThemes[dialogTargetId] = true;
+			} else {
+				ok = await api('/api/teacher/curriculum/points', 'POST', {
+					item_id: dialogTargetId,
+					name,
+					kind
+				});
+				if (ok) openItems[dialogTargetId] = true;
+			}
+		} else {
+			const url = `/api/teacher/curriculum/${basePath(dialogLevel)}/${dialogTargetId}`;
+			const payload = dialogLevel === 'point' ? { name, kind } : { name };
+			ok = await api(url, 'PATCH', payload);
+		}
+
+		if (ok) {
+			dialogOpen = false;
+			toaster.success(dialogMode === 'create' ? 'Ajouté' : 'Modifié');
+			await invalidateAll();
+		}
+	}
+
+	// --- delete ---------------------------------------------------------------
+	async function deleteNode(level: Level, node: { id: string; name: string }) {
+		const warn =
+			level === 'theme'
+				? '\n\nTous ses items et points seront aussi supprimés.'
+				: level === 'item'
+					? '\n\nTous ses points seront aussi supprimés.'
+					: '';
+		if (!confirm(`Supprimer « ${node.name} » ?${warn}`)) return;
+		const ok = await api(`/api/teacher/curriculum/${basePath(level)}/${node.id}`, 'DELETE');
+		if (ok) {
+			toaster.success('Supprimé');
+			await invalidateAll();
+		}
+	}
+
+	// --- reorder (swap display_order with neighbour) --------------------------
+	async function reorder(
+		level: Level,
+		list: { id: string; display_order: number }[],
+		index: number,
+		dir: 'up' | 'down'
+	) {
+		const target = index + (dir === 'up' ? -1 : 1);
+		if (target < 0 || target >= list.length) return;
+		const a = list[index];
+		const b = list[target];
+		const path = (id: string) => `/api/teacher/curriculum/${basePath(level)}/${id}`;
+		const ok1 = await api(path(a.id), 'PATCH', { display_order: b.display_order });
+		if (!ok1) return;
+		const ok2 = await api(path(b.id), 'PATCH', { display_order: a.display_order });
+		if (ok2) await invalidateAll();
+	}
+</script>
+
+<svelte:head><title>Programme | UbuMaths</title></svelte:head>
+
+<div class="container mx-auto max-w-4xl space-y-6 p-4">
+	<!-- Header -->
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div class="flex items-center gap-3">
+			<div class="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10">
+				<ListTodo class="h-6 w-6 text-primary" />
+			</div>
+			<div>
+				<h1 class="text-2xl font-bold tracking-tight">Programme</h1>
+				<p class="text-sm text-muted-foreground">
+					Référentiel de suivi — thèmes, items et points par niveau.
+				</p>
+			</div>
+		</div>
+		<div class="flex items-center gap-2">
+			<MySelect
+				type="single"
+				value={data.grade}
+				items={data.gradeOptions}
+				onValueChange={changeGrade}
+				triggerClass="w-28"
+			/>
+			<Button size="sm" disabled={busy} onclick={() => openCreate('theme')}>
+				<Plus class="mr-1 h-4 w-4" /> Thème
+			</Button>
+		</div>
+	</div>
+
+	<!-- Tree -->
+	{#if data.tree.length === 0}
+		<div class="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+			Aucun thème pour ce niveau. Créez le premier avec « + Thème ».
+		</div>
+	{:else}
+		<div class="space-y-2">
+			{#each data.tree as theme, ti (theme.id)}
+				<div class="rounded-lg border bg-card">
+					<!-- Theme row -->
+					<div class="flex items-center gap-2 p-2">
+						<button
+							class="flex flex-1 items-center gap-2 text-left"
+							onclick={() => (openThemes[theme.id] = !openThemes[theme.id])}
+						>
+							{#if openThemes[theme.id]}
+								<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{:else}
+								<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{/if}
+							<span class="font-semibold">{theme.name}</span>
+							<span class="text-xs text-muted-foreground">
+								{theme.items.length} items · {pointCount(theme)} points
+							</span>
+						</button>
+						<div class="flex items-center gap-1">
+							<Button
+								variant="ghost"
+								size="sm"
+								disabled={busy || ti === 0}
+								onclick={() => reorder('theme', data.tree, ti, 'up')}
+							>
+								<ArrowUp class="h-4 w-4" />
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
+								disabled={busy || ti === data.tree.length - 1}
+								onclick={() => reorder('theme', data.tree, ti, 'down')}
+							>
+								<ArrowDown class="h-4 w-4" />
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
+								disabled={busy}
+								onclick={() => openEdit('theme', theme)}
+							>
+								<Pencil class="h-4 w-4" />
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
+								disabled={busy}
+								onclick={() => deleteNode('theme', theme)}
+							>
+								<Trash2 class="h-4 w-4 text-destructive" />
+							</Button>
+						</div>
+					</div>
+
+					<!-- Items -->
+					{#if openThemes[theme.id]}
+						<div class="space-y-1 border-t bg-muted/30 p-2 pl-6">
+							{#each theme.items as item, ii (item.id)}
+								<div class="rounded-md border bg-card">
+									<div class="flex items-center gap-2 p-2">
+										<button
+											class="flex flex-1 items-center gap-2 text-left"
+											onclick={() => (openItems[item.id] = !openItems[item.id])}
+										>
+											{#if openItems[item.id]}
+												<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+											{:else}
+												<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+											{/if}
+											<span class="font-medium">{item.name}</span>
+											<span class="text-xs text-muted-foreground">{item.points.length} points</span>
+										</button>
+										<div class="flex items-center gap-1">
+											<Button
+												variant="ghost"
+												size="sm"
+												disabled={busy || ii === 0}
+												onclick={() => reorder('item', theme.items, ii, 'up')}
+											>
+												<ArrowUp class="h-4 w-4" />
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												disabled={busy || ii === theme.items.length - 1}
+												onclick={() => reorder('item', theme.items, ii, 'down')}
+											>
+												<ArrowDown class="h-4 w-4" />
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												disabled={busy}
+												onclick={() => openEdit('item', item)}
+											>
+												<Pencil class="h-4 w-4" />
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												disabled={busy}
+												onclick={() => deleteNode('item', item)}
+											>
+												<Trash2 class="h-4 w-4 text-destructive" />
+											</Button>
+										</div>
+									</div>
+
+									<!-- Points -->
+									{#if openItems[item.id]}
+										<div class="space-y-1 border-t p-2 pl-6">
+											{#each item.points as point, pi (point.id)}
+												<div class="flex items-center gap-2 rounded px-1 py-1 hover:bg-muted/50">
+													<span class="flex-1 text-sm">
+														{point.name}
+														{#if kindLabel(point.kind)}
+															<Badge variant="outline" class="ml-2 align-middle text-[10px]">
+																{kindLabel(point.kind)}
+															</Badge>
+														{/if}
+													</span>
+													<div class="flex items-center gap-1">
+														<Button
+															variant="ghost"
+															size="sm"
+															disabled={busy || pi === 0}
+															onclick={() => reorder('point', item.points, pi, 'up')}
+														>
+															<ArrowUp class="h-4 w-4" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="sm"
+															disabled={busy || pi === item.points.length - 1}
+															onclick={() => reorder('point', item.points, pi, 'down')}
+														>
+															<ArrowDown class="h-4 w-4" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="sm"
+															disabled={busy}
+															onclick={() => openEdit('point', point)}
+														>
+															<Pencil class="h-4 w-4" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="sm"
+															disabled={busy}
+															onclick={() => deleteNode('point', point)}
+														>
+															<Trash2 class="h-4 w-4 text-destructive" />
+														</Button>
+													</div>
+												</div>
+											{/each}
+											<Button
+												variant="ghost"
+												size="sm"
+												class="mt-1"
+												disabled={busy}
+												onclick={() => openCreate('point', item.id)}
+											>
+												<Plus class="mr-1 h-4 w-4" /> Point
+											</Button>
+										</div>
+									{/if}
+								</div>
+							{/each}
+							<Button
+								variant="ghost"
+								size="sm"
+								class="mt-1"
+								disabled={busy}
+								onclick={() => openCreate('item', theme.id)}
+							>
+								<Plus class="mr-1 h-4 w-4" /> Item
+							</Button>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<!-- Create / edit dialog -->
+<Dialog.Root bind:open={dialogOpen}>
+	<Dialog.Content class="max-w-lg">
+		<Dialog.Header>
+			<Dialog.Title>{dialogTitle}</Dialog.Title>
+		</Dialog.Header>
+		<form
+			class="space-y-4"
+			onsubmit={(e) => {
+				e.preventDefault();
+				submitDialog();
+			}}
+		>
+			<div class="space-y-2">
+				<Label for="curriculum-name">Nom</Label>
+				<Input id="curriculum-name" bind:value={dialogName} placeholder="Intitulé…" autofocus />
+			</div>
+			{#if dialogLevel === 'point'}
+				<div class="space-y-2">
+					<Label>Type</Label>
+					<MySelect type="single" bind:value={dialogKind} items={kindItems} triggerClass="w-full" />
+				</div>
+			{/if}
+			<Dialog.Footer>
+				<Button type="button" variant="outline" onclick={() => (dialogOpen = false)}>Annuler</Button
+				>
+				<Button type="submit" disabled={busy}>
+					{dialogMode === 'create' ? 'Ajouter' : 'Enregistrer'}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/routes/api/teacher/curriculum/activities/+server.ts
+++ b/src/routes/api/teacher/curriculum/activities/+server.ts
@@ -1,0 +1,101 @@
+/**
+ * API — Journal entry activities (cahier de texte).
+ *
+ * GET  /api/teacher/curriculum/activities?entry_id=<uuid>   — list activities of an entry
+ * POST /api/teacher/curriculum/activities                   — add an activity (3 kinds)
+ *
+ * Adding an 'exercise' activity reconciles the entry's AUTO coverage from the
+ * exercise's curriculum tags. Teacher/admin only.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { createActivitySchema, activityListQuerySchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError } from '$lib/server/curriculum';
+import { reconcileAutoCoverage } from '$lib/server/curriculum-coverage';
+import type { JournalEntryActivity } from '$lib/types/database-helpers';
+
+const ACTIVITY_COLS =
+	'id, entry_id, kind, exercise_id, chapter_id, textbook_ref, label, display_order, created_at';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = activityListQuerySchema.safeParse({ entry_id: url.searchParams.get('entry_id') });
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('journal_entry_activities' as never)
+		.select(ACTIVITY_COLS)
+		.eq('entry_id', parsed.data.entry_id)
+		.order('display_order', { ascending: true })
+		.order('created_at', { ascending: true });
+
+	if (dbErr) {
+		console.error('[curriculum] activities GET failed:', dbErr);
+		return json({ error: 'Échec du chargement des activités' }, { status: 500 });
+	}
+
+	return json({ activities: (data ?? []) as JournalEntryActivity[] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = createActivitySchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+	const input = parsed.data;
+
+	// Build the insert row per kind (columns not relevant to the kind stay null).
+	const row: Record<string, unknown> = {
+		entry_id: input.entry_id,
+		kind: input.kind,
+		display_order: input.display_order ?? 0
+	};
+	if (input.kind === 'exercise') {
+		row.exercise_id = input.exercise_id;
+	} else if (input.kind === 'course') {
+		row.chapter_id = input.chapter_id ?? null;
+		row.label = input.label ?? null;
+	} else {
+		row.textbook_ref = input.textbook_ref;
+		row.label = input.textbook_ref.label;
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('journal_entry_activities' as never)
+		.insert(row as never)
+		.select(ACTIVITY_COLS)
+		.single();
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] activities POST failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	// Exercise activity → refresh auto coverage of the entry.
+	if (input.kind === 'exercise') {
+		try {
+			await reconcileAutoCoverage(locals.supabase, input.entry_id);
+		} catch (e) {
+			console.error('[curriculum] reconcile after activity POST failed:', e);
+			// activity is created; coverage will re-reconcile on next change.
+		}
+	}
+
+	return json({ activity: data as JournalEntryActivity }, { status: 201 });
+};

--- a/src/routes/api/teacher/curriculum/activities/+server.ts
+++ b/src/routes/api/teacher/curriculum/activities/+server.ts
@@ -15,6 +15,7 @@ import { createActivitySchema, activityListQuerySchema } from '$lib/server/valid
 import { curriculumDbError } from '$lib/server/curriculum';
 import { reconcileAutoCoverage } from '$lib/server/curriculum-coverage';
 import type { JournalEntryActivity } from '$lib/types/database-helpers';
+import type { TablesInsert } from '$lib/types/database';
 
 const ACTIVITY_COLS =
 	'id, entry_id, kind, exercise_id, chapter_id, textbook_ref, label, display_order, created_at';
@@ -28,7 +29,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('journal_entry_activities' as never)
+		.from('journal_entry_activities')
 		.select(ACTIVITY_COLS)
 		.eq('entry_id', parsed.data.entry_id)
 		.order('display_order', { ascending: true })
@@ -75,8 +76,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('journal_entry_activities' as never)
-		.insert(row as never)
+		.from('journal_entry_activities')
+		.insert(row as TablesInsert<'journal_entry_activities'>)
 		.select(ACTIVITY_COLS)
 		.single();
 

--- a/src/routes/api/teacher/curriculum/activities/[activityId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/activities/[activityId]/+server.ts
@@ -1,0 +1,58 @@
+/**
+ * API — Journal entry activity — delete.
+ *
+ * DELETE /api/teacher/curriculum/activities/[activityId]
+ *
+ * Removing an 'exercise' activity reconciles the entry's AUTO coverage
+ * (auto points no longer backed by any exercise are dropped; manual rows kept).
+ * Teacher/admin only.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { curriculumDbError } from '$lib/server/curriculum';
+import { reconcileAutoCoverage } from '$lib/server/curriculum-coverage';
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	// Fetch entry_id + kind first (needed to reconcile after delete).
+	const { data: activity, error: fetchErr } = await locals.supabase
+		.from('journal_entry_activities' as never)
+		.select('entry_id, kind')
+		.eq('id', params.activityId)
+		.maybeSingle();
+
+	if (fetchErr) {
+		console.error('[curriculum] activity fetch (DELETE) failed:', fetchErr);
+		return json({ error: 'Échec de la suppression' }, { status: 500 });
+	}
+	if (!activity) {
+		return json({ error: 'Activité introuvable' }, { status: 404 });
+	}
+
+	const { entry_id, kind } = activity as { entry_id: string; kind: string };
+
+	const { error: dbErr } = await locals.supabase
+		.from('journal_entry_activities' as never)
+		.delete()
+		.eq('id', params.activityId);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] activity DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	if (kind === 'exercise') {
+		try {
+			await reconcileAutoCoverage(locals.supabase, entry_id);
+		} catch (e) {
+			console.error('[curriculum] reconcile after activity DELETE failed:', e);
+		}
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/api/teacher/curriculum/activities/[activityId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/activities/[activityId]/+server.ts
@@ -19,7 +19,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 
 	// Fetch entry_id + kind first (needed to reconcile after delete).
 	const { data: activity, error: fetchErr } = await locals.supabase
-		.from('journal_entry_activities' as never)
+		.from('journal_entry_activities')
 		.select('entry_id, kind')
 		.eq('id', params.activityId)
 		.maybeSingle();
@@ -35,7 +35,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	const { entry_id, kind } = activity as { entry_id: string; kind: string };
 
 	const { error: dbErr } = await locals.supabase
-		.from('journal_entry_activities' as never)
+		.from('journal_entry_activities')
 		.delete()
 		.eq('id', params.activityId);
 

--- a/src/routes/api/teacher/curriculum/coverage/+server.ts
+++ b/src/routes/api/teacher/curriculum/coverage/+server.ts
@@ -1,0 +1,123 @@
+/**
+ * API — Journal entry coverage (curriculum points worked on in an entry).
+ *
+ * GET    /api/teacher/curriculum/coverage?entry_id=<uuid>          — list covered points (+ source)
+ * POST   /api/teacher/curriculum/coverage                          — manually check a point
+ * DELETE /api/teacher/curriculum/coverage?entry_id=&point_id=      — uncheck a point (any source)
+ *
+ * Auto points are managed by reconciliation (see curriculum-coverage.ts); this
+ * endpoint manages the teacher's manual checks/unchecks. Teacher/admin only.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import {
+	coveragePointSchema,
+	coverageListQuerySchema,
+	coveragePointQuerySchema
+} from '$lib/server/validation/curriculum';
+import { curriculumDbError } from '$lib/server/curriculum';
+import type { JournalEntryPoint } from '$lib/types/database-helpers';
+
+const COVERAGE_COLS = 'id, entry_id, point_id, source, created_at';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = coverageListQuerySchema.safeParse({ entry_id: url.searchParams.get('entry_id') });
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('journal_entry_points' as never)
+		.select(COVERAGE_COLS)
+		.eq('entry_id', parsed.data.entry_id);
+
+	if (dbErr) {
+		console.error('[curriculum] coverage GET failed:', dbErr);
+		return json({ error: 'Échec du chargement de la couverture' }, { status: 500 });
+	}
+
+	return json({ coverage: (data ?? []) as JournalEntryPoint[] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = coveragePointSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('journal_entry_points' as never)
+		.insert({
+			entry_id: parsed.data.entry_id,
+			point_id: parsed.data.point_id,
+			source: 'manual'
+		} as never)
+		.select(COVERAGE_COLS)
+		.single();
+
+	if (dbErr) {
+		// 23505 = point already covered for this entry. A manual check must WIN
+		// over an existing auto row (otherwise the teacher's choice would be
+		// dropped on the next reconcile). Promote the row to source='manual'.
+		if (dbErr.code === '23505') {
+			const { data: promoted, error: upErr } = await locals.supabase
+				.from('journal_entry_points' as never)
+				.update({ source: 'manual' } as never)
+				.eq('entry_id', parsed.data.entry_id)
+				.eq('point_id', parsed.data.point_id)
+				.select(COVERAGE_COLS)
+				.single();
+			if (upErr) {
+				console.error('[curriculum] coverage POST promote failed:', upErr);
+				return json({ error: 'Erreur serveur' }, { status: 500 });
+			}
+			return json({ coverage: promoted as JournalEntryPoint, promoted: true });
+		}
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] coverage POST failed:', dbErr);
+		return json({ error: 'Erreur serveur' }, { status: 500 });
+	}
+
+	return json({ coverage: data as JournalEntryPoint }, { status: 201 });
+};
+
+export const DELETE: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = coveragePointQuerySchema.safeParse({
+		entry_id: url.searchParams.get('entry_id'),
+		point_id: url.searchParams.get('point_id')
+	});
+	if (!parsed.success) {
+		return json({ error: 'entry_id et point_id requis (UUID)' }, { status: 400 });
+	}
+
+	const { error: dbErr } = await locals.supabase
+		.from('journal_entry_points' as never)
+		.delete()
+		.eq('entry_id', parsed.data.entry_id)
+		.eq('point_id', parsed.data.point_id);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] coverage DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/api/teacher/curriculum/coverage/+server.ts
+++ b/src/routes/api/teacher/curriculum/coverage/+server.ts
@@ -31,7 +31,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('journal_entry_points' as never)
+		.from('journal_entry_points')
 		.select(COVERAGE_COLS)
 		.eq('entry_id', parsed.data.entry_id);
 
@@ -59,12 +59,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('journal_entry_points' as never)
+		.from('journal_entry_points')
 		.insert({
 			entry_id: parsed.data.entry_id,
 			point_id: parsed.data.point_id,
 			source: 'manual'
-		} as never)
+		})
 		.select(COVERAGE_COLS)
 		.single();
 
@@ -74,8 +74,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		// dropped on the next reconcile). Promote the row to source='manual'.
 		if (dbErr.code === '23505') {
 			const { data: promoted, error: upErr } = await locals.supabase
-				.from('journal_entry_points' as never)
-				.update({ source: 'manual' } as never)
+				.from('journal_entry_points')
+				.update({ source: 'manual' })
 				.eq('entry_id', parsed.data.entry_id)
 				.eq('point_id', parsed.data.point_id)
 				.select(COVERAGE_COLS)
@@ -107,7 +107,7 @@ export const DELETE: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { error: dbErr } = await locals.supabase
-		.from('journal_entry_points' as never)
+		.from('journal_entry_points')
 		.delete()
 		.eq('entry_id', parsed.data.entry_id)
 		.eq('point_id', parsed.data.point_id);

--- a/src/routes/api/teacher/curriculum/exercise-tags/+server.ts
+++ b/src/routes/api/teacher/curriculum/exercise-tags/+server.ts
@@ -26,7 +26,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('exercise_curriculum_points' as never)
+		.from('exercise_curriculum_points')
 		.select('exercise_id, point_id, created_at')
 		.eq('exercise_id', parsed.data.exercise_id);
 
@@ -54,8 +54,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { error: dbErr } = await locals.supabase
-		.from('exercise_curriculum_points' as never)
-		.insert({ exercise_id: parsed.data.exercise_id, point_id: parsed.data.point_id } as never);
+		.from('exercise_curriculum_points')
+		.insert({ exercise_id: parsed.data.exercise_id, point_id: parsed.data.point_id });
 
 	if (dbErr) {
 		// 23505 = already tagged → idempotent success
@@ -83,7 +83,7 @@ export const DELETE: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { error: dbErr } = await locals.supabase
-		.from('exercise_curriculum_points' as never)
+		.from('exercise_curriculum_points')
 		.delete()
 		.eq('exercise_id', parsed.data.exercise_id)
 		.eq('point_id', parsed.data.point_id);

--- a/src/routes/api/teacher/curriculum/exercise-tags/+server.ts
+++ b/src/routes/api/teacher/curriculum/exercise-tags/+server.ts
@@ -1,0 +1,99 @@
+/**
+ * API — Exercise ↔ curriculum point tagging.
+ *
+ * GET    /api/teacher/curriculum/exercise-tags?exercise_id=<uuid>  — points tagged on an exercise
+ * POST   /api/teacher/curriculum/exercise-tags                     — tag (exercise_id, point_id)
+ * DELETE /api/teacher/curriculum/exercise-tags?exercise_id=&point_id=  — untag
+ *
+ * Tagging an exercise drives auto coverage when the exercise is referenced
+ * in a cahier de texte entry. Teacher/admin only.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { exerciseTagSchema, exerciseTagListQuerySchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError } from '$lib/server/curriculum';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = exerciseTagListQuerySchema.safeParse({
+		exercise_id: url.searchParams.get('exercise_id')
+	});
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('exercise_curriculum_points' as never)
+		.select('exercise_id, point_id, created_at')
+		.eq('exercise_id', parsed.data.exercise_id);
+
+	if (dbErr) {
+		console.error('[curriculum] exercise-tags GET failed:', dbErr);
+		return json({ error: 'Échec du chargement des tags' }, { status: 500 });
+	}
+
+	return json({ tags: data ?? [] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = exerciseTagSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { error: dbErr } = await locals.supabase
+		.from('exercise_curriculum_points' as never)
+		.insert({ exercise_id: parsed.data.exercise_id, point_id: parsed.data.point_id } as never);
+
+	if (dbErr) {
+		// 23505 = already tagged → idempotent success
+		if (dbErr.code === '23505') {
+			return json({ success: true, alreadyTagged: true });
+		}
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] exercise-tags POST failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true }, { status: 201 });
+};
+
+export const DELETE: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = exerciseTagSchema.safeParse({
+		exercise_id: url.searchParams.get('exercise_id'),
+		point_id: url.searchParams.get('point_id')
+	});
+	if (!parsed.success) {
+		return json({ error: 'exercise_id et point_id requis (UUID)' }, { status: 400 });
+	}
+
+	const { error: dbErr } = await locals.supabase
+		.from('exercise_curriculum_points' as never)
+		.delete()
+		.eq('exercise_id', parsed.data.exercise_id)
+		.eq('point_id', parsed.data.point_id);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] exercise-tags DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/api/teacher/curriculum/items/+server.ts
+++ b/src/routes/api/teacher/curriculum/items/+server.ts
@@ -1,0 +1,73 @@
+/**
+ * API — Curriculum items (level 2).
+ *
+ * GET  /api/teacher/curriculum/items?theme_id=<uuid>   — list items of a theme
+ * POST /api/teacher/curriculum/items                   — create an item
+ *
+ * Teacher/admin only (RLS also enforces is_teacher_or_admin()).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { createItemSchema, itemListQuerySchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, ITEM_COLS } from '$lib/server/curriculum';
+import type { CurriculumItem } from '$lib/types/database-helpers';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = itemListQuerySchema.safeParse({ theme_id: url.searchParams.get('theme_id') });
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_items' as never)
+		.select(ITEM_COLS)
+		.eq('theme_id', parsed.data.theme_id)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+
+	if (dbErr) {
+		console.error('[curriculum] items GET failed:', dbErr);
+		return json({ error: 'Échec du chargement des items' }, { status: 500 });
+	}
+
+	return json({ items: (data ?? []) as CurriculumItem[] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = createItemSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_items' as never)
+		.insert({
+			theme_id: parsed.data.theme_id,
+			name: parsed.data.name,
+			display_order: parsed.data.display_order ?? 0
+		} as never)
+		.select(ITEM_COLS)
+		.single();
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr, 'Un item de ce nom existe déjà dans ce thème');
+		if (mapped) return mapped;
+		console.error('[curriculum] items POST failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ item: data as CurriculumItem }, { status: 201 });
+};

--- a/src/routes/api/teacher/curriculum/items/+server.ts
+++ b/src/routes/api/teacher/curriculum/items/+server.ts
@@ -23,7 +23,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_items' as never)
+		.from('curriculum_items')
 		.select(ITEM_COLS)
 		.eq('theme_id', parsed.data.theme_id)
 		.order('display_order', { ascending: true })
@@ -53,12 +53,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_items' as never)
+		.from('curriculum_items')
 		.insert({
 			theme_id: parsed.data.theme_id,
 			name: parsed.data.name,
 			display_order: parsed.data.display_order ?? 0
-		} as never)
+		})
 		.select(ITEM_COLS)
 		.single();
 

--- a/src/routes/api/teacher/curriculum/items/[itemId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/items/[itemId]/+server.ts
@@ -1,0 +1,72 @@
+/**
+ * API — Curriculum item (level 2) — update & delete.
+ *
+ * PATCH  /api/teacher/curriculum/items/[itemId]   — rename / reorder
+ * DELETE /api/teacher/curriculum/items/[itemId]   — delete (cascade points)
+ *
+ * Teacher/admin only (RLS also enforces is_teacher_or_admin()).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { updateItemSchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, ITEM_COLS } from '$lib/server/curriculum';
+import type { CurriculumItem } from '$lib/types/database-helpers';
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = updateItemSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const updates: Record<string, unknown> = {};
+	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_items' as never)
+		.update(updates as never)
+		.eq('id', params.itemId)
+		.select(ITEM_COLS)
+		.single();
+
+	if (dbErr) {
+		if (dbErr.code === 'PGRST116') {
+			return json({ error: 'Item introuvable' }, { status: 404 });
+		}
+		const mapped = curriculumDbError(dbErr, 'Un item de ce nom existe déjà dans ce thème');
+		if (mapped) return mapped;
+		console.error('[curriculum] item PATCH failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ item: data as CurriculumItem });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const { error: dbErr } = await locals.supabase
+		.from('curriculum_items' as never)
+		.delete()
+		.eq('id', params.itemId);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] item DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/api/teacher/curriculum/items/[itemId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/items/[itemId]/+server.ts
@@ -13,6 +13,7 @@ import { requireRoles } from '$lib/server/middleware/auth';
 import { updateItemSchema } from '$lib/server/validation/curriculum';
 import { curriculumDbError, ITEM_COLS } from '$lib/server/curriculum';
 import type { CurriculumItem } from '$lib/types/database-helpers';
+import type { TablesUpdate } from '$lib/types/database';
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
@@ -29,13 +30,13 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		return json({ error: parsed.error.issues[0].message }, { status: 400 });
 	}
 
-	const updates: Record<string, unknown> = {};
+	const updates: TablesUpdate<'curriculum_items'> = {};
 	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
 	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_items' as never)
-		.update(updates as never)
+		.from('curriculum_items')
+		.update(updates)
 		.eq('id', params.itemId)
 		.select(ITEM_COLS)
 		.single();
@@ -57,7 +58,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
 
 	const { error: dbErr } = await locals.supabase
-		.from('curriculum_items' as never)
+		.from('curriculum_items')
 		.delete()
 		.eq('id', params.itemId);
 

--- a/src/routes/api/teacher/curriculum/points/+server.ts
+++ b/src/routes/api/teacher/curriculum/points/+server.ts
@@ -1,0 +1,74 @@
+/**
+ * API — Curriculum points (level 3, tracking grain).
+ *
+ * GET  /api/teacher/curriculum/points?item_id=<uuid>   — list points of an item
+ * POST /api/teacher/curriculum/points                  — create a point
+ *
+ * Teacher/admin only (RLS also enforces is_teacher_or_admin()).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { createPointSchema, pointListQuerySchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, POINT_COLS } from '$lib/server/curriculum';
+import type { CurriculumPoint } from '$lib/types/database-helpers';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = pointListQuerySchema.safeParse({ item_id: url.searchParams.get('item_id') });
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_points' as never)
+		.select(POINT_COLS)
+		.eq('item_id', parsed.data.item_id)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+
+	if (dbErr) {
+		console.error('[curriculum] points GET failed:', dbErr);
+		return json({ error: 'Échec du chargement des points' }, { status: 500 });
+	}
+
+	return json({ points: (data ?? []) as CurriculumPoint[] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = createPointSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_points' as never)
+		.insert({
+			item_id: parsed.data.item_id,
+			name: parsed.data.name,
+			display_order: parsed.data.display_order ?? 0,
+			kind: parsed.data.kind ?? null
+		} as never)
+		.select(POINT_COLS)
+		.single();
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr, 'Un point de ce nom existe déjà dans cet item');
+		if (mapped) return mapped;
+		console.error('[curriculum] points POST failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ point: data as CurriculumPoint }, { status: 201 });
+};

--- a/src/routes/api/teacher/curriculum/points/+server.ts
+++ b/src/routes/api/teacher/curriculum/points/+server.ts
@@ -23,7 +23,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_points' as never)
+		.from('curriculum_points')
 		.select(POINT_COLS)
 		.eq('item_id', parsed.data.item_id)
 		.order('display_order', { ascending: true })
@@ -53,13 +53,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_points' as never)
+		.from('curriculum_points')
 		.insert({
 			item_id: parsed.data.item_id,
 			name: parsed.data.name,
 			display_order: parsed.data.display_order ?? 0,
 			kind: parsed.data.kind ?? null
-		} as never)
+		})
 		.select(POINT_COLS)
 		.single();
 

--- a/src/routes/api/teacher/curriculum/points/[pointId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/points/[pointId]/+server.ts
@@ -14,6 +14,7 @@ import { requireRoles } from '$lib/server/middleware/auth';
 import { updatePointSchema } from '$lib/server/validation/curriculum';
 import { curriculumDbError, POINT_COLS } from '$lib/server/curriculum';
 import type { CurriculumPoint } from '$lib/types/database-helpers';
+import type { TablesUpdate } from '$lib/types/database';
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
@@ -30,7 +31,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		return json({ error: parsed.error.issues[0].message }, { status: 400 });
 	}
 
-	const updates: Record<string, unknown> = {};
+	const updates: TablesUpdate<'curriculum_points'> = {};
 	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
 	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
 	if (parsed.data.kind !== undefined) updates.kind = parsed.data.kind;
@@ -39,8 +40,8 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_points' as never)
-		.update(updates as never)
+		.from('curriculum_points')
+		.update(updates)
 		.eq('id', params.pointId)
 		.select(POINT_COLS)
 		.single();
@@ -62,7 +63,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
 
 	const { error: dbErr } = await locals.supabase
-		.from('curriculum_points' as never)
+		.from('curriculum_points')
 		.delete()
 		.eq('id', params.pointId);
 

--- a/src/routes/api/teacher/curriculum/points/[pointId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/points/[pointId]/+server.ts
@@ -1,0 +1,77 @@
+/**
+ * API — Curriculum point (level 3) — update, archive & delete.
+ *
+ * PATCH  /api/teacher/curriculum/points/[pointId]   — rename / reorder / kind / archive
+ * DELETE /api/teacher/curriculum/points/[pointId]   — hard delete (cascade coverage)
+ *
+ * Soft-archive (`archived: true`) is preferred over hard delete when a point
+ * already has coverage history. Teacher/admin only.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { updatePointSchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, POINT_COLS } from '$lib/server/curriculum';
+import type { CurriculumPoint } from '$lib/types/database-helpers';
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = updatePointSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const updates: Record<string, unknown> = {};
+	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
+	if (parsed.data.kind !== undefined) updates.kind = parsed.data.kind;
+	if (parsed.data.archived !== undefined) {
+		updates.archived_at = parsed.data.archived ? new Date().toISOString() : null;
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_points' as never)
+		.update(updates as never)
+		.eq('id', params.pointId)
+		.select(POINT_COLS)
+		.single();
+
+	if (dbErr) {
+		if (dbErr.code === 'PGRST116') {
+			return json({ error: 'Point introuvable' }, { status: 404 });
+		}
+		const mapped = curriculumDbError(dbErr, 'Un point de ce nom existe déjà dans cet item');
+		if (mapped) return mapped;
+		console.error('[curriculum] point PATCH failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ point: data as CurriculumPoint });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const { error: dbErr } = await locals.supabase
+		.from('curriculum_points' as never)
+		.delete()
+		.eq('id', params.pointId);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] point DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/api/teacher/curriculum/themes/+server.ts
+++ b/src/routes/api/teacher/curriculum/themes/+server.ts
@@ -1,0 +1,74 @@
+/**
+ * API — Curriculum thèmes (level 1).
+ *
+ * GET  /api/teacher/curriculum/themes?grade=6   — list themes for a grade
+ * POST /api/teacher/curriculum/themes           — create a theme
+ *
+ * Teacher/admin only (RLS also enforces is_teacher_or_admin()).
+ * Spec: docs/wip/suivi-programme-progress.md
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { createThemeSchema, themeListQuerySchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, THEME_COLS } from '$lib/server/curriculum';
+import type { CurriculumTheme } from '$lib/types/database-helpers';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const parsed = themeListQuerySchema.safeParse({ grade: url.searchParams.get('grade') });
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_themes' as never)
+		.select(THEME_COLS)
+		.eq('grade', parsed.data.grade)
+		.order('display_order', { ascending: true })
+		.order('name', { ascending: true });
+
+	if (dbErr) {
+		console.error('[curriculum] themes GET failed:', dbErr);
+		return json({ error: 'Échec du chargement des thèmes' }, { status: 500 });
+	}
+
+	return json({ themes: (data ?? []) as CurriculumTheme[] });
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = createThemeSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_themes' as never)
+		.insert({
+			grade: parsed.data.grade,
+			name: parsed.data.name,
+			display_order: parsed.data.display_order ?? 0
+		} as never)
+		.select(THEME_COLS)
+		.single();
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr, 'Un thème de ce nom existe déjà pour ce niveau');
+		if (mapped) return mapped;
+		console.error('[curriculum] themes POST failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ theme: data as CurriculumTheme }, { status: 201 });
+};

--- a/src/routes/api/teacher/curriculum/themes/+server.ts
+++ b/src/routes/api/teacher/curriculum/themes/+server.ts
@@ -24,7 +24,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_themes' as never)
+		.from('curriculum_themes')
 		.select(THEME_COLS)
 		.eq('grade', parsed.data.grade)
 		.order('display_order', { ascending: true })
@@ -54,12 +54,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_themes' as never)
+		.from('curriculum_themes')
 		.insert({
 			grade: parsed.data.grade,
 			name: parsed.data.name,
 			display_order: parsed.data.display_order ?? 0
-		} as never)
+		})
 		.select(THEME_COLS)
 		.single();
 

--- a/src/routes/api/teacher/curriculum/themes/[themeId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/themes/[themeId]/+server.ts
@@ -13,6 +13,7 @@ import { requireRoles } from '$lib/server/middleware/auth';
 import { updateThemeSchema } from '$lib/server/validation/curriculum';
 import { curriculumDbError, THEME_COLS } from '$lib/server/curriculum';
 import type { CurriculumTheme } from '$lib/types/database-helpers';
+import type { TablesUpdate } from '$lib/types/database';
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
@@ -29,13 +30,13 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		return json({ error: parsed.error.issues[0].message }, { status: 400 });
 	}
 
-	const updates: Record<string, unknown> = {};
+	const updates: TablesUpdate<'curriculum_themes'> = {};
 	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
 	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
 
 	const { data, error: dbErr } = await locals.supabase
-		.from('curriculum_themes' as never)
-		.update(updates as never)
+		.from('curriculum_themes')
+		.update(updates)
 		.eq('id', params.themeId)
 		.select(THEME_COLS)
 		.single();
@@ -57,7 +58,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	await requireRoles(locals, ['teacher', 'admin']);
 
 	const { error: dbErr } = await locals.supabase
-		.from('curriculum_themes' as never)
+		.from('curriculum_themes')
 		.delete()
 		.eq('id', params.themeId);
 

--- a/src/routes/api/teacher/curriculum/themes/[themeId]/+server.ts
+++ b/src/routes/api/teacher/curriculum/themes/[themeId]/+server.ts
@@ -1,0 +1,72 @@
+/**
+ * API — Curriculum thème (level 1) — update & delete.
+ *
+ * PATCH  /api/teacher/curriculum/themes/[themeId]   — rename / reorder
+ * DELETE /api/teacher/curriculum/themes/[themeId]   — delete (cascade items/points)
+ *
+ * Teacher/admin only (RLS also enforces is_teacher_or_admin()).
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireRoles } from '$lib/server/middleware/auth';
+import { updateThemeSchema } from '$lib/server/validation/curriculum';
+import { curriculumDbError, THEME_COLS } from '$lib/server/curriculum';
+import type { CurriculumTheme } from '$lib/types/database-helpers';
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Corps JSON invalide' }, { status: 400 });
+	}
+
+	const parsed = updateThemeSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ error: parsed.error.issues[0].message }, { status: 400 });
+	}
+
+	const updates: Record<string, unknown> = {};
+	if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+	if (parsed.data.display_order !== undefined) updates.display_order = parsed.data.display_order;
+
+	const { data, error: dbErr } = await locals.supabase
+		.from('curriculum_themes' as never)
+		.update(updates as never)
+		.eq('id', params.themeId)
+		.select(THEME_COLS)
+		.single();
+
+	if (dbErr) {
+		if (dbErr.code === 'PGRST116') {
+			return json({ error: 'Thème introuvable' }, { status: 404 });
+		}
+		const mapped = curriculumDbError(dbErr, 'Un thème de ce nom existe déjà pour ce niveau');
+		if (mapped) return mapped;
+		console.error('[curriculum] theme PATCH failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ theme: data as CurriculumTheme });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	await requireRoles(locals, ['teacher', 'admin']);
+
+	const { error: dbErr } = await locals.supabase
+		.from('curriculum_themes' as never)
+		.delete()
+		.eq('id', params.themeId);
+
+	if (dbErr) {
+		const mapped = curriculumDbError(dbErr);
+		if (mapped) return mapped;
+		console.error('[curriculum] theme DELETE failed:', dbErr);
+		return json({ error: dbErr.message }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/supabase/migrations/20260621100000_curriculum_tracking.sql
+++ b/supabase/migrations/20260621100000_curriculum_tracking.sql
@@ -169,17 +169,17 @@ alter table public.journal_entry_activities enable row level security;
 alter table public.journal_entry_points enable row level security;
 
 create policy "Teachers manage curriculum themes" on public.curriculum_themes
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 create policy "Teachers manage curriculum items" on public.curriculum_items
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 create policy "Teachers manage curriculum points" on public.curriculum_points
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 create policy "Teachers manage exercise curriculum tags" on public.exercise_curriculum_points
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 create policy "Teachers manage journal entry activities" on public.journal_entry_activities
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 create policy "Teachers manage journal entry points" on public.journal_entry_points
-	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+	for all to authenticated using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
 
 -- ---------------------------------------------------------------------------
 -- Grants (RLS still gates real access; anon has no policy → denied)

--- a/supabase/migrations/20260621100000_curriculum_tracking.sql
+++ b/supabase/migrations/20260621100000_curriculum_tracking.sql
@@ -1,0 +1,192 @@
+-- Curriculum tracking — Phase 1 (schema + RLS)
+-- ============================================================================
+-- Feature: a teacher-owned curriculum referential, DISTINCT from the evaluation
+-- referential (skills/objectives). Three levels: Thème → Item → Point.
+-- Coverage is fed from the cahier de texte (class_journal_entries): each entry
+-- marks the curriculum points worked on (auto, derived from tagged activities,
+-- or manual). Coverage of a point for a class = count of entries touching it.
+--
+-- Mono-teacher model: NO teacher_id column; ownership is role-based via
+-- public.is_teacher_or_admin() (same pattern as class_chapters / journal).
+-- Students have NO access in V1 (out of scope).
+--
+-- Spec: docs/wip/suivi-programme-progress.md (§4 data model).
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. curriculum_themes  (level 1, per grade) — e.g. "Calcul"
+-- ---------------------------------------------------------------------------
+create table if not exists public.curriculum_themes (
+	id uuid primary key default gen_random_uuid(),
+	grade text not null,
+	name text not null,
+	display_order integer not null default 0,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- canonical grade codes (mirrors assessments_valid_grade)
+	constraint curriculum_themes_valid_grade check (
+		grade = any (array[
+			'CP', 'CE1', 'CE2', 'CM1', 'CM2',
+			'6', '5', '4', '3',
+			'2', '1_GEN', 'T_GEN', '1_SPE', 'T_SPE', 'T_EXP', 'T_COMP', '1_STMG', 'T_STMG'
+		])
+	),
+	constraint curriculum_themes_name_not_blank check (char_length(btrim(name)) > 0),
+	constraint curriculum_themes_grade_name_unique unique (grade, name)
+);
+
+comment on table public.curriculum_themes is
+	'Curriculum referential level 1 (Thème), per grade. Teacher-owned, distinct from the evaluation referential (skill_themes).';
+
+-- ---------------------------------------------------------------------------
+-- 2. curriculum_items  (level 2) — e.g. "Fractions"
+-- ---------------------------------------------------------------------------
+create table if not exists public.curriculum_items (
+	id uuid primary key default gen_random_uuid(),
+	theme_id uuid not null references public.curriculum_themes(id) on delete cascade,
+	name text not null,
+	display_order integer not null default 0,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	constraint curriculum_items_name_not_blank check (char_length(btrim(name)) > 0),
+	constraint curriculum_items_theme_name_unique unique (theme_id, name)
+);
+
+comment on table public.curriculum_items is
+	'Curriculum referential level 2 (Item), under a Thème. e.g. "Fractions".';
+
+-- ---------------------------------------------------------------------------
+-- 3. curriculum_points  (level 3, tracking grain) — e.g. "Additionner deux fractions"
+-- ---------------------------------------------------------------------------
+create table if not exists public.curriculum_points (
+	id uuid primary key default gen_random_uuid(),
+	item_id uuid not null references public.curriculum_items(id) on delete cascade,
+	name text not null,
+	display_order integer not null default 0,
+	-- optional: a point can be a "connaissance" or a "savoir_faire" (neutral by default)
+	kind text,
+	-- soft-archive instead of hard delete when a point already has coverage history
+	archived_at timestamptz,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	constraint curriculum_points_name_not_blank check (char_length(btrim(name)) > 0),
+	constraint curriculum_points_valid_kind check (kind is null or kind = any (array['connaissance', 'savoir_faire'])),
+	constraint curriculum_points_item_name_unique unique (item_id, name)
+);
+
+comment on table public.curriculum_points is
+	'Curriculum referential level 3 (Point) — the tracking grain. e.g. "Additionner deux fractions". kind is optional (connaissance | savoir_faire).';
+
+-- ---------------------------------------------------------------------------
+-- 4. exercise_curriculum_points  (tagging: a system exercise covers points)
+-- ---------------------------------------------------------------------------
+create table if not exists public.exercise_curriculum_points (
+	exercise_id uuid not null references public.exercises(id) on delete cascade,
+	point_id uuid not null references public.curriculum_points(id) on delete cascade,
+	created_at timestamptz not null default now(),
+	primary key (exercise_id, point_id)
+);
+
+comment on table public.exercise_curriculum_points is
+	'Tags a system exercise with the curriculum points it covers. Referencing the exercise in a journal entry derives auto coverage for these points.';
+
+-- ---------------------------------------------------------------------------
+-- 5. journal_entry_activities  (the 3 activity kinds attached to an entry)
+-- ---------------------------------------------------------------------------
+create table if not exists public.journal_entry_activities (
+	id uuid primary key default gen_random_uuid(),
+	entry_id uuid not null references public.class_journal_entries(id) on delete cascade,
+	-- 'exercise' (system exercise) | 'textbook' (manual reference) | 'course' (point de cours)
+	kind text not null,
+	exercise_id uuid references public.exercises(id) on delete set null,
+	chapter_id uuid references public.class_chapters(id) on delete set null,
+	-- free-form textbook reference: { manuel?, page?, numero?, label }
+	textbook_ref jsonb,
+	label text,
+	display_order integer not null default 0,
+	created_at timestamptz not null default now(),
+	constraint journal_entry_activities_valid_kind check (kind = any (array['exercise', 'textbook', 'course'])),
+	-- each kind requires its own reference present
+	constraint journal_entry_activities_kind_shape check (
+		(kind = 'exercise' and exercise_id is not null)
+		or (kind = 'course' and (chapter_id is not null or label is not null))
+		or (kind = 'textbook' and textbook_ref is not null)
+	)
+);
+
+comment on table public.journal_entry_activities is
+	'Activities attached to a cahier de texte entry: system exercise, textbook reference, or course point.';
+
+-- ---------------------------------------------------------------------------
+-- 6. journal_entry_points  (coverage signal: which points an entry worked on)
+-- ---------------------------------------------------------------------------
+create table if not exists public.journal_entry_points (
+	id uuid primary key default gen_random_uuid(),
+	entry_id uuid not null references public.class_journal_entries(id) on delete cascade,
+	point_id uuid not null references public.curriculum_points(id) on delete cascade,
+	-- 'auto' (materialized from a tagged activity) | 'manual' (checked by the teacher)
+	source text not null default 'manual',
+	created_at timestamptz not null default now(),
+	constraint journal_entry_points_valid_source check (source = any (array['auto', 'manual'])),
+	-- one point counts at most once per entry (manual + auto dedup)
+	constraint journal_entry_points_entry_point_unique unique (entry_id, point_id)
+);
+
+comment on table public.journal_entry_points is
+	'Coverage signal: a curriculum point worked on in a journal entry. Coverage of a point for a class = count of entries (in the school year) that touch it.';
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+create index if not exists idx_curriculum_themes_grade on public.curriculum_themes (grade, display_order);
+create index if not exists idx_curriculum_items_theme on public.curriculum_items (theme_id, display_order);
+create index if not exists idx_curriculum_points_item on public.curriculum_points (item_id, display_order);
+create index if not exists idx_exercise_curriculum_points_point on public.exercise_curriculum_points (point_id);
+create index if not exists idx_journal_entry_activities_entry on public.journal_entry_activities (entry_id, display_order);
+create index if not exists idx_journal_entry_activities_exercise on public.journal_entry_activities (exercise_id) where exercise_id is not null;
+create index if not exists idx_journal_entry_points_entry on public.journal_entry_points (entry_id);
+create index if not exists idx_journal_entry_points_point on public.journal_entry_points (point_id);
+
+-- ---------------------------------------------------------------------------
+-- updated_at triggers (reuse existing helper)
+-- ---------------------------------------------------------------------------
+create trigger update_curriculum_themes_updated_at before update on public.curriculum_themes
+	for each row execute function public.update_updated_at_column();
+create trigger update_curriculum_items_updated_at before update on public.curriculum_items
+	for each row execute function public.update_updated_at_column();
+create trigger update_curriculum_points_updated_at before update on public.curriculum_points
+	for each row execute function public.update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security — mono-teacher: teacher/admin manage everything.
+-- Students have no access in V1.
+-- ---------------------------------------------------------------------------
+alter table public.curriculum_themes enable row level security;
+alter table public.curriculum_items enable row level security;
+alter table public.curriculum_points enable row level security;
+alter table public.exercise_curriculum_points enable row level security;
+alter table public.journal_entry_activities enable row level security;
+alter table public.journal_entry_points enable row level security;
+
+create policy "Teachers manage curriculum themes" on public.curriculum_themes
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+create policy "Teachers manage curriculum items" on public.curriculum_items
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+create policy "Teachers manage curriculum points" on public.curriculum_points
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+create policy "Teachers manage exercise curriculum tags" on public.exercise_curriculum_points
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+create policy "Teachers manage journal entry activities" on public.journal_entry_activities
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+create policy "Teachers manage journal entry points" on public.journal_entry_points
+	for all using (public.is_teacher_or_admin()) with check (public.is_teacher_or_admin());
+
+-- ---------------------------------------------------------------------------
+-- Grants (RLS still gates real access; anon has no policy → denied)
+-- ---------------------------------------------------------------------------
+grant all on table public.curriculum_themes to anon, authenticated, service_role;
+grant all on table public.curriculum_items to anon, authenticated, service_role;
+grant all on table public.curriculum_points to anon, authenticated, service_role;
+grant all on table public.exercise_curriculum_points to anon, authenticated, service_role;
+grant all on table public.journal_entry_activities to anon, authenticated, service_role;
+grant all on table public.journal_entry_points to anon, authenticated, service_role;

--- a/supabase/migrations/20260621160000_seed_curriculum_6e.sql
+++ b/supabase/migrations/20260621160000_seed_curriculum_6e.sql
@@ -1,0 +1,179 @@
+-- Seed — Programme de suivi 6ᵉ (curriculum tracking)
+-- ============================================================================
+-- Pré-remplit l'arborescence Thème → Item → Point pour le grade '6', d'après le
+-- BO cycle 3 (blocs « Connaissances et capacités attendues » de la 6ᵉ).
+-- Source de vérité : docs/wip/referentiel/6e-programme-curriculum.md
+--   6 thèmes · 20 items · 95 points.
+--
+-- Idempotent : jointures par nom + ON CONFLICT DO NOTHING. Modèle « hybride » →
+-- le prof peut ensuite éditer/compléter dans l'app (le seed ne s'applique qu'une
+-- fois, ré-éditer après n'est pas écrasé).
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Thèmes
+-- ---------------------------------------------------------------------------
+insert into public.curriculum_themes (grade, name, display_order) values
+	('6', $$Nombres et calculs$$, 1),
+	('6', $$Grandeurs et mesures$$, 2),
+	('6', $$Espace et géométrie$$, 3),
+	('6', $$Organisation, gestion de données et probabilités$$, 4),
+	('6', $$Proportionnalité$$, 5),
+	('6', $$Initiation à la pensée informatique$$, 6)
+on conflict (grade, name) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 2. Items
+-- ---------------------------------------------------------------------------
+insert into public.curriculum_items (theme_id, name, display_order)
+select t.id, v.item_name, v.ord
+from (values
+	($$Nombres et calculs$$, $$Nombres entiers et décimaux$$, 1),
+	($$Nombres et calculs$$, $$Calcul sur les nombres décimaux$$, 2),
+	($$Nombres et calculs$$, $$Fractions$$, 3),
+	($$Nombres et calculs$$, $$Pourcentages$$, 4),
+	($$Nombres et calculs$$, $$Algèbre (pensée algébrique)$$, 5),
+	($$Grandeurs et mesures$$, $$Longueurs et périmètres$$, 1),
+	($$Grandeurs et mesures$$, $$Aires$$, 2),
+	($$Grandeurs et mesures$$, $$Volumes$$, 3),
+	($$Grandeurs et mesures$$, $$Durées et repérage dans le temps$$, 4),
+	($$Espace et géométrie$$, $$Distances, cercles et disques$$, 1),
+	($$Espace et géométrie$$, $$Médiatrice d'un segment$$, 2),
+	($$Espace et géométrie$$, $$Angles$$, 3),
+	($$Espace et géométrie$$, $$Bissectrice d'un angle saillant$$, 4),
+	($$Espace et géométrie$$, $$Triangles$$, 5),
+	($$Espace et géométrie$$, $$Symétrie axiale$$, 6),
+	($$Espace et géométrie$$, $$Vision dans l'espace$$, 7),
+	($$Organisation, gestion de données et probabilités$$, $$Organisation et gestion de données$$, 1),
+	($$Organisation, gestion de données et probabilités$$, $$Probabilités$$, 2),
+	($$Proportionnalité$$, $$Proportionnalité et échelles$$, 1),
+	($$Initiation à la pensée informatique$$, $$Programmer$$, 1)
+) as v(theme_name, item_name, ord)
+join public.curriculum_themes t on t.grade = '6' and t.name = v.theme_name
+on conflict (theme_id, name) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Points (display_order par item ; kind = connaissance | savoir_faire)
+-- ---------------------------------------------------------------------------
+insert into public.curriculum_points (item_id, name, display_order, kind)
+select i.id, v.point_name, v.ord, v.kind
+from (values
+	-- 1.1 Nombres entiers et décimaux
+	($$Nombres entiers et décimaux$$, $$Connaître et utiliser la valeur des chiffres selon leur rang dans l'écriture d'un nombre$$, 1, $$connaissance$$),
+	($$Nombres entiers et décimaux$$, $$Connaître les liens entre les unités de numération (unité, dizaine… dixième, centième, millième)$$, 2, $$connaissance$$),
+	($$Nombres entiers et décimaux$$, $$Connaître des grands nombres entiers$$, 3, $$connaissance$$),
+	($$Nombres entiers et décimaux$$, $$Reconnaître un nombre décimal$$, 4, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Associer et utiliser différentes écritures d'un nombre décimal (virgule, fraction, nombre mixte, pourcentage)$$, 5, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Placer un nombre décimal sur une demi-droite graduée et l'y repérer$$, 6, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Comparer deux nombres décimaux$$, 7, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Ordonner une liste de nombres décimaux$$, 8, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Encadrer un nombre décimal par deux décimaux, intercaler$$, 9, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Donner la valeur arrondie d'un décimal (unité, dixième, centième)$$, 10, $$savoir_faire$$),
+	($$Nombres entiers et décimaux$$, $$Déterminer la valeur arrondie de certains nombres non décimaux$$, 11, $$savoir_faire$$),
+	-- 1.2 Calcul sur les nombres décimaux
+	($$Calcul sur les nombres décimaux$$, $$Additionner et soustraire des nombres décimaux$$, 1, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Multiplier un nombre entier ou décimal par 0,1, 0,01 et 0,001$$, 2, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Connaître le lien avec la division par 10, 100, 1000$$, 3, $$connaissance$$),
+	($$Calcul sur les nombres décimaux$$, $$Comprendre le sens de la multiplication de deux nombres décimaux$$, 4, $$connaissance$$),
+	($$Calcul sur les nombres décimaux$$, $$Calculer le produit de deux nombres décimaux$$, 5, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Contrôler les résultats à l'aide d'ordres de grandeur$$, 6, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Résoudre des problèmes mettant en jeu des multiplications de décimaux$$, 7, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Diviser un nombre décimal par un nombre entier non nul inférieur à 10$$, 8, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Résoudre des problèmes mettant en jeu des divisions décimales$$, 9, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Effectuer la division euclidienne d'un entier par un entier inférieur à 100$$, 10, $$savoir_faire$$),
+	($$Calcul sur les nombres décimaux$$, $$Résoudre des problèmes mettant en jeu des divisions euclidiennes$$, 11, $$savoir_faire$$),
+	-- 1.3 Fractions
+	($$Fractions$$, $$Relier une fraction au résultat exact de la division de son numérateur par son dénominateur$$, 1, $$savoir_faire$$),
+	($$Fractions$$, $$Comprendre et connaître la définition du quotient d'un entier a par un entier b non nul$$, 2, $$connaissance$$),
+	($$Fractions$$, $$Compléter des égalités à trous multiplicatives$$, 3, $$savoir_faire$$),
+	($$Fractions$$, $$Placer une fraction sur une demi-droite graduée (cas simples)$$, 4, $$savoir_faire$$),
+	($$Fractions$$, $$Graduer un segment de longueur donnée$$, 5, $$savoir_faire$$),
+	($$Fractions$$, $$Savoir que la fraction a/b peut représenter un entier, un décimal non entier ou un nombre non décimal$$, 6, $$connaissance$$),
+	($$Fractions$$, $$Utiliser une multiplication pour appliquer une fraction à un nombre entier$$, 7, $$savoir_faire$$),
+	($$Fractions$$, $$Établir des égalités de fractions$$, 8, $$savoir_faire$$),
+	($$Fractions$$, $$Comparer et encadrer des fractions$$, 9, $$savoir_faire$$),
+	($$Fractions$$, $$Ordonner une liste de nombres écrits sous forme de fractions ou de nombres mixtes$$, 10, $$savoir_faire$$),
+	($$Fractions$$, $$Additionner et soustraire des fractions$$, 11, $$savoir_faire$$),
+	($$Fractions$$, $$Multiplier une fraction par un nombre entier$$, 12, $$savoir_faire$$),
+	($$Fractions$$, $$Résoudre des problèmes mettant en jeu des fractions$$, 13, $$savoir_faire$$),
+	($$Fractions$$, $$Inventer des problèmes mettant en jeu des fractions$$, 14, $$savoir_faire$$),
+	-- 1.4 Pourcentages
+	($$Pourcentages$$, $$Connaître la définition d'un pourcentage$$, 1, $$connaissance$$),
+	($$Pourcentages$$, $$Comprendre le sens d'un pourcentage$$, 2, $$connaissance$$),
+	($$Pourcentages$$, $$Calculer une proportion (rapport partie/tout) et l'exprimer en pourcentage (cas simples)$$, 3, $$savoir_faire$$),
+	($$Pourcentages$$, $$Appliquer un pourcentage à une grandeur ou à un nombre$$, 4, $$savoir_faire$$),
+	-- 1.5 Algèbre
+	($$Algèbre (pensée algébrique)$$, $$Utiliser des modèles pré-algébriques pour résoudre des problèmes algébriques$$, 1, $$savoir_faire$$),
+	($$Algèbre (pensée algébrique)$$, $$Identifier la structure d'un motif évolutif en repérant une régularité$$, 2, $$savoir_faire$$),
+	-- 2.1 Longueurs et périmètres
+	($$Longueurs et périmètres$$, $$Savoir que le périmètre du disque est proportionnel à son diamètre$$, 1, $$connaissance$$),
+	($$Longueurs et périmètres$$, $$Connaître la formule du périmètre d'un disque$$, 2, $$connaissance$$),
+	($$Longueurs et périmètres$$, $$Calculer le périmètre d'un disque$$, 3, $$savoir_faire$$),
+	($$Longueurs et périmètres$$, $$Calculer des périmètres de figures composées$$, 4, $$savoir_faire$$),
+	($$Longueurs et périmètres$$, $$Résoudre des problèmes impliquant des longueurs$$, 5, $$savoir_faire$$),
+	-- 2.2 Aires
+	($$Aires$$, $$Effectuer des conversions d'aire$$, 1, $$savoir_faire$$),
+	($$Aires$$, $$Connaître la formule de l'aire d'un carré ou d'un rectangle$$, 2, $$connaissance$$),
+	($$Aires$$, $$Calculer l'aire d'un carré ou d'un rectangle$$, 3, $$savoir_faire$$),
+	-- 2.3 Volumes
+	($$Volumes$$, $$Connaître l'unité centimètre cube$$, 1, $$connaissance$$),
+	($$Volumes$$, $$Comparer des volumes$$, 2, $$savoir_faire$$),
+	($$Volumes$$, $$Déterminer un volume$$, 3, $$savoir_faire$$),
+	-- 2.4 Durées et repérage dans le temps
+	($$Durées et repérage dans le temps$$, $$Effectuer des calculs sur des horaires et des durées$$, 1, $$savoir_faire$$),
+	($$Durées et repérage dans le temps$$, $$Résoudre des problèmes impliquant des horaires et des durées$$, 2, $$savoir_faire$$),
+	($$Durées et repérage dans le temps$$, $$Convertir des durées$$, 3, $$savoir_faire$$),
+	-- 3.1 Distances, cercles et disques
+	($$Distances, cercles et disques$$, $$Connaître et utiliser la définition de la distance entre deux points$$, 1, $$connaissance$$),
+	($$Distances, cercles et disques$$, $$Connaître et utiliser la définition du milieu d'un segment$$, 2, $$connaissance$$),
+	($$Distances, cercles et disques$$, $$Connaître les définitions d'un cercle, d'un disque, d'un rayon, d'un diamètre, d'une corde$$, 3, $$connaissance$$),
+	($$Distances, cercles et disques$$, $$Comprendre la définition d'un cercle et celle d'un disque comme ensembles de points$$, 4, $$connaissance$$),
+	($$Distances, cercles et disques$$, $$Résoudre des problèmes mettant en jeu des distances à un point$$, 5, $$savoir_faire$$),
+	-- 3.2 Médiatrice d'un segment
+	($$Médiatrice d'un segment$$, $$Connaître la définition de la médiatrice d'un segment$$, 1, $$connaissance$$),
+	($$Médiatrice d'un segment$$, $$Comprendre et utiliser la propriété caractéristique de la médiatrice$$, 2, $$savoir_faire$$),
+	($$Médiatrice d'un segment$$, $$Résoudre des problèmes en s'appuyant sur la propriété caractéristique de la médiatrice$$, 3, $$savoir_faire$$),
+	-- 3.3 Angles
+	($$Angles$$, $$Connaître et utiliser les angles, le lexique et les notations (droit, plat, plein, nul, aigu, obtus, opposés par le sommet, adjacents, supplémentaires)$$, 1, $$connaissance$$),
+	($$Angles$$, $$Mesurer un angle$$, 2, $$savoir_faire$$),
+	($$Angles$$, $$Construire un angle de mesure donnée$$, 3, $$savoir_faire$$),
+	-- 3.4 Bissectrice d'un angle saillant
+	($$Bissectrice d'un angle saillant$$, $$Connaître la définition de la bissectrice d'un angle saillant$$, 1, $$connaissance$$),
+	($$Bissectrice d'un angle saillant$$, $$Utiliser la bissectrice pour effectuer des constructions et résoudre des problèmes$$, 2, $$savoir_faire$$),
+	-- 3.5 Triangles
+	($$Triangles$$, $$Construire des triangles$$, 1, $$savoir_faire$$),
+	($$Triangles$$, $$Connaître et utiliser les propriétés angulaires des triangles particuliers (rectangle, isocèle, équilatéral)$$, 2, $$savoir_faire$$),
+	($$Triangles$$, $$Connaître la valeur de la somme des mesures des angles d'un triangle$$, 3, $$connaissance$$),
+	($$Triangles$$, $$Utiliser la somme des angles d'un triangle pour calculer un angle, construire, résoudre des problèmes$$, 4, $$savoir_faire$$),
+	($$Triangles$$, $$Savoir que les médiatrices d'un triangle sont concourantes$$, 5, $$connaissance$$),
+	($$Triangles$$, $$Connaître et construire le cercle circonscrit à un triangle$$, 6, $$savoir_faire$$),
+	-- 3.6 Symétrie axiale
+	($$Symétrie axiale$$, $$Connaître la définition du symétrique d'un point par rapport à une droite$$, 1, $$connaissance$$),
+	($$Symétrie axiale$$, $$Connaître et utiliser les propriétés de la symétrie axiale pour effectuer des constructions$$, 2, $$savoir_faire$$),
+	-- 3.7 Vision dans l'espace
+	($$Vision dans l'espace$$, $$Reconnaître les solides usuels (cube, pavé, cylindre, cône, boule, pyramide, prisme droit)$$, 1, $$connaissance$$),
+	($$Vision dans l'espace$$, $$Voir dans l'espace des assemblages de cubes (passer entre l'objet 3D et ses représentations 2D, dénombrer)$$, 2, $$savoir_faire$$),
+	-- 4.1 Organisation et gestion de données
+	($$Organisation et gestion de données$$, $$Planifier une enquête et recueillir des données$$, 1, $$savoir_faire$$),
+	($$Organisation et gestion de données$$, $$Réaliser des mesures et les consigner dans un tableau$$, 2, $$savoir_faire$$),
+	($$Organisation et gestion de données$$, $$Construire un tableau simple pour présenter des données$$, 3, $$savoir_faire$$),
+	($$Organisation et gestion de données$$, $$Faire un choix en filtrant les données d'un tableau selon un critère$$, 4, $$savoir_faire$$),
+	-- 4.2 Probabilités
+	($$Probabilités$$, $$Savoir que la probabilité d'un évènement est un nombre compris entre 0 et 1$$, 1, $$connaissance$$),
+	($$Probabilités$$, $$Calculer des probabilités dans des situations simples d'équiprobabilité$$, 2, $$savoir_faire$$),
+	($$Probabilités$$, $$Comparer les résultats d'une expérience aléatoire répétée à une probabilité calculée$$, 3, $$savoir_faire$$),
+	-- 5.1 Proportionnalité et échelles
+	($$Proportionnalité et échelles$$, $$Connaître la définition de la proportionnalité et la mettre en lien avec des expressions de la vie courante$$, 1, $$connaissance$$),
+	($$Proportionnalité et échelles$$, $$Identifier si une situation relève du modèle de la proportionnalité$$, 2, $$savoir_faire$$),
+	($$Proportionnalité et échelles$$, $$Résoudre un problème de proportionnalité en choisissant une procédure adaptée (linéarité, retour à l'unité)$$, 3, $$savoir_faire$$),
+	($$Proportionnalité et échelles$$, $$Représenter une situation de proportionnalité à l'aide d'un tableau ou de notations symboliques$$, 4, $$savoir_faire$$),
+	($$Proportionnalité et échelles$$, $$S'initier à la résolution de problèmes d'échelles$$, 5, $$savoir_faire$$),
+	-- 6.1 Programmer
+	($$Programmer$$, $$Identifier une instruction ou une séquence d'instructions$$, 1, $$connaissance$$),
+	($$Programmer$$, $$Produire et exécuter une séquence d'instructions$$, 2, $$savoir_faire$$),
+	($$Programmer$$, $$Répéter à la main une séquence d'instructions pour accomplir une tâche imposée$$, 3, $$savoir_faire$$),
+	($$Programmer$$, $$Programmer la construction d'un chemin simple$$, 4, $$savoir_faire$$)
+) as v(item_name, point_name, ord, kind)
+join public.curriculum_items i on i.name = v.item_name
+join public.curriculum_themes t on t.id = i.theme_id and t.grade = '6'
+on conflict (item_id, name) do nothing;

--- a/tests/integration/curriculum-api.test.ts
+++ b/tests/integration/curriculum-api.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Integration Tests: Curriculum tracking — CRUD API (Phase 1)
+ * ===========================================================
+ *
+ * Exercises the curriculum tree endpoints (Thème → Item → Point):
+ *   - /api/teacher/curriculum/themes            (GET, POST)
+ *   - /api/teacher/curriculum/themes/[themeId]  (PATCH, DELETE)
+ *   - /api/teacher/curriculum/items             (GET, POST)
+ *   - /api/teacher/curriculum/items/[itemId]    (PATCH, DELETE)
+ *   - /api/teacher/curriculum/points            (GET, POST)
+ *   - /api/teacher/curriculum/points/[pointId]  (PATCH, DELETE)
+ *
+ * Requires local Supabase (`pnpm db:start` + `pnpm db:reset`).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+import {
+	GET as themesGET,
+	POST as themesPOST
+} from '../../src/routes/api/teacher/curriculum/themes/+server';
+import {
+	PATCH as themePATCH,
+	DELETE as themeDELETE
+} from '../../src/routes/api/teacher/curriculum/themes/[themeId]/+server';
+import {
+	GET as itemsGET,
+	POST as itemsPOST
+} from '../../src/routes/api/teacher/curriculum/items/+server';
+import {
+	PATCH as itemPATCH,
+	DELETE as itemDELETE
+} from '../../src/routes/api/teacher/curriculum/items/[itemId]/+server';
+import {
+	GET as pointsGET,
+	POST as pointsPOST
+} from '../../src/routes/api/teacher/curriculum/points/+server';
+import { PATCH as pointPATCH } from '../../src/routes/api/teacher/curriculum/points/[pointId]/+server';
+
+import {
+	createServiceRoleClient,
+	TestData,
+	cleanupCompetenceTestData
+} from '../helpers/competence-referentiel.helpers';
+
+// ---------------------------------------------------------------------------
+// Shared service client + cleanup
+// ---------------------------------------------------------------------------
+
+let service: SupabaseClient<Database>;
+
+beforeAll(() => {
+	service = createServiceRoleClient();
+});
+
+afterAll(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+beforeEach(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+async function cleanupCurriculum() {
+	await service
+		.from('curriculum_themes' as never)
+		.delete()
+		.not('id', 'is', null);
+}
+
+// ---------------------------------------------------------------------------
+// Service-role fixtures (parents created directly to keep tests focused)
+// ---------------------------------------------------------------------------
+
+async function svcTheme(grade = '6', name?: string): Promise<{ id: string }> {
+	const { data, error } = await service
+		.from('curriculum_themes' as never)
+		.insert({ grade, name: name ?? `Thème ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id')
+		.single();
+	if (error) throw new Error(error.message);
+	return data as { id: string };
+}
+
+async function svcItem(themeId: string, name?: string): Promise<{ id: string }> {
+	const { data, error } = await service
+		.from('curriculum_items' as never)
+		.insert({ theme_id: themeId, name: name ?? `Item ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id')
+		.single();
+	if (error) throw new Error(error.message);
+	return data as { id: string };
+}
+
+async function svcPoint(itemId: string, name?: string): Promise<{ id: string }> {
+	const { data, error } = await service
+		.from('curriculum_points' as never)
+		.insert({ item_id: itemId, name: name ?? `Point ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id')
+		.single();
+	if (error) throw new Error(error.message);
+	return data as { id: string };
+}
+
+// ---------------------------------------------------------------------------
+// Locals + request/url helpers
+// ---------------------------------------------------------------------------
+
+function buildLocals(userOrNull: User | null): App.Locals {
+	return {
+		supabase: service as unknown as App.Locals['supabase'],
+		safeGetSession: vi.fn().mockResolvedValue({ user: userOrNull }),
+		user: userOrNull,
+		profile: null,
+		requestId: crypto.randomUUID()
+	} as unknown as App.Locals;
+}
+
+function req(body: unknown, method: 'POST' | 'PATCH' = 'POST'): Request {
+	return new Request('http://localhost/api/teacher/curriculum', {
+		method,
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+}
+
+function urlWith(query: Record<string, string>): URL {
+	const u = new URL('http://localhost/api/teacher/curriculum');
+	for (const [k, v] of Object.entries(query)) u.searchParams.set(k, v);
+	return u;
+}
+
+async function teacherUser(): Promise<User> {
+	const t = await TestData.profile().withRole('teacher').create();
+	return { id: t.id } as User;
+}
+
+// ============================================================================
+// Thèmes
+// ============================================================================
+
+describe('POST /api/teacher/curriculum/themes', () => {
+	it('creates a theme and returns 201', async () => {
+		expect.assertions(2);
+		const locals = buildLocals(await teacherUser());
+		const res = await themesPOST({ request: req({ grade: '6', name: 'Calcul' }), locals } as never);
+		expect(res.status).toBe(201);
+		const data = await res.json();
+		expect(data.theme).toMatchObject({ grade: '6', name: 'Calcul', display_order: 0 });
+	});
+
+	it('returns 400 for an invalid grade code', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		const res = await themesPOST({ request: req({ grade: '6e', name: 'X' }), locals } as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('returns 400 for a blank name', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		const res = await themesPOST({ request: req({ grade: '6', name: '   ' }), locals } as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('returns 409 for a duplicate (grade, name)', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		await themesPOST({ request: req({ grade: '6', name: 'Calcul' }), locals } as never);
+		const res = await themesPOST({ request: req({ grade: '6', name: 'Calcul' }), locals } as never);
+		expect(res.status).toBe(409);
+	});
+
+	it('rejects 401 when unauthenticated', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(null);
+		await expect(
+			themesPOST({ request: req({ grade: '6', name: 'X' }), locals } as never)
+		).rejects.toMatchObject({ status: 401 });
+	});
+
+	it('rejects 403 for a student', async () => {
+		expect.assertions(1);
+		const s = await TestData.profile().withRole('student').create();
+		const locals = buildLocals({ id: s.id } as User);
+		await expect(
+			themesPOST({ request: req({ grade: '6', name: 'X' }), locals } as never)
+		).rejects.toMatchObject({ status: 403 });
+	});
+});
+
+describe('GET /api/teacher/curriculum/themes', () => {
+	it('lists themes of a grade sorted by display_order then name', async () => {
+		expect.assertions(3);
+		await svcTheme('6', 'Beta');
+		await svcTheme('6', 'Alpha');
+		await svcTheme('5', 'Other grade');
+		const locals = buildLocals(await teacherUser());
+
+		const res = await themesGET({ url: urlWith({ grade: '6' }), locals } as never);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.themes).toHaveLength(2);
+		expect(data.themes.map((t: { name: string }) => t.name)).toEqual(['Alpha', 'Beta']);
+	});
+
+	it('returns 400 when grade query param is missing/invalid', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		const res = await themesGET({ url: urlWith({}), locals } as never);
+		expect(res.status).toBe(400);
+	});
+});
+
+describe('PATCH/DELETE /api/teacher/curriculum/themes/[themeId]', () => {
+	it('renames a theme', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6', 'Old');
+		const locals = buildLocals(await teacherUser());
+		const res = await themePATCH({
+			request: req({ name: 'New' }, 'PATCH'),
+			locals,
+			params: { themeId: theme.id }
+		} as never);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.theme.name).toBe('New');
+	});
+
+	it('returns 404 when patching a missing theme', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		const res = await themePATCH({
+			request: req({ name: 'X' }, 'PATCH'),
+			locals,
+			params: { themeId: crypto.randomUUID() }
+		} as never);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 400 when PATCH body has no updatable fields', async () => {
+		expect.assertions(1);
+		const theme = await svcTheme('6');
+		const locals = buildLocals(await teacherUser());
+		const res = await themePATCH({
+			request: req({}, 'PATCH'),
+			locals,
+			params: { themeId: theme.id }
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('deletes a theme and cascades to items and points', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		const point = await svcPoint(item.id);
+		const locals = buildLocals(await teacherUser());
+
+		const res = await themeDELETE({ locals, params: { themeId: theme.id } } as never);
+		expect(res.status).toBe(200);
+
+		const { data: rows } = await service
+			.from('curriculum_points' as never)
+			.select('id')
+			.eq('id', point.id);
+		expect(rows ?? []).toHaveLength(0);
+	});
+});
+
+// ============================================================================
+// Items
+// ============================================================================
+
+describe('Items CRUD', () => {
+	it('creates an item under a theme (201)', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		const locals = buildLocals(await teacherUser());
+		const res = await itemsPOST({
+			request: req({ theme_id: theme.id, name: 'Fractions' }),
+			locals
+		} as never);
+		expect(res.status).toBe(201);
+		const data = await res.json();
+		expect(data.item).toMatchObject({ theme_id: theme.id, name: 'Fractions' });
+	});
+
+	it('returns 400 when theme_id does not exist (FK violation)', async () => {
+		expect.assertions(1);
+		const locals = buildLocals(await teacherUser());
+		const res = await itemsPOST({
+			request: req({ theme_id: crypto.randomUUID(), name: 'Orphan' }),
+			locals
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('returns 409 for a duplicate (theme_id, name)', async () => {
+		expect.assertions(1);
+		const theme = await svcTheme('6');
+		await svcItem(theme.id, 'Fractions');
+		const locals = buildLocals(await teacherUser());
+		const res = await itemsPOST({
+			request: req({ theme_id: theme.id, name: 'Fractions' }),
+			locals
+		} as never);
+		expect(res.status).toBe(409);
+	});
+
+	it('lists items of a theme', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		await svcItem(theme.id, 'Fractions');
+		await svcItem(theme.id, 'Décimaux');
+		const locals = buildLocals(await teacherUser());
+		const res = await itemsGET({ url: urlWith({ theme_id: theme.id }), locals } as never);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.items).toHaveLength(2);
+	});
+
+	it('deletes an item', async () => {
+		expect.assertions(1);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		const locals = buildLocals(await teacherUser());
+		const res = await itemDELETE({ locals, params: { itemId: item.id } } as never);
+		expect(res.status).toBe(200);
+	});
+
+	it('renames an item', async () => {
+		expect.assertions(1);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id, 'Old');
+		const locals = buildLocals(await teacherUser());
+		const res = await itemPATCH({
+			request: req({ name: 'New' }, 'PATCH'),
+			locals,
+			params: { itemId: item.id }
+		} as never);
+		const data = await res.json();
+		expect(data.item.name).toBe('New');
+	});
+});
+
+// ============================================================================
+// Points
+// ============================================================================
+
+describe('Points CRUD', () => {
+	it('creates a point with a kind (201)', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		const locals = buildLocals(await teacherUser());
+		const res = await pointsPOST({
+			request: req({ item_id: item.id, name: 'Additionner deux fractions', kind: 'savoir_faire' }),
+			locals
+		} as never);
+		expect(res.status).toBe(201);
+		const data = await res.json();
+		expect(data.point).toMatchObject({ name: 'Additionner deux fractions', kind: 'savoir_faire' });
+	});
+
+	it('returns 400 for an invalid kind', async () => {
+		expect.assertions(1);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		const locals = buildLocals(await teacherUser());
+		const res = await pointsPOST({
+			request: req({ item_id: item.id, name: 'X', kind: 'competence' }),
+			locals
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('archives a point (sets archived_at)', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		const point = await svcPoint(item.id);
+		const locals = buildLocals(await teacherUser());
+		const res = await pointPATCH({
+			request: req({ archived: true }, 'PATCH'),
+			locals,
+			params: { pointId: point.id }
+		} as never);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.point.archived_at).not.toBeNull();
+	});
+
+	it('lists points of an item', async () => {
+		expect.assertions(2);
+		const theme = await svcTheme('6');
+		const item = await svcItem(theme.id);
+		await svcPoint(item.id, 'A');
+		await svcPoint(item.id, 'B');
+		const locals = buildLocals(await teacherUser());
+		const res = await pointsGET({ url: urlWith({ item_id: item.id }), locals } as never);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.points).toHaveLength(2);
+	});
+});

--- a/tests/integration/curriculum-coverage.test.ts
+++ b/tests/integration/curriculum-coverage.test.ts
@@ -474,13 +474,11 @@ describe('RLS & constraints', () => {
 		const client = (await createAuthenticatedClient(
 			student.email
 		)) as unknown as SupabaseClient<Database>;
-		const { error } = await client
-			.from('journal_entry_points' as never)
-			.insert({
-				entry_id: crypto.randomUUID(),
-				point_id: crypto.randomUUID(),
-				source: 'manual'
-			} as never);
+		const { error } = await client.from('journal_entry_points' as never).insert({
+			entry_id: crypto.randomUUID(),
+			point_id: crypto.randomUUID(),
+			source: 'manual'
+		} as never);
 		expect(error?.code).toBe('42501');
 	});
 

--- a/tests/integration/curriculum-coverage.test.ts
+++ b/tests/integration/curriculum-coverage.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Integration Tests: Curriculum tracking — alimentation & coverage (Phase 1, brique 2)
+ * ====================================================================================
+ *
+ * Exercises the tagging + cahier-de-texte alimentation endpoints:
+ *   - /api/teacher/curriculum/exercise-tags             (GET, POST, DELETE)
+ *   - /api/teacher/curriculum/activities                (GET, POST)
+ *   - /api/teacher/curriculum/activities/[activityId]   (DELETE)
+ *   - /api/teacher/curriculum/coverage                  (GET, POST, DELETE)
+ *
+ * Core behaviour: AUTO coverage is materialized from tagged exercise activities
+ * (reconcileAutoCoverage) and coexists with the teacher's MANUAL checks.
+ *
+ * Requires local Supabase (`pnpm db:start` + `pnpm db:reset`).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+import {
+	GET as tagsGET,
+	POST as tagsPOST,
+	DELETE as tagsDELETE
+} from '../../src/routes/api/teacher/curriculum/exercise-tags/+server';
+import {
+	GET as actGET,
+	POST as actPOST
+} from '../../src/routes/api/teacher/curriculum/activities/+server';
+import { DELETE as actDELETE } from '../../src/routes/api/teacher/curriculum/activities/[activityId]/+server';
+import {
+	GET as covGET,
+	POST as covPOST,
+	DELETE as covDELETE
+} from '../../src/routes/api/teacher/curriculum/coverage/+server';
+
+import {
+	createServiceRoleClient,
+	createAuthenticatedClient,
+	TestData,
+	cleanupCompetenceTestData
+} from '../helpers/competence-referentiel.helpers';
+
+let service: SupabaseClient<Database>;
+
+beforeAll(() => {
+	service = createServiceRoleClient();
+});
+
+afterAll(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+beforeEach(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+async function cleanupCurriculum() {
+	await service
+		.from('curriculum_themes' as never)
+		.delete()
+		.not('id', 'is', null);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async function svcPoint(itemId: string, name?: string): Promise<string> {
+	const { data, error } = await service
+		.from('curriculum_points' as never)
+		.insert({ item_id: itemId, name: name ?? `Point ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id')
+		.single();
+	if (error) throw new Error(error.message);
+	return (data as { id: string }).id;
+}
+
+/** Theme → item, returns item id (point parent). */
+async function makeItem(): Promise<string> {
+	const { data: theme, error: tErr } = await service
+		.from('curriculum_themes' as never)
+		.insert({ grade: '6', name: `T ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id')
+		.single();
+	if (tErr) throw new Error(tErr.message);
+	const { data: item, error: iErr } = await service
+		.from('curriculum_items' as never)
+		.insert({ theme_id: (theme as { id: string }).id, name: 'Fractions' } as never)
+		.select('id')
+		.single();
+	if (iErr) throw new Error(iErr.message);
+	return (item as { id: string }).id;
+}
+
+interface Ctx {
+	teacher: { id: string; email: string };
+	teacherUser: User;
+	classId: string;
+	entryId: string;
+}
+
+async function setup(): Promise<Ctx> {
+	const teacher = await TestData.profile().withRole('teacher').create();
+	const klass = await TestData.class().create();
+	const { data: entry, error } = await service
+		.from('class_journal_entries' as never)
+		.insert({ class_id: (klass as { id: string }).id, entry_date: '2026-01-15' } as never)
+		.select('id')
+		.single();
+	if (error) throw new Error(`journal entry: ${error.message}`);
+	return {
+		teacher,
+		teacherUser: { id: teacher.id } as User,
+		classId: (klass as { id: string }).id,
+		entryId: (entry as { id: string }).id
+	};
+}
+
+/** Create an exercise owned by `teacherId`, tagged with the given points. */
+async function makeTaggedExercise(teacherId: string, pointIds: string[]): Promise<string> {
+	const exercise = await TestData.exercise(teacherId).create();
+	const exId = (exercise as { id: string }).id;
+	if (pointIds.length > 0) {
+		const { error } = await service
+			.from('exercise_curriculum_points' as never)
+			.insert(pointIds.map((p) => ({ exercise_id: exId, point_id: p })) as never);
+		if (error) throw new Error(`tag exercise: ${error.message}`);
+	}
+	return exId;
+}
+
+// ---------------------------------------------------------------------------
+// Locals / request helpers
+// ---------------------------------------------------------------------------
+
+function buildLocals(userOrNull: User | null): App.Locals {
+	return {
+		supabase: service as unknown as App.Locals['supabase'],
+		safeGetSession: vi.fn().mockResolvedValue({ user: userOrNull }),
+		user: userOrNull,
+		profile: null,
+		requestId: crypto.randomUUID()
+	} as unknown as App.Locals;
+}
+
+function req(body: unknown, method: 'POST' = 'POST'): Request {
+	return new Request('http://localhost/api/teacher/curriculum', {
+		method,
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+}
+
+function urlWith(query: Record<string, string>): URL {
+	const u = new URL('http://localhost/api/teacher/curriculum');
+	for (const [k, v] of Object.entries(query)) u.searchParams.set(k, v);
+	return u;
+}
+
+/** Read the coverage of an entry as Map<point_id, source>. */
+async function coverageMap(ctx: Ctx): Promise<Map<string, string>> {
+	const res = await covGET({
+		url: urlWith({ entry_id: ctx.entryId }),
+		locals: buildLocals(ctx.teacherUser)
+	} as never);
+	const data = await res.json();
+	return new Map(
+		(data.coverage as { point_id: string; source: string }[]).map((c) => [c.point_id, c.source])
+	);
+}
+
+async function addExerciseActivity(ctx: Ctx, exerciseId: string): Promise<string> {
+	const res = await actPOST({
+		request: req({ entry_id: ctx.entryId, kind: 'exercise', exercise_id: exerciseId }),
+		locals: buildLocals(ctx.teacherUser)
+	} as never);
+	const data = await res.json();
+	return data.activity.id as string;
+}
+
+// ============================================================================
+// 1. Exercise tagging
+// ============================================================================
+
+describe('Exercise tagging', () => {
+	it('tags an exercise with a point (201) and is idempotent', async () => {
+		expect.assertions(2);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+		const exId = (await TestData.exercise(ctx.teacher.id).create()) as { id: string };
+
+		const r1 = await tagsPOST({
+			request: req({ exercise_id: exId.id, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(r1.status).toBe(201);
+
+		const r2 = await tagsPOST({
+			request: req({ exercise_id: exId.id, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(r2.status).toBe(200); // already tagged
+	});
+
+	it('lists and removes a tag', async () => {
+		expect.assertions(2);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+		const exId = await makeTaggedExercise(ctx.teacher.id, [point]);
+
+		const list = await tagsGET({
+			url: urlWith({ exercise_id: exId }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect((await list.json()).tags).toHaveLength(1);
+
+		await tagsDELETE({
+			url: urlWith({ exercise_id: exId, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		const list2 = await tagsGET({
+			url: urlWith({ exercise_id: exId }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect((await list2.json()).tags).toHaveLength(0);
+	});
+
+	it('returns 400 when tagging with an unknown exercise (FK)', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+		const res = await tagsPOST({
+			request: req({ exercise_id: crypto.randomUUID(), point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects 403 for a student', async () => {
+		expect.assertions(1);
+		const s = await TestData.profile().withRole('student').create();
+		const point = await svcPoint(await makeItem());
+		await expect(
+			tagsPOST({
+				request: req({ exercise_id: crypto.randomUUID(), point_id: point }),
+				locals: buildLocals({ id: s.id } as User)
+			} as never)
+		).rejects.toMatchObject({ status: 403 });
+	});
+});
+
+// ============================================================================
+// 2. Activities
+// ============================================================================
+
+describe('Journal entry activities', () => {
+	it('adds an exercise activity (201)', async () => {
+		expect.assertions(2);
+		const ctx = await setup();
+		const exId = await makeTaggedExercise(ctx.teacher.id, []);
+		const res = await actPOST({
+			request: req({ entry_id: ctx.entryId, kind: 'exercise', exercise_id: exId }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(201);
+		expect((await res.json()).activity).toMatchObject({ kind: 'exercise', exercise_id: exId });
+	});
+
+	it('adds a course activity with a free label (201)', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const res = await actPOST({
+			request: req({ entry_id: ctx.entryId, kind: 'course', label: 'Définition d’une fraction' }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(201);
+	});
+
+	it('returns 400 for a course activity without chapter nor label', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const res = await actPOST({
+			request: req({ entry_id: ctx.entryId, kind: 'course' }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('adds a textbook activity with a reference (201)', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const res = await actPOST({
+			request: req({
+				entry_id: ctx.entryId,
+				kind: 'textbook',
+				textbook_ref: { label: 'Sésamath 6e p.42 n°12', page: '42', numero: '12' }
+			}),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(201);
+	});
+
+	it('returns 400 for a textbook activity without a reference', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const res = await actPOST({
+			request: req({ entry_id: ctx.entryId, kind: 'textbook' }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(res.status).toBe(400);
+	});
+
+	it('lists activities of an entry', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		await actPOST({
+			request: req({ entry_id: ctx.entryId, kind: 'course', label: 'A' }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		const res = await actGET({
+			url: urlWith({ entry_id: ctx.entryId }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect((await res.json()).activities).toHaveLength(1);
+	});
+
+	it('returns 404 when deleting a missing activity', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const res = await actDELETE({
+			locals: buildLocals(ctx.teacherUser),
+			params: { activityId: crypto.randomUUID() }
+		} as never);
+		expect(res.status).toBe(404);
+	});
+});
+
+// ============================================================================
+// 3. Auto coverage reconciliation (the core)
+// ============================================================================
+
+describe('Auto coverage reconciliation', () => {
+	it('materializes auto coverage from tagged exercises and reconciles on add/remove', async () => {
+		expect.assertions(8);
+		const ctx = await setup();
+		const item = await makeItem();
+		const [p1, p2, p3, p4] = [
+			await svcPoint(item, 'P1'),
+			await svcPoint(item, 'P2'),
+			await svcPoint(item, 'P3'),
+			await svcPoint(item, 'P4')
+		];
+
+		const e1 = await makeTaggedExercise(ctx.teacher.id, [p1, p2]);
+		const e2 = await makeTaggedExercise(ctx.teacher.id, [p2, p3]);
+
+		// Add E1 → coverage {P1, P2} auto
+		const a1 = await addExerciseActivity(ctx, e1);
+		let cov = await coverageMap(ctx);
+		expect(cov.size).toBe(2);
+		expect(cov.get(p1)).toBe('auto');
+		expect(cov.get(p2)).toBe('auto');
+
+		// Add E2 → coverage {P1, P2, P3} (P2 deduped)
+		await addExerciseActivity(ctx, e2);
+		cov = await coverageMap(ctx);
+		expect(cov.size).toBe(3);
+		expect(cov.get(p3)).toBe('auto');
+
+		// Remove E1 → P1 dropped (no longer backed), P2 kept (E2), P3 kept
+		await actDELETE({ locals: buildLocals(ctx.teacherUser), params: { activityId: a1 } } as never);
+		cov = await coverageMap(ctx);
+		expect(cov.has(p1)).toBe(false);
+		expect(cov.size).toBe(2);
+
+		// Manual P4 + remove E2 → only P4 (manual) remains
+		await covPOST({
+			request: req({ entry_id: ctx.entryId, point_id: p4 }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		const acts = await actGET({
+			url: urlWith({ entry_id: ctx.entryId }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		const e2act = (await acts.json()).activities.find(
+			(a: { exercise_id: string | null; id: string }) => a.exercise_id === e2
+		);
+		await actDELETE({
+			locals: buildLocals(ctx.teacherUser),
+			params: { activityId: e2act.id }
+		} as never);
+		cov = await coverageMap(ctx);
+		expect([...cov.entries()]).toEqual([[p4, 'manual']]);
+	});
+});
+
+// ============================================================================
+// 4. Manual coverage
+// ============================================================================
+
+describe('Manual coverage', () => {
+	it('checks a point manually (201, source manual) and is idempotent', async () => {
+		expect.assertions(3);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+
+		const r1 = await covPOST({
+			request: req({ entry_id: ctx.entryId, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(r1.status).toBe(201);
+		expect((await r1.json()).coverage.source).toBe('manual');
+
+		const r2 = await covPOST({
+			request: req({ entry_id: ctx.entryId, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect(r2.status).toBe(200); // already covered
+	});
+
+	it('unchecks a point', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+		await covPOST({
+			request: req({ entry_id: ctx.entryId, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		await covDELETE({
+			url: urlWith({ entry_id: ctx.entryId, point_id: point }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		const cov = await coverageMap(ctx);
+		expect(cov.size).toBe(0);
+	});
+
+	it('promotes an auto point to manual when checked, so it survives reconcile', async () => {
+		expect.assertions(3);
+		const ctx = await setup();
+		const p1 = await svcPoint(await makeItem(), 'P1');
+		const e1 = await makeTaggedExercise(ctx.teacher.id, [p1]);
+
+		const a1 = await addExerciseActivity(ctx, e1);
+		let cov = await coverageMap(ctx);
+		expect(cov.get(p1)).toBe('auto');
+
+		// Teacher manually checks the same point → promoted to manual.
+		const res = await covPOST({
+			request: req({ entry_id: ctx.entryId, point_id: p1 }),
+			locals: buildLocals(ctx.teacherUser)
+		} as never);
+		expect((await res.json()).coverage.source).toBe('manual');
+
+		// Removing the backing exercise must NOT drop the now-manual point.
+		await actDELETE({ locals: buildLocals(ctx.teacherUser), params: { activityId: a1 } } as never);
+		cov = await coverageMap(ctx);
+		expect(cov.get(p1)).toBe('manual');
+	});
+});
+
+// ============================================================================
+// 5. RLS & constraints (defense in depth)
+// ============================================================================
+
+describe('RLS & constraints', () => {
+	it('forbids a student from inserting coverage (RLS 42501)', async () => {
+		expect.assertions(1);
+		const student = await TestData.profile().withRole('student').create();
+		const client = (await createAuthenticatedClient(
+			student.email
+		)) as unknown as SupabaseClient<Database>;
+		const { error } = await client
+			.from('journal_entry_points' as never)
+			.insert({
+				entry_id: crypto.randomUUID(),
+				point_id: crypto.randomUUID(),
+				source: 'manual'
+			} as never);
+		expect(error?.code).toBe('42501');
+	});
+
+	it('forbids a student from tagging exercises (RLS 42501)', async () => {
+		expect.assertions(1);
+		const student = await TestData.profile().withRole('student').create();
+		const client = (await createAuthenticatedClient(
+			student.email
+		)) as unknown as SupabaseClient<Database>;
+		const { error } = await client
+			.from('exercise_curriculum_points' as never)
+			.insert({ exercise_id: crypto.randomUUID(), point_id: crypto.randomUUID() } as never);
+		expect(error?.code).toBe('42501');
+	});
+
+	it('rejects an activity with an inconsistent kind shape (CHECK)', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		// kind='exercise' but no exercise_id → kind_shape CHECK violation
+		const { error } = await service
+			.from('journal_entry_activities' as never)
+			.insert({ entry_id: ctx.entryId, kind: 'exercise', exercise_id: null } as never);
+		expect(error?.code).toBe('23514');
+	});
+
+	it('rejects an invalid coverage source (CHECK)', async () => {
+		expect.assertions(1);
+		const ctx = await setup();
+		const point = await svcPoint(await makeItem());
+		const { error } = await service
+			.from('journal_entry_points' as never)
+			.insert({ entry_id: ctx.entryId, point_id: point, source: 'bogus' } as never);
+		expect(error?.code).toBe('23514');
+	});
+});

--- a/tests/integration/curriculum-tracking-rls.test.ts
+++ b/tests/integration/curriculum-tracking-rls.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Integration Tests: Curriculum tracking — schema & RLS (Phase 1)
+ * ===============================================================
+ *
+ * Validates migration 20260621100000_curriculum_tracking.sql:
+ *   - RLS mono-teacher: teacher/admin can manage; students cannot (is_teacher_or_admin()).
+ *   - CHECK constraints: valid grade, non-blank name, valid kind.
+ *   - UNIQUE constraints: (grade, name) themes, (theme_id, name) items, (item_id, name) points.
+ *   - Cascade delete: theme → items → points.
+ *
+ * Requires local Supabase (`pnpm db:start` + `pnpm db:reset`) then `pnpm test:integration`.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '$lib/types/database';
+
+import {
+	createServiceRoleClient,
+	createAuthenticatedClient,
+	TestData,
+	cleanupCompetenceTestData
+} from '../helpers/competence-referentiel.helpers';
+
+// ---------------------------------------------------------------------------
+// Shared service client + fixtures
+// ---------------------------------------------------------------------------
+
+let service: SupabaseClient<Database>;
+
+beforeAll(() => {
+	service = createServiceRoleClient();
+});
+
+afterAll(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+beforeEach(async () => {
+	await cleanupCurriculum();
+	await cleanupCompetenceTestData();
+});
+
+/** Purge curriculum rows. Cascade handles items/points/tags/coverage. */
+async function cleanupCurriculum() {
+	await service
+		.from('curriculum_themes' as never)
+		.delete()
+		.not('id', 'is', null);
+}
+
+interface ThemeRow {
+	id: string;
+	grade: string;
+	name: string;
+}
+interface ItemRow {
+	id: string;
+	theme_id: string;
+	name: string;
+}
+interface PointRow {
+	id: string;
+	item_id: string;
+	name: string;
+}
+
+async function createTheme(
+	overrides: { grade?: string; name?: string; display_order?: number } = {}
+): Promise<ThemeRow> {
+	const { data, error } = await service
+		.from('curriculum_themes' as never)
+		.insert({
+			grade: overrides.grade ?? '6',
+			name: overrides.name ?? `Thème ${crypto.randomUUID().slice(0, 8)}`,
+			display_order: overrides.display_order ?? 0
+		} as never)
+		.select('id, grade, name')
+		.single();
+	if (error) throw new Error(`createTheme failed: ${error.message}`);
+	return data as ThemeRow;
+}
+
+async function createItem(themeId: string, name?: string): Promise<ItemRow> {
+	const { data, error } = await service
+		.from('curriculum_items' as never)
+		.insert({ theme_id: themeId, name: name ?? `Item ${crypto.randomUUID().slice(0, 8)}` } as never)
+		.select('id, theme_id, name')
+		.single();
+	if (error) throw new Error(`createItem failed: ${error.message}`);
+	return data as ItemRow;
+}
+
+async function createPoint(
+	itemId: string,
+	overrides: { name?: string; kind?: string | null } = {}
+): Promise<PointRow> {
+	const { data, error } = await service
+		.from('curriculum_points' as never)
+		.insert({
+			item_id: itemId,
+			name: overrides.name ?? `Point ${crypto.randomUUID().slice(0, 8)}`,
+			kind: overrides.kind ?? null
+		} as never)
+		.select('id, item_id, name')
+		.single();
+	if (error) throw new Error(`createPoint failed: ${error.message}`);
+	return data as PointRow;
+}
+
+// ============================================================================
+// 1. RLS — mono-teacher gating (is_teacher_or_admin())
+// ============================================================================
+
+describe('Curriculum RLS — mono-teacher gating', () => {
+	it('lets a teacher insert and read a theme', async () => {
+		expect.assertions(3);
+		const teacher = await TestData.profile().withRole('teacher').create();
+		const client = (await createAuthenticatedClient(
+			teacher.email
+		)) as unknown as SupabaseClient<Database>;
+
+		const { data: inserted, error: insErr } = await client
+			.from('curriculum_themes' as never)
+			.insert({ grade: '6', name: 'Calcul', display_order: 0 } as never)
+			.select('id, name')
+			.single();
+		expect(insErr).toBeNull();
+		expect((inserted as { name: string }).name).toBe('Calcul');
+
+		const { data: rows } = await client
+			.from('curriculum_themes' as never)
+			.select('id')
+			.eq('grade', '6');
+		expect((rows ?? []).length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('forbids a student from inserting a theme (RLS 42501)', async () => {
+		expect.assertions(1);
+		const student = await TestData.profile().withRole('student').create();
+		const client = (await createAuthenticatedClient(
+			student.email
+		)) as unknown as SupabaseClient<Database>;
+
+		const { error } = await client
+			.from('curriculum_themes' as never)
+			.insert({ grade: '6', name: 'Hack', display_order: 0 } as never);
+		expect(error?.code).toBe('42501');
+	});
+
+	it('hides curriculum themes from students on SELECT (RLS filters to empty)', async () => {
+		expect.assertions(1);
+		await createTheme({ name: 'Géométrie' }); // created via service role
+		const student = await TestData.profile().withRole('student').create();
+		const client = (await createAuthenticatedClient(
+			student.email
+		)) as unknown as SupabaseClient<Database>;
+
+		const { data } = await client.from('curriculum_themes' as never).select('id');
+		expect(data ?? []).toHaveLength(0);
+	});
+
+	it('lets an admin manage curriculum points (is_admin ⊂ is_teacher_or_admin)', async () => {
+		expect.assertions(1);
+		const theme = await createTheme();
+		const item = await createItem(theme.id);
+		const admin = await TestData.profile().withRole('admin').create();
+		const client = (await createAuthenticatedClient(
+			admin.email
+		)) as unknown as SupabaseClient<Database>;
+
+		const { error } = await client
+			.from('curriculum_points' as never)
+			.insert({ item_id: item.id, name: 'Additionner deux fractions' } as never);
+		expect(error).toBeNull();
+	});
+});
+
+// ============================================================================
+// 2. CHECK constraints
+// ============================================================================
+
+describe('Curriculum CHECK constraints', () => {
+	it('rejects an invalid grade code', async () => {
+		expect.assertions(1);
+		const { error } = await service
+			.from('curriculum_themes' as never)
+			.insert({ grade: '6e', name: 'Bad grade', display_order: 0 } as never);
+		// '6e' is not a canonical code ('6' is) → CHECK violation 23514
+		expect(error?.code).toBe('23514');
+	});
+
+	it('rejects a blank theme name', async () => {
+		expect.assertions(1);
+		const { error } = await service
+			.from('curriculum_themes' as never)
+			.insert({ grade: '6', name: '   ', display_order: 0 } as never);
+		expect(error?.code).toBe('23514');
+	});
+
+	it('rejects an invalid point kind', async () => {
+		expect.assertions(1);
+		const theme = await createTheme();
+		const item = await createItem(theme.id);
+		const { error } = await service
+			.from('curriculum_points' as never)
+			.insert({ item_id: item.id, name: 'X', kind: 'competence' } as never);
+		expect(error?.code).toBe('23514');
+	});
+
+	it('accepts the two valid point kinds', async () => {
+		expect.assertions(2);
+		const theme = await createTheme();
+		const item = await createItem(theme.id);
+		const a = await service
+			.from('curriculum_points' as never)
+			.insert({ item_id: item.id, name: 'Connaissance X', kind: 'connaissance' } as never);
+		const b = await service
+			.from('curriculum_points' as never)
+			.insert({ item_id: item.id, name: 'Savoir-faire Y', kind: 'savoir_faire' } as never);
+		expect(a.error).toBeNull();
+		expect(b.error).toBeNull();
+	});
+});
+
+// ============================================================================
+// 3. UNIQUE constraints
+// ============================================================================
+
+describe('Curriculum UNIQUE constraints', () => {
+	it('forbids two themes with the same (grade, name)', async () => {
+		expect.assertions(1);
+		await createTheme({ grade: '6', name: 'Calcul' });
+		const { error } = await service
+			.from('curriculum_themes' as never)
+			.insert({ grade: '6', name: 'Calcul', display_order: 1 } as never);
+		expect(error?.code).toBe('23505');
+	});
+
+	it('allows the same theme name in two different grades', async () => {
+		expect.assertions(1);
+		await createTheme({ grade: '6', name: 'Calcul' });
+		const { error } = await service
+			.from('curriculum_themes' as never)
+			.insert({ grade: '5', name: 'Calcul', display_order: 0 } as never);
+		expect(error).toBeNull();
+	});
+
+	it('forbids two points with the same (item_id, name)', async () => {
+		expect.assertions(1);
+		const theme = await createTheme();
+		const item = await createItem(theme.id);
+		await createPoint(item.id, { name: 'Additionner deux fractions' });
+		const { error } = await service
+			.from('curriculum_points' as never)
+			.insert({ item_id: item.id, name: 'Additionner deux fractions' } as never);
+		expect(error?.code).toBe('23505');
+	});
+});
+
+// ============================================================================
+// 4. Cascade delete
+// ============================================================================
+
+describe('Curriculum cascade delete', () => {
+	it('deletes items and points when their theme is deleted', async () => {
+		expect.assertions(2);
+		const theme = await createTheme();
+		const item = await createItem(theme.id);
+		const point = await createPoint(item.id);
+
+		const { error: delErr } = await service
+			.from('curriculum_themes' as never)
+			.delete()
+			.eq('id', theme.id);
+		expect(delErr).toBeNull();
+
+		const { data: pointRows } = await service
+			.from('curriculum_points' as never)
+			.select('id')
+			.eq('id', point.id);
+		expect(pointRows ?? []).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Suivi du programme (cahier de texte + référentiel curriculum)

Référentiel de programme **distinct** du référentiel d'évaluation (`Thème → Item → Point`), alimenté depuis le cahier de texte, avec visualisation de l'avancement par classe.

### La boucle
**Programme** (éditer l'arbre par niveau) → **Exercices** (tagger les points couverts) → **Cahier de texte** (cocher les points travaillés + activités → couverture manuelle & auto) → **Avancement** (heatmap par classe).

### Contenu (9 commits)
- **Schéma** : 6 tables (`curriculum_themes/items/points`, `exercise_curriculum_points`, `journal_entry_activities/points`), RLS mono-prof (`is_teacher_or_admin()`), CHECK/UNIQUE/cascade, index, triggers.
- **API REST** : CRUD arborescence, tagging exercices, activités, couverture (réconciliation auto, *manual* prioritaire sur *auto*).
- **Seed 6ᵉ** : 95 points (BO cycle 3, « Connaissances et capacités attendues »).
- **UI** : page Programme (édition CRUD), bloc « Programme travaillé » + activités dans le cahier de texte, page Avancement (heatmap colorée + filtre « non vus »), tagging dans l'éditeur d'exercice.

### Base de données ⚠️
Les **2 migrations** (`20260621100000_curriculum_tracking`, `20260621160000_seed_curriculum_6e`) sont **déjà appliquées en prod** (additives, aucun code live ne les utilisait). **Le merge déploie donc uniquement le code (API + UI).**

### Tests / qualité
- **53 tests d'intégration** verts (RLS, API CRUD, réconciliation de couverture).
- `check:incremental` (TS + Svelte) = **0 erreur** · svelte-autofixer propre.
- Revue code + sécurité : aucun bloquant, aucune faille critique/élevée.

### Hors périmètre
- Multi-grades : seule la 6ᵉ est seedée (l'arbre reste éditable pour n'importe quel niveau).

Spec & progression détaillées : `docs/wip/suivi-programme-progress.md`.
