### PR TITLE
chore: hook pre-push (prettier --check) pour fermer le trou de formatage local

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+echo "pre-push : prettier --check…"
+if ! pnpm format:check; then
+	echo ""
+	echo "❌ Formatage : des fichiers ne sont pas formatés → la CI échouerait (job Lint)."
+	echo "   Corrige puis re-push :  pnpm format:all"
+	exit 1
+fi
+
+# Note : le full ESLint reste volontairement CI-only — il est type-aware, donc
+# lent (~25 s même sur 1 fichier) et gourmand en RAM (OOM sur machine 8 Go).
+# Le job "Lint" en CI le couvre.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"check:safe": "NODE_OPTIONS='--max-old-space-size=8192' svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"format": "prettier --write",
 		"format:all": "prettier --write .",
+		"format:check": "prettier --check --cache .",
 		"lint": "eslint",
 		"lint:all": "eslint . --cache",
 		"test:server": "vitest run --project=server",


### PR DESCRIPTION
Ajoute un hook **`pre-push`** qui lance `prettier --check --cache .` avant chaque push.

**Pourquoi** : le pre-commit (lint-staged) ne fait que `prettier --write` sur les fichiers *stagés* et peut en laisser passer un ; le `prettier --check` complet n'était qu'en CI → allers-retours (cf. PR #54). Le hook ferme ce trou en local.

- `prettier --check --cache .` : ~60 s à froid puis quelques s (cache gitignored).
- Script `format:check` ajouté.
- **ESLint reste CI-only** (type-aware → ~25 s même sur 1 fichier + OOM sur 8 Go) ; le job « Lint » en CI le couvre.
