### PR TITLE
chore: rebranding Ubumaths → Chiphre (légal / RGPD / consent)

### DIFF
--- a/src/lib/components/ConsentBanner.svelte
+++ b/src/lib/components/ConsentBanner.svelte
@@ -57,7 +57,7 @@
 			<ShieldAlert class="h-4 w-4" />
 			<Alert.Title>Accès limité</Alert.Title>
 			<Alert.Description>
-				Le consentement parental est requis pour utiliser toutes les fonctionnalités d'UbuMaths. Tu
+				Le consentement parental est requis pour utiliser toutes les fonctionnalités d'Chiphre. Tu
 				peux consulter tes cours et devoirs, mais tu ne peux pas soumettre de réponses, envoyer de
 				messages ou jouer aux jeux. Contacte ton enseignant pour qu'il envoie un email à tes
 				parents.

--- a/src/lib/email-templates/parental-consent.ts
+++ b/src/lib/email-templates/parental-consent.ts
@@ -5,7 +5,7 @@
  * The email contains a unique link for the parent to grant consent.
  */
 
-export const CONSENT_EMAIL_SUBJECT = 'Consentement parental requis - UbuMaths';
+export const CONSENT_EMAIL_SUBJECT = 'Consentement parental requis - Chiphre';
 
 /**
  * Get the base URL for consent links.
@@ -103,7 +103,7 @@ export function getConsentEmailText(data: ConsentEmailData): string {
 
 	let text = `Bonjour,
 
-${studentName} souhaite utiliser UbuMaths, une plateforme éducative de mathématiques.
+${studentName} souhaite utiliser Chiphre, une plateforme éducative de mathématiques.
 
 Informations de l'élève :
 - Nom : ${studentName}
@@ -128,7 +128,7 @@ Ce lien expire le ${expiryDate}.
 Si vous n'avez pas demandé ce consentement, vous pouvez ignorer cet email.
 
 Cordialement,
-L'équipe UbuMaths`;
+L'équipe Chiphre`;
 
 	return text;
 }
@@ -164,7 +164,7 @@ export function getConsentEmailHtml(data: ConsentEmailData): string {
   <div style="background-color: #f8fafc; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
     <h1 style="color: #1e40af; margin-top: 0;">Consentement parental requis</h1>
     <p>Bonjour,</p>
-    <p><strong>${studentName}</strong> souhaite utiliser <strong>UbuMaths</strong>, une plateforme éducative de mathématiques.</p>
+    <p><strong>${studentName}</strong> souhaite utiliser <strong>Chiphre</strong>, une plateforme éducative de mathématiques.</p>
   </div>
 
   <div style="background-color: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
@@ -197,7 +197,7 @@ export function getConsentEmailHtml(data: ConsentEmailData): string {
 
   <p style="color: #64748b; font-size: 0.9em;">
     Cordialement,<br>
-    L'équipe UbuMaths
+    L'équipe Chiphre
   </p>
 </body>
 </html>`;

--- a/src/routes/(protected)/dashboard/teacher/consent/+page.svelte
+++ b/src/routes/(protected)/dashboard/teacher/consent/+page.svelte
@@ -125,7 +125,7 @@
 </script>
 
 <svelte:head>
-	<title>Gestion du consentement parental - UbuMaths</title>
+	<title>Gestion du consentement parental - Chiphre</title>
 </svelte:head>
 
 <div class="container mx-auto space-y-6 p-6">

--- a/src/routes/(public)/consent/[token]/+page.svelte
+++ b/src/routes/(public)/consent/[token]/+page.svelte
@@ -46,14 +46,14 @@
 </script>
 
 <svelte:head>
-	<title>Consentement parental - UbuMaths</title>
+	<title>Consentement parental - Chiphre</title>
 </svelte:head>
 
 <div class="min-h-screen bg-gradient-to-b from-blue-50 to-white px-4 py-8">
 	<div class="mx-auto max-w-lg">
 		<!-- Logo/Header -->
 		<div class="mb-8 text-center">
-			<h1 class="text-3xl font-bold text-blue-600">UbuMaths</h1>
+			<h1 class="text-3xl font-bold text-blue-600">Chiphre</h1>
 			<p class="mt-2 text-muted-foreground">Plateforme éducative de mathématiques</p>
 		</div>
 
@@ -172,7 +172,7 @@
 					</form>
 
 					<p class="text-center text-xs text-muted-foreground">
-						En cliquant sur ce bouton, vous acceptez que votre enfant utilise UbuMaths dans le cadre
+						En cliquant sur ce bouton, vous acceptez que votre enfant utilise Chiphre dans le cadre
 						de son éducation.
 					</p>
 				</CardContent>

--- a/src/routes/(public)/consent/success/+page.svelte
+++ b/src/routes/(public)/consent/success/+page.svelte
@@ -5,14 +5,14 @@
 </script>
 
 <svelte:head>
-	<title>Consentement accordé - UbuMaths</title>
+	<title>Consentement accordé - Chiphre</title>
 </svelte:head>
 
 <div class="min-h-screen bg-gradient-to-b from-green-50 to-white px-4 py-8">
 	<div class="mx-auto max-w-lg">
 		<!-- Logo/Header -->
 		<div class="mb-8 text-center">
-			<h1 class="text-3xl font-bold text-blue-600">UbuMaths</h1>
+			<h1 class="text-3xl font-bold text-blue-600">Chiphre</h1>
 			<p class="mt-2 text-muted-foreground">Plateforme éducative de mathématiques</p>
 		</div>
 
@@ -29,7 +29,7 @@
 			</CardHeader>
 			<CardContent class="space-y-6 text-center">
 				<p class="text-muted-foreground">
-					Merci ! Votre enfant peut maintenant utiliser toutes les fonctionnalités d'UbuMaths.
+					Merci ! Votre enfant peut maintenant utiliser toutes les fonctionnalités d'Chiphre.
 				</p>
 
 				<div class="rounded-lg bg-blue-50 p-4 text-left">
@@ -48,7 +48,7 @@
 
 				<div class="pt-4">
 					<Button variant="outline" href="/" class="inline-flex items-center gap-2">
-						Découvrir UbuMaths
+						Découvrir Chiphre
 						<ExternalLink class="h-4 w-4" />
 					</Button>
 				</div>

--- a/src/routes/(public)/legal/cgu/+page.svelte
+++ b/src/routes/(public)/legal/cgu/+page.svelte
@@ -3,10 +3,10 @@
 </script>
 
 <svelte:head>
-	<title>Conditions Generales d'Utilisation - UbuMaths</title>
+	<title>Conditions Generales d'Utilisation - Chiphre</title>
 	<meta
 		name="description"
-		content="Conditions Generales d'Utilisation d'UbuMaths. Regles d'utilisation de la plateforme educative de mathematiques."
+		content="Conditions Generales d'Utilisation d'Chiphre. Regles d'utilisation de la plateforme educative de mathematiques."
 	/>
 </svelte:head>
 
@@ -22,8 +22,8 @@
 			<h2>1. Objet</h2>
 			<p>
 				Les presentes Conditions Generales d'Utilisation (ci-apres "CGU") ont pour objet de definir
-				les modalites et conditions d'utilisation de la plateforme <strong>UbuMaths</strong>,
-				accessible a l'adresse <a href={resolve('/')}>ubumaths.fr</a>.
+				les modalites et conditions d'utilisation de la plateforme <strong>Chiphre</strong>,
+				accessible a l'adresse <a href={resolve('/')}>chiph.re</a>.
 			</p>
 			<p class="rounded-lg bg-muted p-4">
 				<strong
@@ -35,7 +35,7 @@
 		<section>
 			<h2>2. Presentation du Service</h2>
 			<p>
-				UbuMaths est une plateforme educative de mathematiques destinee aux eleves du secondaire
+				Chiphre est une plateforme educative de mathematiques destinee aux eleves du secondaire
 				(college et lycee) et a leurs enseignants.
 			</p>
 
@@ -115,11 +115,11 @@
 			<h2>5. Propriete intellectuelle</h2>
 			<p>
 				L'ensemble des elements du Service (exercices, textes, images, logos, code source) sont la
-				propriete exclusive d'UbuMaths et sont proteges par les lois relatives a la propriete
+				propriete exclusive d'Chiphre et sont proteges par les lois relatives a la propriete
 				intellectuelle.
 			</p>
 			<p>
-				UbuMaths accorde a l'utilisateur une licence personnelle, non exclusive et non transferable
+				Chiphre accorde a l'utilisateur une licence personnelle, non exclusive et non transferable
 				pour utiliser le Service dans le cadre de son usage pedagogique.
 			</p>
 		</section>
@@ -142,8 +142,8 @@
 		<section>
 			<h2>7. Responsabilites</h2>
 
-			<h3>7.1 Responsabilite d'UbuMaths</h3>
-			<p>UbuMaths s'engage a :</p>
+			<h3>7.1 Responsabilite d'Chiphre</h3>
+			<p>Chiphre s'engage a :</p>
 			<ul>
 				<li>Assurer la disponibilite du Service dans la mesure du possible</li>
 				<li>Mettre en oeuvre des mesures de securite appropriees</li>
@@ -172,7 +172,7 @@
 				Les enseignants ont acces aux messages de leurs eleves dans le cadre du suivi pedagogique.
 				Les contenus contraires aux CGU peuvent etre supprimes sans preavis.
 			</p>
-			<p>En cas de non-respect des CGU, UbuMaths se reserve le droit de :</p>
+			<p>En cas de non-respect des CGU, Chiphre se reserve le droit de :</p>
 			<ul>
 				<li>Adresser un avertissement a l'utilisateur</li>
 				<li>Suspendre temporairement l'acces au Service</li>
@@ -183,7 +183,7 @@
 		<section>
 			<h2>9. Disponibilite du Service</h2>
 			<p>
-				UbuMaths peut interrompre temporairement le Service pour des operations de maintenance. Ces
+				Chiphre peut interrompre temporairement le Service pour des operations de maintenance. Ces
 				interruptions seront, dans la mesure du possible, planifiees en dehors des heures de cours.
 			</p>
 			<p>
@@ -195,7 +195,7 @@
 		<section>
 			<h2>10. Modification des CGU</h2>
 			<p>
-				UbuMaths se reserve le droit de modifier les presentes CGU a tout moment. Les utilisateurs
+				Chiphre se reserve le droit de modifier les presentes CGU a tout moment. Les utilisateurs
 				seront informes des modifications substantielles par une notification dans l'application.
 			</p>
 			<p>
@@ -217,7 +217,7 @@
 			<h2>12. Contact</h2>
 			<p>Pour toute question relative aux presentes CGU :</p>
 			<ul>
-				<li><strong>Email</strong> : contact@ubumaths.fr</li>
+				<li><strong>Email</strong> : contact@chiph.re</li>
 			</ul>
 		</section>
 

--- a/src/routes/(public)/legal/confidentialite/+page.svelte
+++ b/src/routes/(public)/legal/confidentialite/+page.svelte
@@ -3,10 +3,10 @@
 </script>
 
 <svelte:head>
-	<title>Politique de Confidentialite - UbuMaths</title>
+	<title>Politique de Confidentialite - Chiphre</title>
 	<meta
 		name="description"
-		content="Politique de confidentialite d'UbuMaths. Decouvrez comment nous collectons, utilisons et protegeons vos donnees personnelles."
+		content="Politique de confidentialite d'Chiphre. Decouvrez comment nous collectons, utilisons et protegeons vos donnees personnelles."
 	/>
 </svelte:head>
 
@@ -20,19 +20,19 @@
 
 		<section>
 			<h2>1. Identite du responsable de traitement</h2>
-			<p><strong>UbuMaths</strong> est edite par :</p>
+			<p><strong>Chiphre</strong> est edite par :</p>
 			<ul>
 				<li><strong>Responsable</strong> : [A COMPLETER]</li>
 				<li><strong>Adresse</strong> : [A COMPLETER]</li>
-				<li><strong>Email de contact</strong> : contact@ubumaths.fr</li>
-				<li><strong>Site web</strong> : <a href={resolve('/')}>ubumaths.fr</a></li>
+				<li><strong>Email de contact</strong> : contact@chiph.re</li>
+				<li><strong>Site web</strong> : <a href={resolve('/')}>chiph.re</a></li>
 			</ul>
 		</section>
 
 		<section>
 			<h2>2. Objet du service</h2>
 			<p>
-				UbuMaths est une plateforme educative de mathematiques destinee aux eleves du secondaire
+				Chiphre est une plateforme educative de mathematiques destinee aux eleves du secondaire
 				(college et lycee) et a leurs enseignants. Le service permet :
 			</p>
 			<ul>
@@ -161,7 +161,7 @@
 
 			<h3>5.1 Age des utilisateurs</h3>
 			<p>
-				UbuMaths est destine principalement aux eleves ages de <strong>11 a 18 ans</strong>.
+				Chiphre est destine principalement aux eleves ages de <strong>11 a 18 ans</strong>.
 				Conformement a l'article 8 du RGPD et aux recommandations de la CNIL :
 			</p>
 			<ul>
@@ -338,7 +338,7 @@
 
 		<section>
 			<h2>10. Cookies</h2>
-			<p>UbuMaths utilise uniquement des <strong>cookies strictement necessaires</strong> :</p>
+			<p>Chiphre utilise uniquement des <strong>cookies strictement necessaires</strong> :</p>
 			<div class="overflow-x-auto">
 				<table>
 					<thead>
@@ -368,8 +368,8 @@
 				</table>
 			</div>
 			<p class="rounded-lg bg-muted p-4">
-				<strong>UbuMaths n'utilise aucun cookie d'analyse ou de publicite.</strong> La mesure de
-				performance (Vercel) fonctionne sans cookie. UbuMaths utilise par ailleurs le
+				<strong>Chiphre n'utilise aucun cookie d'analyse ou de publicite.</strong> La mesure de
+				performance (Vercel) fonctionne sans cookie. Chiphre utilise par ailleurs le
 				<strong>stockage local</strong> du navigateur a des fins strictement fonctionnelles (sauvegarde
 				de vos documents tableur / tableau blanc et preferences d'affichage), conservees sur votre appareil.
 			</p>
@@ -379,7 +379,7 @@
 			<h2>11. Contact</h2>
 			<p>Pour toute question relative a cette politique ou pour exercer vos droits :</p>
 			<ul>
-				<li><strong>Email</strong> : contact@ubumaths.fr</li>
+				<li><strong>Email</strong> : contact@chiph.re</li>
 			</ul>
 			<p>Nous nous engageons a repondre dans un delai d'un mois conformement au RGPD.</p>
 		</section>

--- a/src/routes/(public)/legal/mentions-legales/+page.svelte
+++ b/src/routes/(public)/legal/mentions-legales/+page.svelte
@@ -3,10 +3,10 @@
 </script>
 
 <svelte:head>
-	<title>Mentions Legales - UbuMaths</title>
+	<title>Mentions Legales - Chiphre</title>
 	<meta
 		name="description"
-		content="Mentions legales d'UbuMaths. Informations sur l'editeur, l'hebergement et les conditions d'utilisation."
+		content="Mentions legales d'Chiphre. Informations sur l'editeur, l'hebergement et les conditions d'utilisation."
 	/>
 </svelte:head>
 
@@ -21,14 +21,14 @@
 		<section>
 			<h2>1. Editeur du site</h2>
 			<p>
-				Le site <strong>UbuMaths</strong> accessible a l'adresse
-				<a href={resolve('/')}>ubumaths.fr</a> est edite par :
+				Le site <strong>Chiphre</strong> accessible a l'adresse
+				<a href={resolve('/')}>chiph.re</a> est edite par :
 			</p>
 			<ul>
 				<li><strong>Responsable de publication</strong> : [A COMPLETER]</li>
 				<li><strong>Statut</strong> : [A COMPLETER]</li>
 				<li><strong>Adresse</strong> : [A COMPLETER]</li>
-				<li><strong>Email</strong> : contact@ubumaths.fr</li>
+				<li><strong>Email</strong> : contact@chiph.re</li>
 			</ul>
 		</section>
 
@@ -61,7 +61,7 @@
 			<h2>3. Propriete intellectuelle</h2>
 			<p>
 				L'ensemble des elements presents sur le site (textes, exercices, images, logos, code source,
-				design) sont la propriete exclusive d'UbuMaths, sauf mention contraire.
+				design) sont la propriete exclusive d'Chiphre, sauf mention contraire.
 			</p>
 			<p>
 				Toute reproduction, representation, modification ou publication du site ou de son contenu,
@@ -75,7 +75,7 @@
 			<h3>4.1 Responsable du traitement</h3>
 			<ul>
 				<li><strong>Nom</strong> : [A COMPLETER]</li>
-				<li><strong>Email</strong> : contact@ubumaths.fr</li>
+				<li><strong>Email</strong> : contact@chiph.re</li>
 			</ul>
 
 			<h3>4.2 Politique de confidentialite</h3>
@@ -94,7 +94,7 @@
 				<li>Droit a la portabilite</li>
 				<li>Droit d'opposition</li>
 			</ul>
-			<p>Pour exercer ces droits, contactez-nous a : <strong>contact@ubumaths.fr</strong></p>
+			<p>Pour exercer ces droits, contactez-nous a : <strong>contact@chiph.re</strong></p>
 
 			<h3>4.4 Reclamation</h3>
 			<p>En cas de difficulte, vous pouvez adresser une reclamation a la CNIL :</p>
@@ -142,7 +142,7 @@
 			</div>
 			<p class="rounded-lg bg-muted p-4">
 				Le site n'utilise <strong>aucun cookie</strong> de mesure d'audience, de publicite ou de
-				suivi. La mesure de performance (Vercel) fonctionne <strong>sans cookie</strong>. UbuMaths
+				suivi. La mesure de performance (Vercel) fonctionne <strong>sans cookie</strong>. Chiphre
 				utilise par ailleurs le <strong>stockage local</strong> du navigateur a des fins strictement
 				fonctionnelles (sauvegarde de vos documents tableur / tableau blanc et preferences d'affichage)
 				; ces donnees restent sur votre appareil.
@@ -152,12 +152,12 @@
 		<section>
 			<h2>6. Limitation de responsabilite</h2>
 			<p>
-				UbuMaths s'efforce d'assurer la disponibilite du site 24h/24 et 7j/7, mais ne peut garantir
+				Chiphre s'efforce d'assurer la disponibilite du site 24h/24 et 7j/7, mais ne peut garantir
 				une disponibilite permanente. Des interruptions pour maintenance peuvent survenir.
 			</p>
 			<p>
 				Les informations presentes sur le site sont fournies a titre indicatif et pedagogique.
-				UbuMaths ne saurait etre tenue responsable des erreurs ou omissions eventuelles.
+				Chiphre ne saurait etre tenue responsable des erreurs ou omissions eventuelles.
 			</p>
 		</section>
 
@@ -174,7 +174,7 @@
 			<h2>8. Contact</h2>
 			<p>Pour toute question concernant ces mentions legales :</p>
 			<ul>
-				<li><strong>Email</strong> : contact@ubumaths.fr</li>
+				<li><strong>Email</strong> : contact@chiph.re</li>
 			</ul>
 		</section>
 


### PR DESCRIPTION
## Rebranding Ubumaths → Chiphre — légal / RGPD / consent

PR dédiée (relecture séparée) : pages légales, consentement parental, email de consentement.

### Contenu (`c0cbc6eba`)

- Nom de marque `UbuMaths` → `Chiphre`.
- Domaine légal affiché `ubumaths.fr` → `chiph.re` (apex).
- Email contact/DPO `contact@ubumaths.fr` → `contact@chiph.re`.
- **Texte légal/RGPD inchangé** (éditeur, hébergeurs Vercel/Supabase, CNIL, durées de conservation, droits) — audité « seuls le nom, le domaine et l'email de contact bougent ».

### ⚠️ RGPD

`contact@chiph.re` doit **recevoir** (obligation d'un contact qui aboutit) avant la sortie de maintenance.

### Vérification

`check:incremental` = 0 erreur.
